### PR TITLE
print absolute path of store metadata

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -115,7 +115,7 @@ def info(file):
         }
 
         if deployments:
-            click.echo('Loaded deployment information from %s' % app_store.get_path())
+            click.echo('Loaded deployment information from %s' % abspath(app_store.get_path()))
 
             for deployment in deployments:
                 click.echo()


### PR DESCRIPTION
- Surround the `app_store.get_path()` call with `abspath()` so we know exactly where it is.

# Testing Notes

`rsconnect info` should print the absolute path of the deployment metadata file at the very top after "Loaded deployment information from..."