### PR TITLE
smoke test the CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@ ifneq (${JOB_NAME},)
 	RUNNER=bash -c
 endif
 
+ifneq (${CONNECT_SERVER},)
+    TEST_ENV1=CONNECT_SERVER=${CONNECT_SERVER}
+endif
+ifneq (${CONNECT_API_KEY},)
+    TEST_ENV2=CONNECT_API_KEY=${CONNECT_API_KEY}
+endif
+
 all-tests: all-images test-2.7 test-3.5 test-3.6 test-3.7 test-3.8
 
 all-images: image-2.7 image-3.5 image-3.6 image-3.7 image-3.8
@@ -23,7 +30,7 @@ shell-%:
 	$(RUNNER) 'python setup.py develop --user && bash'
 
 test-%:
-	$(RUNNER) 'python setup.py develop --user && python -m unittest discover'
+	$(RUNNER) 'python setup.py develop --user && ${TEST_ENV1} ${TEST_ENV2} python -m unittest discover'
 
 coverage-%:
 	$(RUNNER) 'python setup.py develop --user && pytest --cov=rsconnect --cov-report=html --no-cov-on-fail rsconnect/tests/'

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -406,5 +406,6 @@ def manifest_notebook(force, python, verbose, file, extra_files):
                 f.write(environment['contents'])
 
 
-cli()
-click.echo()
+if __name__ == '__main__':
+    cli()
+    click.echo()

--- a/rsconnect/tests/test_main.py
+++ b/rsconnect/tests/test_main.py
@@ -1,0 +1,44 @@
+import os
+
+from unittest import TestCase
+from click.testing import CliRunner
+from ..main import cli
+from ..api import VERSION
+
+
+class TestMain(TestCase):
+    def require_connect(self):
+        connect_server = os.environ.get('CONNECT_SERVER', None)
+        if connect_server is None:
+            self.skipTest('Set CONNECT_SERVER to test this function.')
+        return connect_server
+
+    def require_api_key(self):
+        connect_api_key = os.environ.get('CONNECT_API_KEY', None)
+        if connect_api_key is None:
+            self.skipTest('Set CONNECT_API_KEY to test this function.')
+        return connect_api_key
+
+    def test_version(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ['version'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(VERSION, result.output)
+
+    def test_ping(self):
+        connect_server = self.require_connect()
+        runner = CliRunner()
+        result = runner.invoke(cli, ['test', '-s', connect_server])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("OK", result.output)
+
+    def test_ping_api_key(self):
+        connect_server = self.require_connect()
+        api_key = self.require_api_key()
+        runner = CliRunner()
+        result = runner.invoke(cli, ['test', '-s', connect_server, '-k', api_key])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("OK", result.output)
+
+
+


### PR DESCRIPTION
Fallout from #26 

Closes #27 

- Add CLI smoke tests
- Hook it into the makefile so we can plug in a connect server or mock connect as needed.