### PR TITLE
Correct handling of user-specified titles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ by this package.
 
 A command-line deployment tool is also provided that can be used directly to deploy
 Jupyter notebooks. Other content types can be deployed if they include a prepared
-`manifest.json` file. See ["Creating a Manifest for Future Deployment"](#creating-a-manifest-for-future-deployment)
+`manifest.json` file. See ["Deploying R or Other Content"](#deploying-r-or-other-content)
 for details.
 
 ## Deploying Python Content to RStudio Connect

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -337,7 +337,6 @@ def gather_basic_deployment_info_for_notebook(connect_server, app_store, file_na
     :return: the app ID, name, title and mode for the deployment.
     """
     deployment_name = make_deployment_name()
-    deployment_title = title or default_title(file_name)
 
     if app_id is not None:
         # Don't read app metadata if app-id is specified. Instead, we need
@@ -359,7 +358,7 @@ def gather_basic_deployment_info_for_notebook(connect_server, app_store, file_na
             raise api.RSConnectException('Cannot change app mode to "static" once deployed. '
                                          'Use --new to create a new deployment.')
 
-    return app_id, deployment_name, deployment_title, app_mode
+    return app_id, deployment_name, title or default_title(file_name), app_mode
 
 
 def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_name, new, app_id, title):
@@ -377,7 +376,6 @@ def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_n
     """
     source_manifest, _ = read_manifest_file(file_name)
     deployment_name = make_deployment_name()
-    deployment_title = title or default_title_from_manifest(source_manifest)
     # noinspection SpellCheckingInspection
     app_mode = AppModes.get_by_name(source_manifest['metadata']['appmode'])
 
@@ -386,7 +384,7 @@ def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_n
         # Use the saved app information unless overridden by the user.
         app_id, title, app_mode = app_store.resolve(connect_server.url, app_id, title, app_mode)
 
-    return app_id, deployment_name, deployment_title, app_mode
+    return app_id, deployment_name, title or default_title_from_manifest(source_manifest), app_mode
 
 
 def get_python_env_info(file_name, python, compatibility_mode, force_generate):

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -270,6 +270,12 @@ def _validate_deploy_to_args(name, url, api_key, insecure, ca_cert, api_key_is_r
     return connect_server
 
 
+def _validate_title(title):
+    if title:
+        if not (3 <= len(title) <= 1024):
+            raise api.RSConnectException('A title must be between 3-1024 characters long.')
+
+
 # noinspection SpellCheckingInspection,DuplicatedCode
 @deploy.command(name='notebook', short_help='Deploy Jupyter notebook to RStudio Connect.',
                 help='Deploy a Jupyter notebook to RStudio Connect. This may be done by source or as a static HTML '
@@ -312,6 +318,8 @@ def deploy_notebook(name, server, api_key, static, new, app_id, title, python, c
 
         if new and app_id:
             raise api.RSConnectException('Specify either --new/-N or --app-id/-a but not both.')
+
+        _validate_title(title)
 
         file_suffix = splitext(file)[1].lower()
         if file_suffix != '.ipynb':
@@ -379,6 +387,8 @@ def deploy_manifest(name, server, api_key, new, app_id, title, insecure, cacert,
 
         if new and app_id:
             raise api.RSConnectException('Specify either --new/-N or --app-id/-a but not both.')
+
+        _validate_title(title)
 
         if basename(file) != 'manifest.json':
             raise api.RSConnectException('The deploy manifest command requires an existing manifest.json file to be '


### PR DESCRIPTION
### Description

This change adds validation to the value a user specifies for the `--title`/`-t` option.  Prior to the change, the length constraints Connect imposes on the title would not be verified until the actual deployment.  This also fixes a bug where the title might not end up being what the user expects.

Connected to https://github.com/rstudio/connect/issues/16501#issuecomment-587535979

### Testing Notes / Validation Steps

- [ ] The required length for a title will now be enforced when specified on the `--title` option.
- [ ] If `--title` is specified, it will now correctly override any previous title on redeploys.