### PR TITLE
Add support for a mocked Connect.

### DIFF
--- a/mock_connect/.gitignore
+++ b/mock_connect/.gitignore
@@ -1,0 +1,1 @@
+mock_connect.log

--- a/mock_connect/Dockerfile
+++ b/mock_connect/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7-alpine
+MAINTAINER RStudio Connect <rsconnect@rstudio.com>
+
+# Add the Python packags we need.
+RUN pip install flask

--- a/mock_connect/Makefile
+++ b/mock_connect/Makefile
@@ -1,0 +1,48 @@
+#
+# Makefile for our mock Connect server.
+#
+# The targets here provide all the support for running a mock version of Connect.
+#
+MOCK_IMAGE?="rstudio/connect:mock"
+MOCK_HOST?="mock-connect"
+PRE_FETCH_FILE?=""
+LOG_FILE?="mock_connect.log"
+
+# Build the image in which the mock server will run.
+image:
+	docker build -t ${MOCK_IMAGE} .
+
+# Bring the mock Connect server up.  Note that it is run as a daemon.
+up:
+	@echo "Starting ${MOCK_HOST} ..."
+	@docker run --rm -d -t --init \
+	 	--name ${MOCK_HOST} \
+		--volume $(CURDIR):/rsconnect \
+	 	--env=FLASK_APP=/rsconnect/mock_connect/main.py \
+	 	--env=PRE_FETCH_FILE=${PRE_FETCH_FILE} \
+	 	--publish 3939:3939 \
+	 	--workdir /rsconnect \
+		${MOCK_IMAGE} \
+		flask run --host=0.0.0.0 --port=3939 1>/dev/null
+	@docker logs -f ${MOCK_HOST} > ${LOG_FILE} &
+
+# Bring the mock Connect server down.
+down:
+	$(eval CONNECT_EXISTS=$(shell docker container inspect ${MOCK_HOST} > /dev/null 2>&1 && echo 0 || echo 1))
+	@if [ "${CONNECT_EXISTS}" = "0" ] ; then \
+	    echo "Stopping ${MOCK_HOST} ..."; \
+	    docker stop ${MOCK_HOST} 1>/dev/null; \
+	fi;
+
+# Clean up after ourselves.
+clean:
+	@rm -f ${LOG_FILE}
+
+# Start the mock Connect docker image but just dump into a shell.
+sh:
+	@docker run --name mock_connect --rm -it \
+		-v $(CURDIR):/rsconnect -w /rsconnect \
+		${MOCK_IMAGE} sh
+
+# Nothing is real...
+.PHONY: image up down clean sh

--- a/mock_connect/README.md
+++ b/mock_connect/README.md
@@ -1,0 +1,62 @@
+## Mock RStudio Connect
+
+This directory holds a mocked version of RStudio Connect to support testing.  This
+works by providing a Docker container equipped with Python (and necessary support
+libraries).  The container looks to the outside world like an installation of RStudio
+Connect.
+
+### Restrictions
+
+- The mock RStudio Connect does not support HTTPS connections; only HTTP.
+- Not all Connect endpoints are implements; only those needed to verify `rsconnect-python`
+  functionality.
+
+## Data Handling
+
+The mock server does everything in memory, rather than use an external database.  If you
+want to see what's currently there, visit the root index page of the mock server
+(`http://localhost:3939/` by default) and you'll see a dump of them.  This is useful in
+seeing the results of updating APIs.
+
+The server comes with only one predefined object defined, the "admin" user.  It does allow
+you to preload data if you wish.  This is intended to provide support for specific testing
+scenarios.  To preload data, create a JSON file containing the data you want loaded.  See
+the [sample](sample.json) file for the basic structure.  Look at the
+[data code file](mock_connect/data.py) file for supported attributes for each object.
+
+If the JSON data for an object does not contain an `id` attribute, a unique one will be
+automatically assigned.  As new objects are created, each ID is guaranteed to be unique.
+For objects that have a `guid` attribute, these also are automatically filled in if not
+provided.  All other attribute values (even creation dates) are the responsibility of
+the data file.
+
+The definition of a user in the preload data file may contain an extra attribute called
+`api_key` to specify an API key for the user.
+
+Once you have the JSON file with the data you want to preload, specify its name as the value
+of the `PRE_FETCH_FILE` environment variable when invoking `make up` to start the server.
+
+## The `Makefile`
+
+The `Makefile` contains several useful targets.
+
+- `image` -- This target builds the Docker image in which the mock Connect server will be run.
+- `up` -- This target starts the Docker container, exposing the mock server on port `3939`.
+  The container is started as a daemon.  The output of the server is directed to a file
+  called `mock_connect.log` (use the `LOG_FILE` environment variable to change this).
+- `down` -- This target stops the Docker container running the mock server.
+- `clean` -- This target cleans up work files, like the log file.
+- `sh` -- This target brings up the Docker container but dumps you into a `sh` shell rather
+  than starting the mock server.
+
+> **Note:**
+> - There is no `all` target.
+> - `make` without a target will run the `image` target.
+> - There are no dependencies between targets.
+
+## Future
+
+In the future, the pre-fetch data file will also allow for tailoring server responses based
+on request input.  This makes it significantly easier to simulate a variety of errors so
+that non-happy paths may also be fully tested.
+ 

