### PR TITLE
Detect no conda and refuse to deploy conda content when detected

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -312,7 +312,7 @@ def deploy_by_manifest(connect_server, manifest_file_name, new=False, app_id=Non
     of log lines.  The log lines value will be None if a log callback was provided.
     """
     app_store = AppStore(manifest_file_name)
-    app_id, deployment_name, deployment_title, app_mode = \
+    app_id, deployment_name, deployment_title, app_mode, package_manager = \
         gather_basic_deployment_info_from_manifest(connect_server, app_store, manifest_file_name, new, app_id, title)
     bundle = make_manifest_bundle(manifest_file_name)
     app = deploy_bundle(connect_server, app_id, deployment_name, deployment_title, bundle)
@@ -372,7 +372,7 @@ def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_n
     :param app_id: the ID of the app to redeploy.
     :param title: an optional title.  If this isn't specified, a default title will
     be generated.
-    :return: the app ID, name, title and mode for the deployment.
+    :return: the app ID, name, title, mode, and package manager for the deployment.
     """
     source_manifest, _ = read_manifest_file(file_name)
     deployment_name = make_deployment_name()
@@ -384,7 +384,9 @@ def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_n
         # Use the saved app information unless overridden by the user.
         app_id, title, app_mode = app_store.resolve(connect_server.url, app_id, title, app_mode)
 
-    return app_id, deployment_name, title or default_title_from_manifest(source_manifest), app_mode
+    package_manager = source_manifest.get('python', {}).get('package_manager', {}).get('name', None)
+
+    return app_id, deployment_name, title or default_title_from_manifest(source_manifest), app_mode, package_manager
 
 
 def get_python_env_info(file_name, python, compatibility_mode, force_generate):
@@ -411,6 +413,17 @@ def get_python_env_info(file_name, python, compatibility_mode, force_generate):
     logger.debug('Environment: %s' % pformat(environment))
 
     return python, environment
+
+
+def is_conda_supported_on_server(connect_server):
+    """
+    Returns True when conda is supported on a target server and False otherwise
+    Makes network calls.
+    :param connect_server: Connect server URL as passed to gather_server_details
+    :return: boolean True if supported, False otherwise
+    """
+    details = gather_server_details(connect_server)
+    return details.get('conda', {}).get('supported', False)
 
 
 def create_notebook_deployment_bundle(file_name, extra_files, app_mode, python, environment):

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -340,8 +340,7 @@ def deploy_notebook(name, server, api_key, static, new, app_id, title, python, c
 
     if conda:
         with cli_feedback('Ensuring conda is supported'):
-            if not is_conda_supported_on_server(connect_server.url):
-                conda = False
+            if not is_conda_supported_on_server(connect_server):
                 raise api.RSConnectException('Conda is not supported on the target server. Please try deploying '
                                              'again without conda enabled (remove the --conda/-C flag).')
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -7,9 +7,10 @@ import click
 from six import text_type
 
 from rsconnect import VERSION
-from rsconnect.actions import set_verbosity, cli_feedback, test_server, test_api_key, gather_server_details,\
-    gather_basic_deployment_info_for_notebook, get_python_env_info, create_notebook_deployment_bundle, deploy_bundle,\
-    spool_deployment_log, gather_basic_deployment_info_from_manifest, write_manifest_json, write_environment_file
+from rsconnect.actions import set_verbosity, cli_feedback, test_server, test_api_key, gather_server_details, \
+    gather_basic_deployment_info_for_notebook, get_python_env_info, create_notebook_deployment_bundle, deploy_bundle, \
+    spool_deployment_log, gather_basic_deployment_info_from_manifest, write_manifest_json, write_environment_file, \
+    is_conda_supported_on_server
 from . import api
 from .bundle import make_manifest_bundle
 from .metadata import ServerStore, AppStore
@@ -337,6 +338,13 @@ def deploy_notebook(name, server, api_key, static, new, app_id, title, python, c
 
     click.secho('    Deploying %s to server "%s"' % (file, connect_server.url), fg='white')
 
+    if conda:
+        with cli_feedback('Ensuring conda is supported'):
+            if not is_conda_supported_on_server(connect_server.url):
+                conda = False
+                raise api.RSConnectException('Conda is not supported on the target server. Please try deploying '
+                                             'again without conda enabled (remove the --conda/-C flag).')
+
     with cli_feedback('Inspecting python environment'):
         python, environment = get_python_env_info(file, python, not conda, force_generate)
 
@@ -394,10 +402,16 @@ def deploy_manifest(name, server, api_key, new, app_id, title, insecure, cacert,
             raise api.RSConnectException('The deploy manifest command requires an existing manifest.json file to be '
                                          'provided on the command line.')
 
-        app_id, deployment_name, title, app_mode = \
+        app_id, deployment_name, title, app_mode, package_manager = \
             gather_basic_deployment_info_from_manifest(connect_server, app_store, file, new, app_id, title)
 
     click.secho('    Deploying %s to server "%s"' % (file, connect_server.url), fg='white')
+
+    if package_manager == 'conda':
+        with cli_feedback('Ensuring conda is supported'):
+            if not is_conda_supported_on_server(connect_server):
+                raise api.RSConnectException('Conda is not supported on the target server. Please try creating this '
+                                             'manifest again without conda enabled (no --conda/-C flag).')
 
     with cli_feedback('Creating deployment bundle'):
         bundle = make_manifest_bundle(file)


### PR DESCRIPTION
- Checks the server information before deployment of a notebook or manifest and bails if there's a mismatch between what the user or manifest asks for and the server's capabilities.