### PR TITLE
Jsk productize info write manifest

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -15,7 +15,8 @@ from rsconnect import api
 from .bundle import make_notebook_html_bundle, make_notebook_source_bundle, make_manifest_bundle, read_manifest_file, \
     make_source_manifest, manifest_add_file, manifest_add_buffer
 from .environment import EnvironmentException
-from .metadata import AppStore, AppModes
+from .metadata import AppStore
+from .models import AppModes
 
 import click
 from six.moves.urllib_parse import urlparse

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -3,7 +3,7 @@ import time
 from _ssl import SSLError
 
 from rsconnect.http_support import HTTPResponse, HTTPServer, append_to_path
-from rsconnect.metadata import AppModes
+from rsconnect.models import AppModes
 
 
 class RSConnectException(Exception):

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -3,6 +3,7 @@ import time
 from _ssl import SSLError
 
 from rsconnect.http_support import HTTPResponse, HTTPServer, append_to_path
+from rsconnect.metadata import AppModes
 
 
 class RSConnectException(Exception):
@@ -277,35 +278,12 @@ def emit_task_log(connect_server, app_id, task_id, log_callback, timeout=None):
         return result
 
 
-(
-    UnknownMode,
-    ShinyMode,
-    ShinyRmdMode,
-    StaticRmdMode,
-    StaticMode,
-    APIMode,
-    TensorFlowModelAPI,
-    StaticJupyterMode,
-) = range(8)
-
-app_modes = {
-    UnknownMode: 'unknown',
-    ShinyMode: 'shiny',
-    ShinyRmdMode: 'rmd-shiny',
-    StaticRmdMode: 'rmd-static',
-    StaticMode: 'static',
-    APIMode: 'api',
-    TensorFlowModelAPI: 'tensorflow-saved-model',
-    StaticJupyterMode: 'jupyter-static',
-}
-
-
 def app_data(api, app):
     return {
         'id': app['id'],
         'name': app['name'],
         'title': app['title'],
-        'app_mode': app_modes.get(app['app_mode']),
+        'app_mode': AppModes.get_by_ordinal(app['app_mode']),
         'config_url': api.app_config(app['id'])['config_url'],
     }
 
@@ -321,7 +299,7 @@ def app_search(connect_server, app_id, app_title):
         found = False
 
         for app in apps or []:
-            if app['app_mode'] in (StaticMode, StaticJupyterMode):
+            if app['app_mode'] in (AppModes.STATIC.ordinal(), AppModes.JUPYTER_NOTEBOOK.ordinal()):
                 data.append(app_data(server, app))
                 if app['id'] == app_id:
                     found = True
@@ -330,7 +308,7 @@ def app_search(connect_server, app_id, app_title):
             try:
                 # offer the current location as an option
                 app = server.app_get(app_id)
-                if app['app_mode'] in (StaticMode, StaticJupyterMode):
+                if app['app_mode'] in (AppModes.STATIC.ordinal(), AppModes.JUPYTER_NOTEBOOK.ordinal()):
                     data.append(app_data(server, app))
             except RSConnectException:
                 logger.exception('Error getting info for previous app_id "%s", skipping', app_id)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -12,7 +12,8 @@ from rsconnect.actions import set_verbosity, cli_feedback, test_server, test_api
     spool_deployment_log, gather_basic_deployment_info_from_manifest, write_manifest_json, write_environment_file
 from . import api
 from .bundle import make_manifest_bundle
-from .metadata import ServerStore, AppStore, AppModes
+from .metadata import ServerStore, AppStore
+from .models import AppModes
 
 server_store = ServerStore()
 logging.basicConfig()

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -8,6 +8,7 @@ import sys
 from os.path import abspath, basename, dirname, exists, join
 
 from rsconnect import api
+from rsconnect.models import AppMode, AppModes
 
 logger = logging.getLogger('rsconnect')
 
@@ -407,64 +408,3 @@ class AppStore(DataStore):
         # app mode cannot be changed on redeployment
         app_mode = AppModes.get_by_name(metadata.get('app_mode'))
         return app_id, title, app_mode
