### PR TITLE
Normalize CLI argument usage.

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -130,8 +130,7 @@ def verify_server(server, insecure, ca_data):
 
 
 def verify_api_key(server, api_key, insecure, ca_data):
-    uri = urlparse(server)
-    api.verify_api_key(uri, api_key, insecure, ca_data)
+    api.verify_api_key(server, api_key, insecure, ca_data)
 
 
 def do_ping(server, api_key, insecure, ca_data):

--- a/rsconnect/tests/test_metadata.py
+++ b/rsconnect/tests/test_metadata.py
@@ -56,8 +56,8 @@ class TestServerMetadata(TestCase):
         self.assertEqual(servers[1]['url'], 'http://connect.local')
 
     def test_resolve_by_name(self):
-        server, api_key, insecure, ca_cert = 'foo', None, None, None
-        server, api_key, insecure, ca_cert = self.server_store.resolve(server, api_key, insecure, ca_cert)
+        name, server, api_key, insecure, ca_cert = 'foo', None, None, None, None
+        server, api_key, insecure, ca_cert = self.server_store.resolve(name, server, api_key, insecure, ca_cert)
 
         self.assertEqual(server, 'http://connect.local')
         self.assertEqual(api_key, 'notReallyAnApiKey')
@@ -65,8 +65,8 @@ class TestServerMetadata(TestCase):
         self.assertEqual(ca_cert, '/certs/connect')
 
     def test_resolve_by_url(self):
-        server, api_key, insecure, ca_cert = 'http://connect.local', None, None, None
-        server, api_key, insecure, ca_cert = self.server_store.resolve(server, api_key, insecure, ca_cert)
+        name, server, api_key, insecure, ca_cert = None, 'http://connect.local', None, None, None
+        server, api_key, insecure, ca_cert = self.server_store.resolve(name, server, api_key, insecure, ca_cert)
 
         self.assertEqual(server, 'http://connect.local')
         self.assertEqual(api_key, 'notReallyAnApiKey')
@@ -75,13 +75,13 @@ class TestServerMetadata(TestCase):
 
     def test_resolve_by_default(self):
         # with multiple entries, server None will not resolve by default
-        server, api_key, insecure, ca_cert = None, None, None, None
-        server, api_key, insecure, ca_cert = self.server_store.resolve(server, api_key, insecure, ca_cert)
+        name, server, api_key, insecure, ca_cert = None, None, None, None, None
+        server, api_key, insecure, ca_cert = self.server_store.resolve(name, server, api_key, insecure, ca_cert)
         self.assertEqual(server, None)
 
         # with only a single entry, server None will resolve to that entry
         self.server_store.remove('http://connect.remote')
-        server, api_key, insecure, ca_cert = self.server_store.resolve(server, api_key, insecure, ca_cert)
+        server, api_key, insecure, ca_cert = self.server_store.resolve(name, server, api_key, insecure, ca_cert)
         self.assertEqual(server, 'http://connect.local')
         self.assertEqual(api_key, 'notReallyAnApiKey')
         self.assertEqual(insecure, False)


### PR DESCRIPTION
### Description

This change normalizes CLI argument definition and usage.  See the testing notes below for details.

Some general things to note:

- Some command options did not have a short form.  This has been addressed as follows:

    * `--insecure` may now be `-i`
    * `--cacert` may now be `-c`
    * `--python` may now be `-p`
    * `--static` may now be `-S` (capitalized)
    * `--app-id` may now be `-a`

    > **Note:** The short form for the `--new` option to force a new deployment has been changed to `-N` so as not to conflict with the short form of `--name`.

- Help text was standardized to sentences; i.e., periods are now consistently used.

- Function order was rearranged to group related CLI commands together.

Connected to https://github.com/rstudio/connect/issues/16405

### Testing Notes / Validation Steps

- [ ] Running `rsconnect` by itself should now include prose on the CLI's function.
- [ ] Help for `rsconnect test` should be more clear and complete.
- [ ] Help for `rsconnect add` should be more clear and complete.
- [ ] The `rsconnect remove` command now requires that a nickname be specified with `-n`/`--name` and that a server URL be specified with `-s`/`--server` for consistency with other commands.  Specifying neither or both should result in an error.
- [ ] Help for `rsconnect remove` should be more clear and complete.
- [ ] Help for `rsconnect list` should be more clear and complete.
- [ ] The `rsconnect deploy notebook` command now requires that a nickname be specified with `-n`/`--name` and that a server URL be specified with `-s`/`--server` for consistency with other commands.  Specifying neither or both should result in an error.
- [ ] Help for `rsconnect deploy notebook` should be more clear and complete.
- [ ] The `rsconnect deploy manifest` command now requires that a nickname be specified with `-n`/`--name` and that a server URL be specified with `-s`/`--server` for consistency with other commands.  Specifying neither or both should result in an error.
- [ ] Help for `rsconnect deploy manifest` should be more clear and complete.
- [ ] All commands that accept `--insecure` should now accept `-I` also.
- [ ] All commands that accept `--cacert` should now accept `-c` also.
- [ ] All commands that accept `--python` should now accept `-p` also.
- [ ] All commands that accept `--static` should now accept `-S` also.
- [ ] All commands that accept `--app-id` should now accept `-a` also.
- [ ] All commands that accept `--new` should now accept `-N` for force new rather than `-n`, which now means `--name`.