--- a/mock_connect/mock_connect/data.py
+++ b/mock_connect/mock_connect/data.py
@@ -1,0 +1,314 @@
+"""
+This provides our "database" handling.  It defines our object models along
+with appropriate storage/retrieval actions.
+"""
+import datetime
+import io
+import json
+import sys
+import tarfile
+import uuid
+from enum import Enum
+from json import JSONDecodeError
+from os import environ
+from os.path import isfile
+
+
+def timestamp():
+    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + 'Z'
+
+
+class DBObject(object):
+    generated_id = {}
+    instances = {}
+    attrs = ['id']
+    show = ['id']
+
+    @classmethod
+    def _get_all_ids(cls):
+        name = cls.__name__
+        if name in cls.instances:
+            return cls.instances[name].keys()
+        return []
+
+    @classmethod
+    def _next_id(cls):
+        name = cls.__name__
+        if name not in cls.generated_id:
+            cls.generated_id[name] = range(1, sys.maxsize**10).__iter__()
+        new_id = next(cls.generated_id[name])
+        existing_ids = cls._get_all_ids()
+        while new_id in existing_ids:
+            existing_ids = cls._get_all_ids()
+        return new_id
+
+    @classmethod
+    def get_object(cls, db_id: int):
+        name = cls.__name__
+        if name in cls.instances and db_id in cls.instances[name]:
+            return cls.instances[name][db_id]
+        return None
+
+    @classmethod
+    def get_all_objects(cls):
+        name = cls.__name__
+        if name in cls.instances:
+            return cls.instances[name].values()
+        return []
+
+    @classmethod
+    def create_from(cls, data: dict):
+        if 'id' in data:
+            result = cls.__new__(cls)
+            if 'guid' in cls.attrs and 'guid' not in data:
+                result.guid = str(uuid.uuid4())
+        else:
+            result = cls()
+
+        result.update_from(data)
+
+        if 'id' in data:
+            cls._save(result)
+
+        return result
+
+    @classmethod
+    def _save(cls, instance):
+        name = cls.__name__
+        if name not in cls.instances:
+            cls.instances[name] = {}
+        cls.instances[name][instance.id] = instance
+
+    @classmethod
+    def get_table_headers(cls):
+        return '<tr><th>%s</th></tr>' % '</th><th>'.join(cls.show)
+
+    def __init__(self, needs_uuid: bool = False):
+        self.id = self._next_id()
+
+        if needs_uuid:
+            self.guid = str(uuid.uuid4())
+
+        self._save(self)
+
+    def update_from(self, data: dict):
+        for attr in self.attrs:
+            if attr in data:
+                self.__setattr__(attr, data[attr])
+
+    def to_dict(self) -> dict:
+        result = {}
+        for attr in self.attrs:
+            result[attr] = self.__getattribute__(attr)
+        return result
+
+    def get_table_row(self):
+        items = [str(self.__getattribute__(item)) for item in self.show]
+        return '<tr><td>%s</td></tr>' % '</td><td>'.join(items)
+
+
+class AppMode(Enum):
+    STATIC = 4
+    JUPYTER_STATIC = 7
+
+    @staticmethod
+    def value_of(name: str):
+        name = name.upper().replace('-', '_')
+        return AppMode[name].value if name in AppMode else None
+
+
+class Application(DBObject):
+    attrs = ['id', 'guid', 'name', 'url', 'owner_username', 'owner_first_name', 'owner_last_name', 'owner_email',
+             'owner_locked', 'bundle_id', 'needs_config', 'access_type', 'description', 'app_mode', 'created_time',
+             'title', 'last_deployed_time']
+    show = ['id', 'name', 'title', 'url']
+
+    @classmethod
+    def get_app_by_name(cls, name: str):
+        for app in cls.get_all_objects():
+            if name == app.name:
+                return app
+        return None
+
+    def __init__(self, name, title, url, user):
+        super(Application, self).__init__(needs_uuid=True)
+        self.name = name
+        self.title = title
+        self.url = '{0}content/{1}'.format(url, self.id)
+        self.owner_username = user.username
+        self.owner_first_name = user.first_name
+        self.owner_last_name = user.last_name
+        self.owner_email = user.email
+        self.owner_locked = user.locked
+        self.bundle_id = None
+        self.needs_config = True
+        self.access_type = None
+        self.description = ''
+        self.app_mode = None
+        self.created_time = timestamp()
+        self.last_deployed_time = None
+
+    def bundle_deployed(self, bundle, new_app_mode):
+        self.bundle_id = bundle.id
+        self.app_mode = new_app_mode
+        self.last_deployed_time = timestamp()
+
+    def get_bundle(self):
+        if self.bundle_id is not None:
+            return Bundle.get_object(self.bundle_id)
+        return None
+
+
+class User(DBObject):
+    attrs = ['id', 'guid', 'username', 'first_name', 'last_name', 'email', 'user_role', 'password', 'confirmed',
+             'locked', 'created_time', 'updated_time', 'active_time', 'privileges']
+    show = ['id', 'username', 'first_name', 'last_name']
+
+    @classmethod
+    def get_user_by_api_key(cls, key: str):
+        if key in api_keys:
+            return User.get_object(api_keys[key])
+        return None
+
+    def __init__(self):
+        super(User, self).__init__(needs_uuid=True)
+
+
+class Bundle(DBObject):
+    attrs = ['id', 'app_id', 'created_time', 'updated_time']
+    show = ['id', 'app_id']
+
+    def __init__(self, app: Application, tarball):
+        super(Bundle, self).__init__()
+        self.app_id = app.id
+        self.created_time = timestamp()
+        self.updated_time = self.created_time
+        self.tarball = tarball
+
+    def read_bundle_file(self, file_name):
+        raw_bytes = io.BytesIO(self.tarball)
+        with tarfile.open('r:gz', fileobj=raw_bytes) as tar:
+            return tar.extractfile(file_name).read()
+
+    def get_manifest(self):
+        manifest_data = self.read_bundle_file('manifest.json').decode('utf-8')
+        return json.loads(manifest_data)
+
+    def get_rendered_content(self):
+        manifest = self.get_manifest()
+        meta = manifest['metadata']
+        # noinspection SpellCheckingInspection
+        file_name = meta.get('primary_html') or meta.get('entrypoint')
+        return self.read_bundle_file(file_name).decode('utf-8')
+
+
+class Task(DBObject):
+    attrs = ['id', 'user_id', 'finished', 'code', 'error', 'last_status', 'status']
+
+    def __init__(self):
+        super(Task, self).__init__()
+        self.user_id = 0
+        self.finished = True
+        self.code = 0
+        self.error = ''
+        self.last_status = 0
+        self.status = ['Building static content', 'Deploying static content']
+
+
+def _apply_pre_fetch_data(data: dict):
+    for key, value in data.items():
+        if key in tag_map:
+            if isinstance(value, dict):
+                value = [value]
+            cls = tag_map[key]
+            for item in value:
+                new_object = cls.create_from(item)
+                if cls == User and 'api_key' in item:
+                    api_keys[item['api_key']] = new_object.id
+        else:
+            print('WARNING: Unknown pre-fetch data type: %s' % key)
+
+
+def _pre_fetch_data():
+    file_name = environ.get('PRE_FETCH_FILE')
+    if file_name is not None and len(file_name) > 0:
+        if isfile(file_name):
+            try:
+                with open(file_name) as fd:
+                    _apply_pre_fetch_data(json.load(fd))
+            except JSONDecodeError:
+                print('WARNING: Unable to read pre-fetch file %s as JSON.' % file_name)
+        else:
+            print('WARNING: Pre-fetch file %s does not exist.' % file_name)
+
+
+def _format_section(sections, name, rows):
+    table = '<table>\n%s</table>\n' % '\n'.join(rows)
+    sections.append('<h2>%ss</h2>\n%s' % (name, table))
+
+
+def get_data_dump():
+    ts = ' style="border-style: solid; border-width: 1px"'
+    sections = []
+    for cls in (Application, User, Bundle, Task):
+        rows = [item.get_table_row() for item in cls.get_all_objects()]
+        rows.insert(0, cls.get_table_headers())
+        _format_section(sections, cls.__name__, rows)
+    rows = ['<tr><th>API Key</th><th>User ID</th></tr>']
+    for key, value in api_keys.items():
+        rows.append('<tr><td>%s</td><td>%s</td</tr' % (key, value))
+    _format_section(sections, 'API Key', rows)
+    text = '\n'.join(sections)
+    text = text.replace('<th>', '<th%s>' % ts)
+    text = text.replace('<td>', '<td%s>' % ts)
+    return text
+
+
+tag_map = {
+    'apps': Application,
+    'users': User,
+    'bundles': Bundle,
+    'tasks': Task
+}
+admin_user = User.create_from({
+    "guid": "29a74070-2c13-4ef9-a898-cfc6bcf0f275",
+    "username": "admin",
+    "first_name": "Super",
+    "last_name": "User",
+    "email": "admin@example.com",
+    "user_role": "administrator",
+    "password": "",
+    "confirmed": True,
+    "locked": False,
+    "created_time": "2018-08-29T19:25:23.68280816Z",
+    "active_time": "2018-08-30T23:49:18.421238194Z",
+    "updated_time": "2018-08-29T19:25:23.68280816Z",
+    "privileges": [
+        "add_users",
+        "add_vanities",
+        "change_app_permissions",
+        "change_apps",
+        "change_groups",
+        "change_usernames",
+        "change_users",
+        "change_variant_schedule",
+        "create_groups",
+        "edit_run_as",
+        "edit_runtime",
+        "lock_users",
+        "publish_apps",
+        "remove_apps",
+        "remove_groups",
+        "remove_users",
+        "remove_vanities",
+        "view_app_settings",
+        "view_apps"
+    ]
+})
+# noinspection SpellCheckingInspection
+api_keys = {
+    '0123456789abcdef0123456789abcdef': admin_user.id
+}
+
+# Handle any pre-fetching we should do.
+_pre_fetch_data()

