### PR TITLE
Unit tests for app mode stuff. Help fix. Info fix.

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -217,7 +217,7 @@ def info(file):
                 click.echo('App GUID:   %s' % deployment.get('app_guid'))
                 click.echo('Title:      "%s"' % deployment.get('title'))
                 click.echo('Filename:   %s' % deployment.get('filename'))
-                click.echo('Type:       %s' % AppModes.get_by_name(deployment.get('app_mode'), True)).desc()
+                click.echo('Type:       %s' % AppModes.get_by_name(deployment.get('app_mode'), True).desc())
         else:
             click.echo('No saved deployment information was found for %s.' % file)
 
@@ -438,8 +438,7 @@ def write_manifest():
               help='Path to python interpreter whose environment should be used. ' +
                    'The python environment must have the rsconnect package installed.')
 @click.option('--conda', '-C', is_flag=True,
-              help='Force freezing the current environment using pip instead of conda, when conda is not supported on '
-                   'RStudio Connect (version<=1.8.0).')
+              help='Use conda to deploy (unsupported for versions <=1.8.0)')
 @click.option('--force-generate', '-g', is_flag=True,
               help='Force generating "requirements.txt" or "environment.yml", even if it already exists.')
 @click.option('--verbose', '-v', 'verbose', is_flag=True, help='Print detailed messages')

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -291,7 +291,7 @@ def _validate_deploy_to_args(name, url, api_key, insecure, ca_cert, api_key_is_r
               help='Path to python interpreter whose environment should be used. '
                    'The python environment must have the rsconnect package installed.')
 @click.option('--conda', '-C', is_flag=True,
-              help='Use conda to deploy (unsupported for versions <=1.8.0)')
+              help='Use conda to deploy (requires Connect version 1.8.2 or later)')
 @click.option('--force-generate', '-g', is_flag=True,
               help='Force generating "requirements.txt" or "environment.yml", even if it already exists.')
 @click.option('--insecure', '-i', envvar='CONNECT_INSECURE', is_flag=True,
@@ -438,7 +438,7 @@ def write_manifest():
               help='Path to python interpreter whose environment should be used. ' +
                    'The python environment must have the rsconnect package installed.')
 @click.option('--conda', '-C', is_flag=True,
-              help='Use conda to deploy (unsupported for versions <=1.8.0)')
+              help='Use conda to deploy (requires Connect version 1.8.2 or later)')
 @click.option('--force-generate', '-g', is_flag=True,
               help='Force generating "requirements.txt" or "environment.yml", even if it already exists.')
 @click.option('--verbose', '-v', 'verbose', is_flag=True, help='Print detailed messages')

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -4,9 +4,9 @@ This file defines some support data models.
 
 
 class AppMode(object):
-    def __init__(self, ordinal, symbol, text, ext=None):
+    def __init__(self, ordinal, name, text, ext=None):
         self._ordinal = ordinal
-        self._symbol = symbol
+        self._name = name
         self._text = text
         self._ext = ext
 
@@ -14,7 +14,7 @@ class AppMode(object):
         return self._ordinal
 
     def name(self):
-        return self._symbol
+        return self._name
 
     def desc(self):
         return self._text
@@ -43,7 +43,7 @@ class AppModes(object):
 
     @classmethod
     def get_by_ordinal(cls, ordinal, return_unknown=False):
-        return cls._find_by(lambda mode: mode.ordinal() == ordinal, 'with ordinal %d' % ordinal, return_unknown)
+        return cls._find_by(lambda mode: mode.ordinal() == ordinal, 'with ordinal %s' % ordinal, return_unknown)
 
     @classmethod
     def get_by_name(cls, name, return_unknown=False):
@@ -51,6 +51,12 @@ class AppModes(object):
 
     @classmethod
     def get_by_extension(cls, extension, return_unknown=False):
+        # We can't allow a lookup by None since some modes have that for an extension.
+        if extension is None:
+            if return_unknown:
+                return cls.UNKNOWN
+            raise ValueError('No app mode with extension %s' % extension)
+
         return cls._find_by(lambda mode: mode.extension() == extension, 'with extension: %s' % extension,
                             return_unknown)
 

--- a/rsconnect/tests/test_models.py
+++ b/rsconnect/tests/test_models.py
@@ -1,4 +1,3 @@
-import re
 from unittest import TestCase
 
 from rsconnect.models import AppMode, AppModes

