### PR TITLE
Check for Python API availability instead of by version.

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -215,20 +215,24 @@ def gather_server_details(connect_server):
     }
     return {
         'connect': server_settings['version'],
-        'python': python_versions,
+        'python': {
+            'api_enabled': python_settings['api_enabled'] if 'api_enabled' in python_settings else False,
+            'versions': python_versions
+        },
         'conda': conda_settings
     }
 
 
-def is_version_1_8_2_or_higher(connect_details):
+def are_apis_supported_on_server(connect_details):
     """
-    Returns whether or not the Connect server is at least 1.8.2.
+    Returns whether or not the Connect server has Python itself enabled and its license allows
+    for API usage.  This controls whether APIs may be deployed..
 
     :param connect_details: details about a Connect server as returned by gather_server_details()
-    :return: boolean True if the Connect server is at least at version 1.8.2 or False if not.
-    :error: The RStudio Connect server must be at least v1.8.2.
+    :return: boolean True if the Connect server supports Python APIs or not or False if not.
+    :error: The RStudio Connect does not allow for Python APIs.
     """
-    return Version(connect_details['connect']) >= Version('1.8.1-1')
+    return connect_details['python']['api_enabled']
 
 
 def is_conda_supported_on_server(connect_details):

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -16,7 +16,7 @@ from .bundle import make_notebook_html_bundle, make_notebook_source_bundle, make
     make_source_manifest, manifest_add_file, manifest_add_buffer, make_api_bundle
 from .environment import EnvironmentException
 from .metadata import AppStore
-from .models import AppModes, Version
+from .models import AppModes
 
 import click
 from six.moves.urllib_parse import urlparse

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -3,47 +3,6 @@ This file defines some support data models.
 """
 
 
-class Version(object):
-    def __init__(self, text):
-        self._parts = [int(part) for part in text.replace('-', '.').split('.')]
-
-    def __eq__(self, other):
-        if not isinstance(other, Version):
-            raise NotImplementedError()
-        return self._parts == other._parts
-
-    def __ne__(self, other):
-        if not isinstance(other, Version):
-            raise NotImplementedError()
-        return self._parts != other._parts
-
-    def __lt__(self, other):
-        if not isinstance(other, Version):
-            raise NotImplementedError()
-        return self._parts < other._parts
-
-    def __le__(self, other):
-        if not isinstance(other, Version):
-            raise NotImplementedError()
-        return self._parts <= other._parts
-
-    def __gt__(self, other):
-        if not isinstance(other, Version):
-            raise NotImplementedError()
-        return self._parts > other._parts
-
-    def __ge__(self, other):
-        if not isinstance(other, Version):
-            raise NotImplementedError()
-        return self._parts >= other._parts
-
-    def __repr__(self):
-        text = '%d.%d.%d' % (self._parts[0], self._parts[1], self._parts[2])
-        if len(self._parts) > 3:
-            text = '%s-%d' % (text, self._parts[3])
-        return text
-
-
 class AppMode(object):
     def __init__(self, ordinal, name, text, ext=None):
         self._ordinal = ordinal

--- a/rsconnect/tests/test_actions.py
+++ b/rsconnect/tests/test_actions.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from rsconnect import api
 
 from rsconnect.actions import default_title, default_title_from_manifest, which_python, _to_server_check_list, \
-    _verify_server, check_server_capabilities, is_version_1_8_2_or_higher, is_conda_supported_on_server
+    _verify_server, check_server_capabilities, are_apis_supported_on_server, is_conda_supported_on_server
 from rsconnect.api import RSConnectException, RSConnectServer
 
 
@@ -38,16 +38,16 @@ class TestActions(TestCase):
         self.assertEqual(a_list, ['scheme://no-scheme'])
 
     def test_check_server_capabilities(self):
-        old_connect = {'connect': '1.8.0-42'}
-        new_connect = {'connect': '1.8.1-1'}
+        no_api_support = {'python': {'api_enabled': False}}
+        api_support = {'python': {'api_enabled': True}}
 
         with self.assertRaises(api.RSConnectException) as context:
-            check_server_capabilities(None, (is_version_1_8_2_or_higher,), lambda x: old_connect)
-        self.assertEqual(str(context.exception), 'The RStudio Connect server must be at least v1.8.2.')
+            check_server_capabilities(None, (are_apis_supported_on_server,), lambda x: no_api_support)
+        self.assertEqual(str(context.exception), 'The RStudio Connect does not allow for Python APIs.')
 
-        check_server_capabilities(None, (is_version_1_8_2_or_higher,), lambda x: new_connect)
+        check_server_capabilities(None, (are_apis_supported_on_server,), lambda x: api_support)
 
-        no_conda = new_connect
+        no_conda = api_support
         conda_not_supported = {'conda': {'supported': False}}
         conda_supported = {'conda': {'supported': True}}
 

--- a/rsconnect/tests/test_models.py
+++ b/rsconnect/tests/test_models.py
@@ -1,31 +1,9 @@
 from unittest import TestCase
 
-from rsconnect.models import AppMode, AppModes, Version
+from rsconnect.models import AppMode, AppModes
 
 
 class TestModels(TestCase):
-    def test_version_class(self):
-        self.assertTrue(Version('1.8.1') > Version('0.7.1'))
-        self.assertTrue(Version('1.8.1') >= Version('0.7.1'))
-        self.assertTrue(Version('1.8.1') < Version('2.7.1'))
-        self.assertTrue(Version('1.8.1') <= Version('2.7.1'))
-        self.assertTrue(Version('1.8.1') != Version('2.7.1'))
-
-        self.assertTrue(Version('1.8.1') > Version('1.7.1'))
-        self.assertTrue(Version('1.8.1') >= Version('1.7.1'))
-        self.assertTrue(Version('1.8.1') < Version('1.9.1'))
-        self.assertTrue(Version('1.8.1') <= Version('1.9.1'))
-        self.assertTrue(Version('1.8.1') != Version('1.9.1'))
-        self.assertTrue(Version('1.8.1') == Version('1.8.1'))
-
-        self.assertTrue(Version('1.8.1') != Version('1.8.1-9999'))
-        self.assertTrue(Version('1.8.1') <= Version('1.8.1-9999'))
-        self.assertTrue(Version('1.8.1') < Version('1.8.1-9999'))
-
-        self.assertTrue(Version('1.8.1') != Version('1.8.2-1'))
-        self.assertTrue(Version('1.8.1') <= Version('1.8.2-1'))
-        self.assertTrue(Version('1.8.1') < Version('1.8.2-1'))
-
     def test_app_mode_class(self):
         mode = AppMode(1, 'test', 'Testing')
 


### PR DESCRIPTION
### Description

This change updates how `rsconnect-python` determines whether Python APIs can be deployed successfully to Connect.  Previously, this was done by querying the version of Connect but this information is not always available.  Connect now advertises whether Python APIs are allowed (a combination of Python itself is enabled and whether the current license) and `rsconnect-python` uses this information.

### Testing Notes / Validation Steps

- [ ] `rsconnect details` will now report `<redacted>` as the version of Connect when this information is suppressed by configuration.
- [ ] `rsconnect deploy api` will now fail if Connect reports that Python APIs are not allowed.