-
-
-class AppMode(object):
-    def __init__(self, ordinal, symbol, text, ext=None):
-        self._ordinal = ordinal
-        self._symbol = symbol
-        self._text = text
-        self._ext = ext
-
-    def ordinal(self):
-        return self._ordinal
-
-    def name(self):
-        return self._symbol
-
-    def desc(self):
-        return self._text
-
-    def extension(self):
-        return self._ext
-
-    def __str__(self):
-        return self.name()
-
-    def __repr__(self):
-        return self.desc()
-
-
-class AppModes(object):
-    UNKNOWN = AppMode(0, 'unknown', '<unknown>')
-    SHINY = AppMode(1, 'shiny', 'Shiny App', '.R')
-    RMD = AppMode(3, 'rmd-static', 'R Markdown', '.Rmd')
-    SHINY_RMD = AppMode(2, 'rmd-shiny', 'Shiny App (Rmd)')
-    STATIC = AppMode(4, 'static', 'Static HTML', '.html')
-    API = AppMode(5, 'api', 'API')
-    TENSORFLOW = AppMode(6, 'tensorflow-saved-model', 'TensorFlow Model')
-    JUPYTER_NOTEBOOK = AppMode(7, 'jupyter-static', 'Jupyter Notebook', '.ipynb')
-
-    _modes = [UNKNOWN, SHINY, RMD, SHINY_RMD, STATIC, API, TENSORFLOW, JUPYTER_NOTEBOOK]
-
-    @classmethod
-    def get_by_ordinal(cls, ordinal, return_unknown=False):
-        return cls._find_by(lambda mode: mode.ordinal() == ordinal, 'with ordinal %d' % ordinal, return_unknown)
-
-    @classmethod
-    def get_by_name(cls, name, return_unknown=False):
-        return cls._find_by(lambda mode: mode.name() == name, 'named %s' % name, return_unknown)
-
-    @classmethod
-    def get_by_extension(cls, extension, return_unknown=False):
-        return cls._find_by(lambda mode: mode.extension() == extension, 'with extension: %s' % extension,
-                            return_unknown)
-
-    @classmethod
-    def _find_by(cls, predicate, message, return_unknown):
-        for mode in cls._modes:
-            if predicate(mode):
-                return mode
-        if return_unknown:
-            return cls.UNKNOWN
-        raise ValueError('No app mode %s' % message)

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -385,7 +385,7 @@ class AppStore(DataStore):
             app_id=app_id,
             app_guid=app_guid,
             title=title,
-            app_mode=app_mode,
+            app_mode=app_mode.name() if isinstance(app_mode, AppMode) else app_mode,
         ))
 
     def resolve(self, server, app_id, title, app_mode):
@@ -405,5 +405,66 @@ class AppStore(DataStore):
             logger.debug('Using saved title: "%s"' % title)
 
         # app mode cannot be changed on redeployment
-        app_mode = metadata.get('app_mode')
+        app_mode = AppModes.get_by_name(metadata.get('app_mode'))
         return app_id, title, app_mode
