### PR TITLE
Preliminary work on testing with a mock Connect.

### DIFF
--- a/mock_connect/mock_connect/data.py
+++ b/mock_connect/mock_connect/data.py
@@ -12,6 +12,7 @@ from enum import Enum
 from json import JSONDecodeError
 from os import environ
 from os.path import isfile
+from typing import Union
 
 
 def timestamp():
@@ -43,7 +44,7 @@ class DBObject(object):
         return new_id
 
     @classmethod
-    def get_object(cls, db_id: int):
+    def get_object(cls, db_id: Union[int, str]):
         name = cls.__name__
         if name in cls.instances and db_id in cls.instances[name]:
             return cls.instances[name][db_id]
@@ -78,6 +79,8 @@ class DBObject(object):
         if name not in cls.instances:
             cls.instances[name] = {}
         cls.instances[name][instance.id] = instance
+        if 'guid' in instance.attrs:
+            cls.instances[name][instance.guid] = instance
 
     @classmethod
     def get_table_headers(cls):

--- a/mock_connect/mock_connect/http_helpers.py
+++ b/mock_connect/mock_connect/http_helpers.py
@@ -1,6 +1,7 @@
 """
 This provides some low-level things to make our HTTP life easier.
 """
+import re
 from functools import wraps
 
 from typing import Dict, List
@@ -9,6 +10,8 @@ from typing import Dict, List
 from flask import abort, after_this_request, g, jsonify, request
 
 from .data import DBObject, User
+
+digits = re.compile(r'\d+')
 
 
 def error(code, reason):
@@ -58,7 +61,9 @@ def endpoint(authenticated: bool = False, auth_optional: bool = False, cls=None,
             if cls is None:
                 result = _make_json_ready(function(*args, **kwargs))
             else:
-                item = cls.get_object(int(object_id))
+                if digits.match(object_id):
+                    object_id = int(object_id)
+                item = cls.get_object(object_id)
                 if item is None:
                     result = error(404, '%s with ID %s not found.' % (cls.__name__, object_id))
                 else:

--- a/mock_connect/mock_connect/http_helpers.py
+++ b/mock_connect/mock_connect/http_helpers.py
@@ -11,7 +11,7 @@ from flask import abort, after_this_request, g, jsonify, request
 
 from .data import DBObject, User
 
-digits = re.compile(r'\d+')
+digits = re.compile(r'^\d+$')
 
 
 def error(code, reason):

--- a/mock_connect/mock_connect/main.py
+++ b/mock_connect/mock_connect/main.py
@@ -1,9 +1,9 @@
 """
 This is the main file, run via `flask run`, for the mock Connect server.
 """
-# noinspection PyPackageRequirements
 import sys
 
+# noinspection PyPackageRequirements
 from flask import Flask, Blueprint, g, request, url_for
 
 from .data import Application, AppMode, Bundle, Task, get_data_dump, default_server_settings


### PR DESCRIPTION
### Description

This change is the first step in running tests against a mock Connect during CI.  This boils down to the need to correct how applications are retrieved.  Prior to this change, an app could only be looked up by its numeric ID.  Once an app has been created, the `rsconnect` library prefers using the UUID.  The mock Connect now correctly supports retrieving an app by either its ID or UUID.

A new (simplistic) target, `mock-test-%`, has been added to the top level `Makefile` which spins up the mock Connect server, runs the full set of tests with appropriate env vars set and then brings down the mock server.  This target is scaffolding while we work out what we really want here.

Connected to https://github.com/rstudio/connect/issues/16313

### Testing Notes / Validation Steps

This work is somewhat preliminary to see if we like the direction.  The main goal is to make sure the mock server correctly supports the current set of tests.

-  [ ] `make mock-test-2.7` should successfully run all current unit tests without skipping any.  Any supported Python version should also work; i.e., `mock-test-3.7`, etc.

> **Important:** There is currently a disconnect between the storage files the `rsconnect` library writes to remember deployment information about a deployed notebook or manifest which prevents a `mock-test-%` target from being run more than once successfully (mostly because when the mock Connect is started, it has no memory of what's in the deployment storage files).  Because of this, those storage files are deleted as the first step of the new `mock-test-%` `make` target.  This will affect your manual testing so be aware.