### PR TITLE
Finish up Conda reporting.

### DIFF
--- a/mock_connect/mock_connect/data.py
+++ b/mock_connect/mock_connect/data.py
@@ -334,7 +334,6 @@ default_server_settings = {
     "git_enabled": True,
     "git_available": True,
     "documentation_dashboard": False,
-    "conda_supported": False
 }
 tag_map = {
     'apps': Application,

--- a/mock_connect/mock_connect/main.py
+++ b/mock_connect/mock_connect/main.py
@@ -135,7 +135,8 @@ def python_settings():
     v = "%d.%d.%d" % (v[0], v[1], v[2])
 
     return {
-        "installations": [{"version": v}]
+        "installations": [{"version": v}],
+        "conda_supported": False
     }
 
 

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -208,9 +208,10 @@ def gather_server_details(server, api_key, insecure, ca_data):
     :param api_key: the API key to authenticate with.
     :param insecure: a flag to disable TLS verification.
     :param ca_data: client side certificate data to use for TLS.
-    :return: a two-entry dictionary.  The key 'connect' will refer to the version
+    :return: a three-entry dictionary.  The key 'connect' will refer to the version
     of Connect that was found.  The key `python` will refer to a sequence of version
-    strings for all the versions of Python that are installed.
+    strings for all the versions of Python that are installed.  The key `conda` will
+    refer to data about whether Connect is configured to support Conda environments.
     """
     def _to_sort_key(text):
         parts = [part.zfill(5) for part in text.split('.')]
@@ -219,7 +220,11 @@ def gather_server_details(server, api_key, insecure, ca_data):
     server_settings = api.verify_server(server, api_key, insecure, ca_data)
     python_settings = api.get_python_info(server, api_key, insecure, ca_data)
     python_versions = sorted([item['version'] for item in python_settings['installations']], key=_to_sort_key)
+    conda_settings = {
+        'supported': python_settings['conda_supported'] if 'conda_supported' in python_settings else False
+    }
     return {
         'connect': server_settings['version'],
-        'python': python_versions
+        'python': python_versions,
+        'conda': conda_settings
     }

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -161,6 +161,7 @@ def details(name, server, api_key, insecure, cacert, verbose):
 
     if server_details:
         python_versions = server_details['python']
+        conda_details = server_details['conda']
         click.echo('    RStudio Connect version: %s' % server_details['connect'])
 
         if len(python_versions) == 0:
@@ -169,6 +170,9 @@ def details(name, server, api_key, insecure, cacert, verbose):
             click.echo('    Installed versions of Python:')
             for python_version in python_versions:
                 click.echo('        %s' % python_version)
+
+        click.echo('    Conda: %ssupported' % ('' if conda_details['supported'] else 'not '))
+
 
 
 @cli.command(help='Remove the information about an RStudio Connect server by nickname or URL.  '

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -254,13 +254,13 @@ def _validate_deploy_to_args(name, server, api_key, insecure, ca_cert):
 
     real_server, api_key, insecure, ca_data, from_store = server_store.resolve(name, server, api_key, insecure, ca_data)
 
-    if not from_store:
-        real_server, _ = test_server(real_server, insecure, ca_data)
-
     # This can happen if the user specifies neither --name or --server and there's not
     # a single default to go with.
     if not real_server:
         raise api.RSConnectException('You must specify one of -n/--name or -s/--server.')
+
+    if not from_store:
+        real_server, _ = test_server(real_server, insecure, ca_data)
 
     if not urlparse(real_server).netloc:
         raise api.RSConnectException('Invalid server URL: "%s".' % real_server)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -434,7 +434,7 @@ def deploy_manifest(name, server, api_key, new, app_id, title, insecure, cacert,
             # Use the saved app information unless overridden by the user.
             app_id, title, app_mode = app_store.resolve(server, app_id, title, app_mode)
 
-        api_client = api.RSConnect(server, api_key, [], insecure, ca_data)
+        api_client = api.RSConnect(server, api_key, insecure, ca_data)
 
     if name or server:
         click.secho('    Deploying %s to server "%s"' % (file, server), fg='white')


### PR DESCRIPTION
### Description

This change accounts for the relocation of the "Conda supported" flag in Connect.  It also now reports this flag as part of the `details` command.

This also corrects a problem with the `deploy manifest` command and an argument handling problem with the `details`, `deploy notebook` and `deploy manifest` commands.

### Testing Notes / Validation Steps

- [ ] Running `rsconnect details <server>` now includes a line about whether Conda is supported on the specified Connect server.
- [ ] The `rsconnect deploy manifest ...` command should work now.
- [ ] Running `rsconnect details` with no other arguments and either 0 or > 1 remembered servers should now produce a proper error and not a traceback.
- [ ] Running `rsconnect deploy notebook <file>` with no other arguments and either 0 or > 1 remembered servers should now produce a proper error and not a traceback.
- [ ] Running `rsconnect deploy manifest <file>` with no other arguments and either 0 or > 1 remembered servers should now produce a proper error and not a traceback. 