--- a/mock_connect/mock_connect/http_helpers.py
+++ b/mock_connect/mock_connect/http_helpers.py
@@ -1,0 +1,72 @@
+"""
+This provides some low-level things to make our HTTP life easier.
+"""
+from functools import wraps
+
+from typing import Dict, List
+
+# noinspection PyPackageRequirements
+from flask import abort, after_this_request, g, jsonify, request
+
+from .data import DBObject, User
+
+
+def error(code, reason):
+    """
+    This sets up flask to return an error.
+
+    :param code: the HTTP status code to return with the error.
+    :param reason: the text of the error message to return.
+    """
+    def set_code(response):
+        response.status_code = code
+        return response
+
+    after_this_request(set_code)
+
+    return {
+        'error': reason
+    }
+
+
+def _make_json_ready(thing):
+    if isinstance(thing, DBObject):
+        thing = thing.to_dict()
+    elif isinstance(thing, Dict):
+        for key, value in thing.items():
+            thing[key] = _make_json_ready(value)
+    elif isinstance(thing, List):
+        thing = [_make_json_ready(item) for item in thing]
+    return thing
+
+
+def endpoint(authenticated: bool = False, cls=None, writes_json: bool = False):
+    def decorator(function):
+        @wraps(function)
+        def wrapper(object_id=None, *args, **kwargs):
+            if authenticated:
+                auth = request.headers.get('Authorization')
+                if auth is None or not auth.startswith('Key '):
+                    abort(401)
+                user = User.get_user_by_api_key(auth[4:])
+                if user is None:
+                    abort(401)
+                g.user = user
+
+            if cls is None:
+                result = _make_json_ready(function(*args, **kwargs))
+            else:
+                item = cls.get_object(int(object_id))
+                if item is None:
+                    result = error(404, '%s with ID %s not found.' % (cls.__name__, object_id))
+                else:
+                    result = _make_json_ready(function(item, *args, **kwargs))
+
+            if writes_json:
+                result = jsonify(result)
+
+            return result
+
+        return wrapper
+
+    return decorator

