### PR TITLE
Always use unicode certificate data

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -75,7 +75,7 @@ def test(server, api_key, insecure, cacert, verbose):
 
 
 def _test_server_and_api(server, api_key, insecure, ca_cert):
-    ca_data = ca_cert and ca_cert.read()
+    ca_data = ca_cert and unicode(ca_cert.read())
     me = None
 
     with cli_feedback('Checking %s' % server):
@@ -241,7 +241,7 @@ def deploy():
 
 
 def _validate_deploy_to_args(name, server, api_key, insecure, ca_cert):
-    ca_data = ca_cert and ca_cert.read()
+    ca_data = ca_cert and unicode(ca_cert.read())
 
     if name and server:
         raise api.RSConnectException('You must specify only one of -n/--name or -s/--server, not both.')

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -7,6 +7,7 @@ from os.path import abspath, basename, dirname, exists, join, splitext
 from pprint import pformat
 
 import click
+from six import text_type
 from six.moves.urllib_parse import urlparse
 
 from rsconnect import VERSION
@@ -75,7 +76,7 @@ def test(server, api_key, insecure, cacert, verbose):
 
 
 def _test_server_and_api(server, api_key, insecure, ca_cert):
-    ca_data = ca_cert and unicode(ca_cert.read())
+    ca_data = ca_cert and text_type(ca_cert.read())
     me = None
 
     with cli_feedback('Checking %s' % server):
@@ -241,7 +242,7 @@ def deploy():
 
 
 def _validate_deploy_to_args(name, server, api_key, insecure, ca_cert):
-    ca_data = ca_cert and unicode(ca_cert.read())
+    ca_data = ca_cert and text_type(ca_cert.read())
 
     if name and server:
         raise api.RSConnectException('You must specify only one of -n/--name or -s/--server, not both.')


### PR DESCRIPTION
https://bugs.python.org/issue37079

We were failing to use `cacert` properly in python 2.7 because `.read()` doesn't return unicode. Now it does.

This addresses the "nested asn1 error" message when attempting to contact a server with the `cacert` specified on the command line in python 2.7.

## Testing Notes

Deploy to a server which requires a certificate under python 2.7

Alternatively, add a server which requires a certificate under python 2.7