### PR TITLE
add deploy test with optional cacert argument

### DIFF
--- a/rsconnect/tests/test_bundle.py
+++ b/rsconnect/tests/test_bundle.py
@@ -3,27 +3,21 @@ import sys
 import tarfile
 
 from unittest import TestCase
-from os.path import dirname, exists, join
+from os.path import dirname, join
 
 from rsconnect.environment import detect_environment
 from rsconnect.bundle import list_files, make_manifest_bundle, make_notebook_html_bundle, make_notebook_source_bundle
+from rsconnect.tests.test_data_util import get_dir
 
 
 class TestBundle(TestCase):
-    def get_dir(self, name):
-        py_version = 'py%d' % sys.version_info[0]
-        # noinspection SpellCheckingInspection
-        path = join(dirname(__file__), 'testdata', py_version, name)
-        self.assertTrue(exists(path))
-        return path
-
     @staticmethod
     def python_version():
         return u'.'.join(map(str, sys.version_info[:3]))
 
     def test_source_bundle1(self):
         self.maxDiff = 5000
-        directory = self.get_dir('pip1')
+        directory = get_dir('pip1')
         nb_path = join(directory, 'dummy.ipynb')
 
         # Note that here we are introspecting the environment from within
@@ -81,7 +75,7 @@ class TestBundle(TestCase):
 
     def test_source_bundle2(self):
         self.maxDiff = 5000
-        directory = self.get_dir('pip2')
+        directory = get_dir('pip2')
         nb_path = join(directory, 'dummy.ipynb')
 
         # Note that here we are introspecting the environment from within
@@ -180,10 +174,10 @@ class TestBundle(TestCase):
         self.assertEqual(files, paths[:2])
 
     def test_html_bundle1(self):
-        self.do_test_html_bundle(self.get_dir('pip1'))
+        self.do_test_html_bundle(get_dir('pip1'))
 
     def test_html_bundle2(self):
-        self.do_test_html_bundle(self.get_dir('pip2'))
+        self.do_test_html_bundle(get_dir('pip2'))
 
     def do_test_html_bundle(self, directory):
         self.maxDiff = 5000

--- a/rsconnect/tests/test_data_util.py
+++ b/rsconnect/tests/test_data_util.py
@@ -1,0 +1,11 @@
+import sys
+from os.path import join, dirname, exists
+
+
+def get_dir(name):
+    py_version = 'py%d' % sys.version_info[0]
+    # noinspection SpellCheckingInspection
+    path = join(dirname(__file__), 'testdata', py_version, name)
+    if not exists(path):
+        raise AssertionError('%s does not exist' % path)
+    return path

--- a/rsconnect/tests/test_main.py
+++ b/rsconnect/tests/test_main.py
@@ -23,10 +23,10 @@ class TestMain(TestCase):
         return connect_api_key
 
     def optional_target(self, default):
-        return os.environ.get('TARGET', default)
+        return os.environ.get('CONNECT_DEPLOY_TARGET', default)
 
     def optional_cadata(self, default=None):
-        return os.environ.get('CADATA_FILE', default)
+        return os.environ.get('CONNECT_CADATA_FILE', default)
 
     def test_version(self):
         runner = CliRunner()

--- a/rsconnect/tests/test_main.py
+++ b/rsconnect/tests/test_main.py
@@ -1,7 +1,10 @@
 import os
+from os.path import join
 
 from unittest import TestCase
 from click.testing import CliRunner
+
+from .test_data_util import get_dir
 from ..main import cli
 from rsconnect import VERSION
 
@@ -19,17 +22,23 @@ class TestMain(TestCase):
             self.skipTest('Set CONNECT_API_KEY to test this function.')
         return connect_api_key
 
+    def optional_target(self, default):
+        return os.environ.get('TARGET', default)
+
+    def optional_cadata(self, default=None):
+        return os.environ.get('CADATA_FILE', default)
+
     def test_version(self):
         runner = CliRunner()
         result = runner.invoke(cli, ['version'])
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn(VERSION, result.output)
 
     def test_ping(self):
         connect_server = self.require_connect()
         runner = CliRunner()
         result = runner.invoke(cli, ['test', '-s', connect_server])
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("OK", result.output)
 
     def test_ping_api_key(self):
@@ -37,8 +46,21 @@ class TestMain(TestCase):
         api_key = self.require_api_key()
         runner = CliRunner()
         result = runner.invoke(cli, ['test', '-s', connect_server, '-k', api_key])
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("OK", result.output)
 
+    def test_deploy(self):
+        connect_server = self.require_connect()
+        api_key = self.require_api_key()
+        target = self.optional_target(get_dir(join('pip1', 'dummy.ipynb')))
+        cadata_file = self.optional_cadata(None)
+        runner = CliRunner()
+        args = ['deploy', 'notebook', '-s', connect_server, '-k', api_key]
+        if cadata_file is not None:
+            args.append(['--cacert', cadata_file])
+        args.append(target)
+        result = runner.invoke(cli, args)
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("OK", result.output)
 
 


### PR DESCRIPTION
- Add a deploy test with an optional cacert argument

We now have four (!) environment variables that can be specified to do a parameterized test of the CLI:

- `CONNECT_SERVER` - connect server URL
- `CONNECT_API_KEY` - api key for the given server
- `CONNECT_DEPLOY_TARGET` - path to a file that will be used to deploy
- `CONNECT_CADATA_FILE` - path to a file that will be used as the certificate data