--- a/rsconnect/tests/test_models.py
+++ b/rsconnect/tests/test_models.py
@@ -1,0 +1,85 @@
+import re
+from unittest import TestCase
+
+from rsconnect.models import AppMode, AppModes
+
+
+class TestModels(TestCase):
+    def test_app_mode_class(self):
+        mode = AppMode(1, 'test', 'Testing')
+
+        self.assertEqual(mode.ordinal(), 1)
+        self.assertEqual(mode.name(), 'test')
+        self.assertEqual(mode.desc(), 'Testing')
+        self.assertIsNone(mode.extension())
+        self.assertEqual(mode.name(), str(mode))
+        self.assertEqual(mode.desc(), repr(mode))
+
+        mode = AppMode(2, 'test-2', 'Testing (again)', '.ipynb')
+
+        self.assertEqual(mode.ordinal(), 2)
+        self.assertEqual(mode.name(), 'test-2')
+        self.assertEqual(mode.desc(), 'Testing (again)')
+        self.assertEqual(mode.extension(), '.ipynb')
+
+    def test_app_modes_constants(self):
+        defined = list(filter(lambda n: n.isupper(), AppModes.__dict__.keys()))
+        modes = list(AppModes._modes)
+        ordinals = []
+        names = []
+        descriptions = []
+        extensions = []
+
+        self.assertEqual(len(defined), 8)
+        self.assertEqual(len(modes), 8)
+
+        # This makes sure all named mode constants appear in the modes list.
+        for name in defined:
+            named_mode = AppModes.__dict__.get(name)
+            self.assertIn(named_mode, modes)
+
+        # The stuff here makes sure that each mode defined in the modes list is unique.
+        for mode in modes:
+            self.assertNotIn(mode.ordinal(), ordinals)
+            ordinals.append(mode.ordinal())
+            self.assertNotIn(mode.name(), names)
+            ordinals.append(mode.name())
+            self.assertNotIn(mode.desc(), descriptions)
+            ordinals.append(mode.desc())
+
+            if mode.extension() is not None:
+                self.assertNotIn(mode.extension(), extensions)
+                ordinals.append(mode.extension())
+
+    def test_get_by_ordinal(self):
+        self.assertIs(AppModes.get_by_ordinal(1), AppModes.SHINY)
+        self.assertIs(AppModes.get_by_ordinal(-1, True), AppModes.UNKNOWN)
+        self.assertIs(AppModes.get_by_ordinal(None, True), AppModes.UNKNOWN)
+
+        with self.assertRaises(ValueError):
+            AppModes.get_by_ordinal(-1)
+
+        with self.assertRaises(ValueError):
+            AppModes.get_by_ordinal(None)
+
+    def test_get_by_name(self):
+        self.assertIs(AppModes.get_by_name('shiny'), AppModes.SHINY)
+        self.assertIs(AppModes.get_by_name('bad-name', True), AppModes.UNKNOWN)
+        self.assertIs(AppModes.get_by_name(None, True), AppModes.UNKNOWN)
+
+        with self.assertRaises(ValueError):
+            AppModes.get_by_name('bad-name')
+
+        with self.assertRaises(ValueError):
+            AppModes.get_by_name(None)
+
+    def test_get_by_extension(self):
+        self.assertIs(AppModes.get_by_extension('.R'), AppModes.SHINY)
+        self.assertIs(AppModes.get_by_extension('.bad-ext', True), AppModes.UNKNOWN)
+        self.assertIs(AppModes.get_by_extension(None, True), AppModes.UNKNOWN)
+
+        with self.assertRaises(ValueError):
+            AppModes.get_by_extension('.bad-ext')
+
+        with self.assertRaises(ValueError):
+            AppModes.get_by_extension(None)


### PR DESCRIPTION
### Description

This change does 3 things:

- Fixes https://github.com/rstudio/connect/issues/16555#issuecomment-586445528
- Fixes https://github.com/rstudio/connect/issues/16555#issuecomment-586421892
- Adds unit tests that cover the data models supporting app modes.

Connected to https://github.com/rstudio/connect/issues/16555
Connected to https://github.com/rstudio/connect/issues/16574

### Testing Notes / Validation Steps

- [ ] `rsconnect info` should now work (see https://github.com/rstudio/connect/issues/16555#issuecomment-586421892)
- [ ] Both places where `--conda`/`-C` options are present should now show the same (correct) help for the option.
- [ ] CI passes (covers the new unit tests)