### PR TITLE
Clean up deploy other-content output.

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import subprocess
+import textwrap
 
 from os.path import abspath, basename, dirname, exists, join, splitext
 from pprint import pformat
@@ -454,14 +455,15 @@ def deploy_manifest(name, server, api_key, new, app_id, title, insecure, cacert,
         app_store.save()
 
 
-@deploy.command(name='other-content', help='Show help on how to deploy other content to RStudio Connect')
+@deploy.command(name='other-content', help='Show help on how to deploy other content to RStudio Connect.')
 def deploy_help():
-    print(
-        'To deploy a Shiny app or R Markdown document,\n'
-        'use the rsconnect package in the RStudio IDE. Or,\n'
-        'use rsconnect::writeManifest to create a manifest.json file\n'
-        'and deploy that using this tool with the command\n'
-        '"rsconnect deploy manifest".')
+    text = 'To deploy a Shiny application or R Markdown document, use the rsconnect R package in the RStudio IDE.  ' \
+           'Or, use rsconnect::writeManifest (again in the IDE) to create a manifest.json file and deploy that using ' \
+           'this tool with the command, '
+    click.echo('\n'.join(textwrap.wrap(text, 79)))
+    click.echo()
+    click.echo('    rsconnect deploy manifest <manifest-file>')
+    click.echo()
 
 
 @cli.group(name="write-manifest", no_args_is_help=True,

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -462,7 +462,7 @@ def deploy_help():
            'this tool with the command, '
     click.echo('\n'.join(textwrap.wrap(text, 79)))
     click.echo()
-    click.echo('    rsconnect deploy manifest <manifest-file>')
+    click.echo('    rsconnect deploy manifest [-n <name>|-s <url> -k <key>] <manifest-file>')
     click.echo()
 
 


### PR DESCRIPTION
### Description

This change provides polish to the `deploy other-content` command.

Connected to https://github.com/rstudio/connect/issues/16445

### Testing Notes / Validation Steps

- [ ] The output of the `rsconnect deploy other-conent` command should be clear, complete and well formatted.
