### PR TITLE
Jsk fix server construction

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -140,6 +140,9 @@ def do_ping(server, api_key, insecure, ca_data):
     If api_key is set, also validate the API key.
     Raises an exception on failure, otherwise returns None.
     """
+    if not server.endswith('/'):
+        server += '/'
+
     with cli_feedback('Checking %s' % server):
         uri = urlparse(server)
         if not uri.scheme:

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -104,7 +104,7 @@ class ServerStore(object):
         else:
             # Here we know we're dealing with a URL and not a name, so make sure it has
             # the requisite trailing slash.
-            if not name_or_url.endswith('/'):
+            if name_or_url and not name_or_url.endswith('/'):
                 name_or_url += '/'
 
             return name_or_url, api_key, insecure, ca_cert

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -102,6 +102,11 @@ class ServerStore(object):
         if entry:
             return entry['url'], entry['api_key'], entry['insecure'], entry['ca_cert']
         else:
+            # Here we know we're dealing with a URL and not a name, so make sure it has
+            # the requisite trailing slash.
+            if not name_or_url.endswith('/'):
+                name_or_url += '/'
+
             return name_or_url, api_key, insecure, ca_cert
 
     def load(self):


### PR DESCRIPTION
### Description

This change updates server URL handling to treat a URI of the form, `../uri` as if they are `../uri/`.  This provides the behavior most users would intuitively expect.

In addition, error handling on Connect API calls now properly deal with receiving non-JSON response payloads (as will happen under certain error conditions.

### Testing Notes / Validation Steps

- [ ] Server URLs that don't end in `/` will now work.
- [ ] If we get a non-JSON error back from Connect, it will now be correctly reported rather than throw an exception.