### PR TITLE
Make JSON error trapping v2 safe.

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -4,7 +4,6 @@ import re
 import socket
 import time
 import ssl
-from json import JSONDecodeError
 
 from os.path import join, dirname
 from six.moves import http_client as http
@@ -188,7 +187,7 @@ class RSConnect:
 
         try:
             data = json.loads(raw)
-        except JSONDecodeError:
+        except ValueError:
             data = {
                 'error': str(raw)
             }


### PR DESCRIPTION
### Description

This change updates the API code to use a more general (and Python v2 compliant) exception when testing for JSON decode failures.

### Testing Notes / Validation Steps

- [ ] The code will now work correctly under Python 2.x
- [ ] The code will continue to work correctly under Python 3.x