--- a/mock_connect/mock_connect/main.py
+++ b/mock_connect/mock_connect/main.py
@@ -1,0 +1,132 @@
+"""
+This is the main file, run via `flask run`, for the mock Connect server.
+"""
+# noinspection PyPackageRequirements
+from flask import Flask, Blueprint, g, request, url_for
+
+from .data import Application, AppMode, Bundle, Task, get_data_dump
+from .http_helpers import endpoint, error
+
+app = Flask(__name__)
+api = Blueprint('api', __name__)
+
+
+@app.route('/')
+def index():
+    return """<html>
+<head><title>RStudio Connect -- Mocked</title></head><body>
+<h1>RStudio Connect -- Mocked</h1>
+<p>Welcome to the mocked RStudio Connect!
+<hr>
+%s
+</body></html>
+""" % get_data_dump()
+
+
+@api.route('me')
+@endpoint(authenticated=True, writes_json=True)
+def me():
+    return g.user
+
+
+@api.route('applications', methods=['GET', 'POST'])
+@endpoint(authenticated=True, writes_json=True)
+def applications():
+    if request.method == 'POST':
+        connect_app = request.get_json(force=True)
+        name = connect_app.get('name')
+        if name and Application.get_app_by_name(name) is not None:
+            return error(409, 'An object with that name already exists.')
+        title = connect_app['title'] if 'title' in connect_app else ''
+
+        return Application(name, title, url_for('index', _external=True), g.user)
+    else:
+        count = int(request.args.get('count', 10000))
+        search = request.args.get('search')
+
+        def match(app_to_match):
+            return search is None or app_to_match.title.startswith(search)
+
+        matches = list(filter(match, Application.get_all_objects()))[:count]
+        return {
+            'count': len(matches),
+            'total': len(matches),
+            'applications': matches,
+        }
+
+
+# noinspection PyUnresolvedReferences
+@api.route('applications/<object_id>', methods=['GET', 'POST'])
+@endpoint(authenticated=True, cls=Application, writes_json=True)
+def application(connect_app):
+    if request.method == 'POST':
+        connect_app.update_from(request.get_json(force=True))
+
+    return connect_app
+
+
+# noinspection PyUnresolvedReferences
+@api.route('applications/<object_id>/config')
+@endpoint(authenticated=True, cls=Application, writes_json=True)
+def config(connect_app):
+    return {
+        'config_url': connect_app.url
+    }
+
+
+# noinspection PyUnresolvedReferences
+@api.route('applications/<object_id>/upload', methods=['POST'])
+@endpoint(authenticated=True, cls=Application, writes_json=True)
+def upload(connect_app):
+    return Bundle(connect_app, request.data)
+
+
+# noinspection PyUnresolvedReferences
+@api.route('applications/<object_id>/deploy', methods=['POST'])
+@endpoint(authenticated=True, cls=Application, writes_json=True)
+def deploy(connect_app):
+    bundle_id = request.get_json(force=True).get('bundle')
+    if bundle_id is None:
+        return error(400, 'bundle_id is required')  # message and status code probably wrong
+    bundle = Bundle.get_object(bundle_id)
+    if bundle is None:
+        return error(404, 'bundle %s not found' % bundle_id)  # message and status code probably wrong
+
+    manifest = bundle.get_manifest()
+    old_app_mode = connect_app.app_mode
+    # noinspection SpellCheckingInspection
+    new_app_mode = AppMode.value_of(manifest['metadata']['appmode'])
+
+    if old_app_mode is not None and old_app_mode != new_app_mode:
+        return error(400, 'Cannot change app mode once deployed')  # message and status code probably wrong
+
+    connect_app.bundle_deployed(bundle, new_app_mode)
+
+    return Task()
+
+
+# noinspection PyUnresolvedReferences
+@api.route('tasks/<object_id>')
+@endpoint(authenticated=True, cls=Task, writes_json=True)
+def get_task(task):
+    return task
+
+
+@api.route('server_settings')
+@endpoint(writes_json=True)
+def server_settings():
+    # for our purposes, any non-error response will do
+    return {}
+
+
+# noinspection PyUnresolvedReferences
+@app.route('/content/apps/<object_id>')
+@endpoint(cls=Application)
+def content(connect_app):
+    bundle = connect_app.get_bundle()
+    if bundle is None:
+        return error(400, 'The content has not been deployed.')  # message and status code probably wrong
+    return bundle.get_rendered_content()
+
+
+app.register_blueprint(api, url_prefix='/__api__')

--- a/mock_connect/sample.json
+++ b/mock_connect/sample.json
@@ -1,0 +1,8 @@
+{
+  "apps": {},
+  "users": {
+
+  },
+  "bundles": {},
+  "tasks": {}
+}


### PR DESCRIPTION
### Description

This change adds the first draft of a mock Connect server, with all the associated docs.  Eventually, this will be expanded to provide a full range of testing support for the actual `rsconnect-python` tests.

### Testing Notes / Validation Steps

All these are relative to the new `mock_connect` directory in the project.

- [ ] The `make image` target correctly creates a Python container with Flask installed.
- [ ] The `make up` target correctly starts the mock server, exposed on port 3939.
- [ ] The `make down` target correctly stops the mock server.
- [ ] The 'clean` target removes the `mock_connect.log` file.
- [ ] The `sh` target starts the Docker container and puts you in an interactive shell (`sh`) session.

With the mock server running,

- [ ] Visiting the root index page (`http://localhost:3939/`) will show a Welcome page along with a dump of all known Connect objects.
- [ ] Supported Connect APIs will work.