### PR TITLE
Allow absence of scheme on server specifications.

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -249,6 +249,9 @@ def _validate_deploy_to_args(name, server, api_key, insecure, ca_cert):
 
     real_server, api_key, insecure, ca_data, from_store = server_store.resolve(name, server, api_key, insecure, ca_data)
 
+    if not from_store:
+        real_server, _ = test_server(real_server, insecure, ca_data)
+
     # This can happen if the user specifies neither --name or --server and there's not
     # a single default to go with.
     if not real_server:
@@ -262,7 +265,6 @@ def _validate_deploy_to_args(name, server, api_key, insecure, ca_cert):
 
     # If our info came from the command line, we really should test it out first.
     if not from_store:
-        real_server, _ = test_server(real_server, insecure, ca_data)
         _ = test_api_key(real_server, api_key, insecure, ca_data)
 
     return real_server, api_key, insecure, ca_data


### PR DESCRIPTION
### Description

This change corrects an issue with accepting server URLs without a scheme on the `deploy` commands.

### Testing Notes / Validation Steps

- [ ] Specifying `reconnect deploy notebook -s <host>:<port> ...` (i.e., neither `http://` or `https://` prefix) should now work.