### PR TITLE
Allow for empty body tagged as JSON.

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -76,6 +76,7 @@ class RSConnect(HTTPServer):
         if app_id is None:
             # create an app if id is not provided
             app = self.app_create(app_name)
+            app_id = app['id']
         else:
             # assume app exists. if it was deleted then Connect will
             # raise an error

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -99,7 +99,7 @@ class HTTPResponse(object):
             self.content_type = response.getheader('Content-Type')
             self.response_body = response.read().decode('utf-8')
 
-            if self.content_type and self.content_type.startswith('application/json'):
+            if self.content_type and self.content_type.startswith('application/json') and len(self.response_body) > 0:
                 self.json_data = json.loads(self.response_body)
 
 

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -79,7 +79,7 @@ class HTTPResponse(object):
     """
     This class represents the result of executing an HTTP request.
     """
-    def __init__(self, response=None, exception=None):
+    def __init__(self, response=None, body=None, exception=None):
         """
         This constructs an HTTPResponse object.  One and only one of the arguments will
         be None.
@@ -91,13 +91,12 @@ class HTTPResponse(object):
         self.exception = exception
         self.content_type = None
         self.json_data = None
-        self.response_body = None
+        self.response_body = body
 
         if response is not None:
             self.status = response.status
             self.reason = response.reason
             self.content_type = response.getheader('Content-Type')
-            self.response_body = response.read().decode('utf-8')
 
             if self.content_type and self.content_type.startswith('application/json') and len(self.response_body) > 0:
                 self.json_data = json.loads(self.response_body)
@@ -188,6 +187,7 @@ class HTTPServer(object):
                 self._conn.request(method, full_uri, body, headers)
 
                 response = self._conn.getresponse()
+                response_body = response.read().decode('utf-8').strip()
             finally:
                 if local_connection:
                     self.__exit__()
@@ -206,7 +206,7 @@ class HTTPServer(object):
 
             self._handle_set_cookie(response)
 
-            return self._tweak_response(HTTPResponse(response=response))
+            return self._tweak_response(HTTPResponse(response=response, body=response_body))
         except (http.HTTPException, IOError, OSError, socket.error, socket.herror, socket.gaierror,
                 socket.timeout) as exception:
             return HTTPResponse(exception=exception)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -89,7 +89,7 @@ def _test_server_and_api(server, api_key, insecure, ca_cert):
 
 
 # noinspection SpellCheckingInspection
-@cli.command(help='Associate a simple nickname with the information needed to interact with an RStudio Connect server')
+@cli.command(help='Associate a simple nickname with the information needed to interact with an RStudio Connect server.')
 @click.option('--name', '-n', required=True, help='The nickname to associate with the server.')
 @click.option('--server', '-s', required=True, help='The URL for the RStudio Connect server.')
 @click.option('--api-key', '-k', required=True, help='The API key to use to authenticate with RStudio Connect.')
@@ -341,9 +341,9 @@ def deploy_notebook(name, server, api_key, static, new, app_id, title, python, i
                                              'Use --new to create a new deployment.')
 
     if name or server:
-        click.secho('Deploying %s to server "%s"' % (file, name or server), fg='bright_white')
+        click.secho('    Deploying %s to server "%s"' % (file, server), fg='white')
     else:
-        click.secho('Deploying %s' % file, fg='bright_white')
+        click.secho('    Deploying %s' % file, fg='white')
 
     with cli_feedback('Inspecting python environment'):
         python = which_python(python)
@@ -429,9 +429,9 @@ def deploy_manifest(name, server, api_key, new, app_id, title, insecure, cacert,
         api_client = api.RSConnect(server, api_key, [], insecure, ca_data)
 
     if name or server:
-        click.secho('Deploying %s to server "%s"' % (file, name or server), fg='bright_white')
+        click.secho('    Deploying %s to server "%s"' % (file, server), fg='white')
     else:
-        click.secho('Deploying %s' % file, fg='bright_white')
+        click.secho('    Deploying %s' % file, fg='white')
 
     with cli_feedback('Creating deployment bundle'):
         bundle = make_manifest_bundle(file)


### PR DESCRIPTION
### Description

This change updates the HTTP code to allow for a response that carries both a content type of JSON and an empty body.

### Testing Notes / Validation Steps

- [ ] The `deploy` command should now work.