+
+
+class AppMode(object):
+    def __init__(self, ordinal, symbol, text, ext=None):
+        self._ordinal = ordinal
+        self._symbol = symbol
+        self._text = text
+        self._ext = ext
+
+    def ordinal(self):
+        return self._ordinal
+
+    def name(self):
+        return self._symbol
+
+    def desc(self):
+        return self._text
+
+    def extension(self):
+        return self._ext
+
+    def __str__(self):
+        return self.name()
+
+    def __repr__(self):
+        return self.desc()
+
+
+class AppModes(object):
+    UNKNOWN = AppMode(0, 'unknown', '<unknown>')
+    SHINY = AppMode(1, 'shiny', 'Shiny App', '.R')
+    RMD = AppMode(3, 'rmd-static', 'R Markdown', '.Rmd')
+    SHINY_RMD = AppMode(2, 'rmd-shiny', 'Shiny App (Rmd)')
+    STATIC = AppMode(4, 'static', 'Static HTML', '.html')
+    API = AppMode(5, 'api', 'API')
+    TENSORFLOW = AppMode(6, 'tensorflow-saved-model', 'TensorFlow Model')
+    JUPYTER_NOTEBOOK = AppMode(7, 'jupyter-static', 'Jupyter Notebook', '.ipynb')
+
+    _modes = [UNKNOWN, SHINY, RMD, SHINY_RMD, STATIC, API, TENSORFLOW, JUPYTER_NOTEBOOK]
+
+    @classmethod
+    def get_by_ordinal(cls, ordinal, return_unknown=False):
+        return cls._find_by(lambda mode: mode.ordinal() == ordinal, 'with ordinal %d' % ordinal, return_unknown)
+
+    @classmethod
+    def get_by_name(cls, name, return_unknown=False):
+        return cls._find_by(lambda mode: mode.name() == name, 'named %s' % name, return_unknown)
+
+    @classmethod
+    def get_by_extension(cls, extension, return_unknown=False):
+        return cls._find_by(lambda mode: mode.extension() == extension, 'with extension: %s' % extension,
+                            return_unknown)
+
+    @classmethod
+    def _find_by(cls, predicate, message, return_unknown):
+        for mode in cls._modes:
+            if predicate(mode):
+                return mode
+        if return_unknown:
+            return cls.UNKNOWN
+        raise ValueError('No app mode %s' % message)

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -1,0 +1,64 @@
+"""
+This file defines some support data models.
+"""
+
+
+class AppMode(object):
+    def __init__(self, ordinal, symbol, text, ext=None):
+        self._ordinal = ordinal
+        self._symbol = symbol
+        self._text = text
+        self._ext = ext
+
+    def ordinal(self):
+        return self._ordinal
+
+    def name(self):
+        return self._symbol
+
+    def desc(self):
+        return self._text
+
+    def extension(self):
+        return self._ext
+
+    def __str__(self):
+        return self.name()
+
+    def __repr__(self):
+        return self.desc()
+
+
+class AppModes(object):
+    UNKNOWN = AppMode(0, 'unknown', '<unknown>')
+    SHINY = AppMode(1, 'shiny', 'Shiny App', '.R')
+    RMD = AppMode(3, 'rmd-static', 'R Markdown', '.Rmd')
+    SHINY_RMD = AppMode(2, 'rmd-shiny', 'Shiny App (Rmd)')
+    STATIC = AppMode(4, 'static', 'Static HTML', '.html')
+    API = AppMode(5, 'api', 'API')
+    TENSORFLOW = AppMode(6, 'tensorflow-saved-model', 'TensorFlow Model')
+    JUPYTER_NOTEBOOK = AppMode(7, 'jupyter-static', 'Jupyter Notebook', '.ipynb')
+
+    _modes = [UNKNOWN, SHINY, RMD, SHINY_RMD, STATIC, API, TENSORFLOW, JUPYTER_NOTEBOOK]
+
+    @classmethod
+    def get_by_ordinal(cls, ordinal, return_unknown=False):
+        return cls._find_by(lambda mode: mode.ordinal() == ordinal, 'with ordinal %d' % ordinal, return_unknown)
+
+    @classmethod
+    def get_by_name(cls, name, return_unknown=False):
+        return cls._find_by(lambda mode: mode.name() == name, 'named %s' % name, return_unknown)
+
+    @classmethod
+    def get_by_extension(cls, extension, return_unknown=False):
+        return cls._find_by(lambda mode: mode.extension() == extension, 'with extension: %s' % extension,
+                            return_unknown)
+
+    @classmethod
+    def _find_by(cls, predicate, message, return_unknown):
+        for mode in cls._modes:
+            if predicate(mode):
+                return mode
+        if return_unknown:
+            return cls.UNKNOWN
+        raise ValueError('No app mode %s' % message)


### PR DESCRIPTION
### Description

This change provides polish to the `info` and `write-manifest` commands.  All commands now have both short and long help text.  See the testing notes below for more detail.

Some refactoring around app mode has been done; smoke testing areas that involve an app mode (`deploy notebook`, `deploy manifest` and `info` commands) should be performed.

Connected to https://github.com/rstudio/connect/issues/16555

### Testing Notes / Validation Steps

- [ ] Smoke testing all commands should show no problems.  All argument combinations should still be handled correctly and all commands should still function correctly.
- [ ] All help for the `info` and `write-manifest` commands has been updated to have both a short and long form of help.  This eliminates all the ellipsis stuff on the one line help for the parent command and also provides more detailed help for each command.  This should all be proofread.
- [ ] The 'rsconnect write-manifest --help` command should produce clear and complete help.
- [ ] The `rsconnect info --help` command should produce clear and complete help.
- [ ] The `rsconnect write-manifest` command should still work and produce sensible looking output, even for error conditions.
- [ ] The `rsconnect info` command should still work and produce sensible looking output, even for error conditions.
- [ ] There are now high-level manifest deploy functions in `actions.py`.
- [ ] Docstrings have been provided on functions affected by this change.