### PR TITLE
Make rsconnect version work.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(name='rsconnect_python',
       author_email='mike@rstudio.com',
       license='GPL-2.0',
       packages=['rsconnect'],
+      package_data={'': ['version.txt']},
+      include_package_data=True,
       zip_safe=False,
       install_requires=[
           'six',


### PR DESCRIPTION
### Description

This change updates `setup.py` to correctly include `version.txt` in the packaged egg.

(_1.3.0_)