### PR TITLE
Deal with no default locale in a reasonable way.

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -85,7 +85,8 @@ def get_conda_version(conda):
 
 
 def get_default_locale():
-    return '.'.join(locale.getdefaultlocale())
+    result = '.'.join([item or '' for item in locale.getdefaultlocale()])
+    return '' if result == '.' else result
 
 
 def get_version(module):


### PR DESCRIPTION
### Description

This change updates our environment scanning to properly cope with systems for which there is no default locale.  In this case, `locale.getdefaultlocale()` reports `(None, None)` which then causes the string `join` we do to except.  Now, if either part is missing, it is replaced with an empty string, which will have the separating period either as a prefix or a suffix, depending no which is missing.  If both parts are missing, we report a simple empty string, no period at all.

Connected to https://github.com/rstudio/connect/issues/16573

### Testing Notes / Validation Steps

- [ ] Running `environment.py` on a system with no default locale will no longer produce a traceback but an actual value as described above.  Our dev docker images (like `denial` may be used as they contain an installed Python but do not have a locale.