### PR TITLE
Jsk merge details and test

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -124,7 +124,7 @@ def list_servers(verbose):
 
 
 # noinspection SpellCheckingInspection
-@cli.command(help='Show version details about an RStudio Connect server and the versions of Python installed.')
+@cli.command(help='Show version details about an RStudio Connect server and installed Python/Conda information.')
 @click.option('--name', '-n', help='The nickname of the RStudio Connect server to get details for.')
 @click.option('--server', '-s', envvar='CONNECT_SERVER',
               help='The URL for the RStudio Connect server to get details for.')


### PR DESCRIPTION
### Description

This change merges the `test` and `details` commands.  There is now only `details` but the API key is now optional.  If an API key is not available, only the server's URL is displayed.  If an API key is present, the Connect, Python and Conda information is shown after the URL.

Connected to https://github.com/rstudio/connect/issues/16498

### Testing Notes / Validation Steps

- [ ] Executing `rsconnect test` will now respond with `Error: No such command "test".`
- [ ] The `rsconnect details` command no longer requires `-k`/`--api-key`.  The command will now always show the effective URL when it refers to Connect.  If an API key is not provided, no other output is produced.  If an API key is provided, the Connect, Python and Conda information are also shown.