### PR TITLE
Catch SSL cert errors also.

### DIFF
--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -213,8 +213,8 @@ class HTTPServer(object):
             self._handle_set_cookie(response)
 
             return self._tweak_response(HTTPResponse(full_uri, response=response, body=response_body))
-        except (http.HTTPException, IOError, OSError, socket.error, socket.herror, socket.gaierror,
-                socket.timeout) as exception:
+        except (http.HTTPException, ssl.CertificateError, IOError, OSError, socket.error, socket.herror,
+                socket.gaierror, socket.timeout) as exception:
             logger.debug('An exception occurred processing the HTTP request.', exc_info=True)
             return HTTPResponse(full_uri, exception=exception)
 


### PR DESCRIPTION
### Description

This change includes catching of `CertificateError` exceptions.  Prior to this, such exceptions would be raised when running under Python 2.x and using self-signed certs for SSL.  This produced a full traceback whereas the same condition under 3.x would produce a simple error message.  We now produce a simple error message rather than the traceback, even for Python 2.x.

Connected to https://github.com/rstudio/connect/issues/16440

### Testing Notes / Validation Steps

See https://github.com/rstudio/connect/issues/16440#issuecomment-587987569

- [ ] A simple message should now be produced under either Python 2.x or 3.x.  Note that the actual message will still be different; the key is that we no longer produce the traceback.