### PR TITLE
Help text updates and doc feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ In addition to various kinds of R content, RStudio Connect also supports the dep
 
 - RStudio Connect insists on matching <MAJOR.MINOR> versions of Python. For example, a server with only Python 3.5 installed will fail to match content deployed with Python 3.4. Your administrator may also enable exact Python version matching which will be stricter and require matching major, minor, and patch versions. For more information see the [RStudio Connect Admin Guide chapter titled Python Version Matching](https://docs.rstudio.com/connect/admin/python.html#python-version-matching).
 
-- 
-
 ### Installation
 
 To install from this repository:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 This package is a library used by the rsconnect-jupyter package to deploy Jupyter notebooks to RStudio Connect. It can also be used by other Python-based deployment tools.
 
-There is also a CLI deployment tool which can be used directly to deploy Jupyter notebooks. Other content types can be deployed if they include a prepared `manifest.json` file.
+There is also a CLI deployment tool which can be used directly to deploy Jupyter notebooks. Other content types can be deployed if they include a prepared `manifest.json` file. See 
+["Creating a Manifest for Future Deployment"](#creating-a-manifest-for-future-deployment) for details
+
+## Deploying Python Content to RStudio Connect
+
+In addition to various kinds of R content, RStudio Connect also supports the deployment of Jupyter notebooks. Much like deploying R content to RStudio Connect, there are some caveats to understand when replicating your environment on the RStudio Connect server:
+
+- RStudio Connect insists on matching <MAJOR.MINOR> versions of Python. For example, a server with only Python 3.5 installed will fail to match content deployed with Python 3.4. Your administrator may also enable exact Python version matching which will be stricter and require matching major, minor, and patch versions. For more information see the [RStudio Connect Admin Guide chapter titled Python Version Matching](https://docs.rstudio.com/connect/admin/python.html#python-version-matching).
+
+- 
 
 ### Installation
 
@@ -228,6 +237,13 @@ rsconnect deploy notebook --app-id 123456 my-notebook.ipynb
 You must be the owner of the target deployment, or a collaborator with permission to change the content. The type of content (static notebook, or notebook with source code) must match the existing deployment.
 
 Note: there is no confirmation required to update a deployment. If you do so accidentally, use the "Source Versions" dialog in the Connect dashboard to activate the previous version and remove the erroneous one.
+
+
+##### Finding the App ID
+
+The App ID associated with a piece of content you have previously deployed from the `rsconnect` command line interface can be found easily by querying the deployment information using the `info` command. For more information, see [Showing the Deployment Information](#showing-the-deployment-information).
+
+If the content was deployed elsewhere or `info` does not return the correct App ID, but you can open the content on RStudio Connect, find the content and open it in a browser. The URL in your browser's location bar will contain `#/apps/NNN` where `NNN` is your App ID.
 
 #### Showing the Deployment Information
 You can see the information that rsconnect-python has saved for the most recent deployment

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -160,7 +160,7 @@ def deploy():
 @click.option('--server', '-s', envvar='CONNECT_SERVER', help='Connect server URL or saved server name')
 @click.option('--api-key', '-k', envvar='CONNECT_API_KEY', help='Connect server API key (Optional if server is saved)')
 @click.option('--static', is_flag=True,
-              help='Deploy a static, pre-rendered notebook and do not include the notebook source. Static notebooks '
+              help='Render a notebook locally and deploy the result as a static notebook. Will not include the notebook source. Static notebooks '
                    'cannot be re-run on the server.')
 @click.option('--new', '-n', is_flag=True,
               help='Force a new deployment, even if there is saved metadata from a previous deployment.')

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -136,9 +136,11 @@ def version():
 
 
 # noinspection SpellCheckingInspection
-@cli.command(help='Verify a Connect server URL')
+@cli.command(help='Verify a Connect server URL without adding the server. If API key is provided, verify that the '
+                  'given API key is valid for the server; otherwise, verify that the server is running RStudio '
+                  'Connect.')
 @click.option('--server', '-s', required=True, envvar='CONNECT_SERVER', help='Connect server URL')
-@click.option('--api-key', '-k', envvar='CONNECT_API_KEY', help='Connect server API key')
+@click.option('--api-key', '-k', envvar='CONNECT_API_KEY', help='Connect server API key (Optional if server is saved)')
 @click.option('--insecure', envvar='CONNECT_INSECURE', is_flag=True, help='Disable TLS certification validation.')
 @click.option('--cacert', envvar='CONNECT_CA_CERTIFICATE', type=click.File(),
               help='Path to trusted TLS CA certificate.')
@@ -156,9 +158,10 @@ def deploy():
 # noinspection SpellCheckingInspection,DuplicatedCode
 @deploy.command(name='notebook', help='Deploy content to RStudio Connect')
 @click.option('--server', '-s', envvar='CONNECT_SERVER', help='Connect server URL or saved server name')
-@click.option('--api-key', '-k', envvar='CONNECT_API_KEY', help='Connect server API key')
+@click.option('--api-key', '-k', envvar='CONNECT_API_KEY', help='Connect server API key (Optional if server is saved)')
 @click.option('--static', is_flag=True,
-              help='Deployed a static, pre-rendered notebook. Static notebooks cannot be re-run on the server.')
+              help='Deploy a static, pre-rendered notebook and do not include the notebook source. Static notebooks '
+                   'cannot be re-run on the server.')
 @click.option('--new', '-n', is_flag=True,
               help='Force a new deployment, even if there is saved metadata from a previous deployment.')
 @click.option('--app-id', help='Existing app ID or GUID to replace. Cannot be used with --new.')
@@ -270,7 +273,7 @@ def deploy_notebook(server, api_key, static, new, app_id, title, python, insecur
 # noinspection SpellCheckingInspection,DuplicatedCode
 @deploy.command(name='manifest', short_help='Deploy content to RStudio Connect using an existing manifest.json file')
 @click.option('--server', '-s', envvar='CONNECT_SERVER', help='Connect server URL or saved server name')
-@click.option('--api-key', '-k', envvar='CONNECT_API_KEY', help='Connect server API key')
+@click.option('--api-key', '-k', envvar='CONNECT_API_KEY', help='Connect server API key (Optional if server is saved)')
 @click.option('--new', '-n', is_flag=True,
               help='Force a new deployment, even if there is saved metadata from a previous deployment.'
               )
@@ -346,7 +349,7 @@ def deploy_manifest(server, api_key, new, app_id, title, insecure, cacert, verbo
         app_store.save()
 
 
-@deploy.command(name='help', help='Show help on how to deploy other content to RStudio Connect')
+@deploy.command(name='other-content', help='Show help on how to deploy other content to RStudio Connect')
 def deploy_help():
     print(
         'To deploy a Shiny app or R Markdown document,\n'
@@ -362,7 +365,9 @@ def manifest():
     pass
 
 
-@manifest.command(name="notebook", help='Create a manifest.json file for a notebook, for later deployment')
+@manifest.command(name="notebook", help='Create a manifest.json file for a notebook, for later deployment. '
+                                        'Creates an environment file (requirements.txt) if one does not exist. '
+                                        'All files are created in the same directory as the notebook file.')
 @click.option('--force', '-f', is_flag=True, help='Replace manifest.json, if it exists.')
 @click.option('--python', type=click.Path(exists=True),
               help='Path to python interpreter whose environment should be used. ' +


### PR DESCRIPTION
- change `rsconnect deploy help` to `rsconnect deploy other-content`
- Make every API key argument except `add` explicitly say optional if the server is saved.
- Explain the purpose behind `test` and why it's different from `add`
- Explain `write-manifest` will write a `requirements.txt` if it does not exist.

Doc Updates:
- Explain how to generate a manifest when it's first mentioned
- Explain basics of deploying python content to RSC
- Explain how to find the App ID