### PR TITLE
Make sure we're generating good titles.

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -240,12 +240,15 @@ def make_deployment_name():
 
 def default_title(file_name):
     """
-    Produce a default content title from the given file path.
+    Produce a default content title from the given file path.  The result is
+    guaranteed to be between 3 and 1024 characters long, as required by RStudio
+    Connect.
 
     :param file_name: the name from which the title will be derived.
     :return: the derived title.
     """
-    return basename(file_name).rsplit('.')[0]
+    # noinspection PyTypeChecker
+    return basename(file_name).rsplit('.', 1)[0][:1024].rjust(3, '0')
 
 
 def deploy_jupyter_notebook(connect_server, file_name, extra_files, new=False, app_id=None, title=None, static=False,

--- a/rsconnect/tests/test_actions.py
+++ b/rsconnect/tests/test_actions.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from rsconnect.actions import default_title
+
+
+class TestActions(TestCase):
+    def test_default_title(self):
+        self.assertEqual(default_title('testing.txt'), 'testing')
+        self.assertEqual(default_title('this.is.a.test.ext'), 'this.is.a.test')
+        self.assertEqual(default_title('1.ext'), '001')
+        self.assertEqual(default_title('%s.ext' % ('n' * 2048)), 'n' * 1024)


### PR DESCRIPTION
## Description

This change updates how we generate titles for a deployment so that they are guaranteed to be acceptable to Connect.  Prior to this, we could generate titles that were too short or too long.

Connected to https://github.com/rstudio/connect/issues/16501

### Testing Notes / Validation Steps

Title generation is fully covered by unit tests so CI passing should be sufficient.

To test manually,

- [ ] Deploy a notebook with a name like `05.01-What-Is-Machine-Learning.ipynb`.  Prior to this change, the title was taken from the name up to the first period.  Now, the title is taken from the full name without the extension.
- [ ] Deploy a notebook with a name like `1.ipynb`.  Prior to this change, the title would be `1` which is too short.  Now, such names are padded to the left with zeros.  So, the title will be `001`.
- [ ] Deploy a notebook with a name that, without the extension, is more than 1024 characters long. Prior to the change, this would fail.  Now, the title will be that name, truncated to 1024 characters.