### PR TITLE
Unique names, working -x, correct app modes, etc.

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -3,7 +3,6 @@ import time
 from _ssl import SSLError
 
 from rsconnect.http_support import HTTPResponse, HTTPServer, append_to_path
-from rsconnect.models import AppModes
 
 
 class RSConnectException(Exception):

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -15,7 +15,7 @@ from rsconnect.models import AppModes
 log = logging.getLogger('rsconnect')
 # From https://github.com/rstudio/rsconnect/blob/485e05a26041ab8183a220da7a506c9d3a41f1ff/R/bundle.R#L85-L88
 # noinspection SpellCheckingInspection
-directories_to_ignore = ['rsconnect/', 'packrat/', '.svn/', '.git/', '.Rproj.user/']
+directories_to_ignore = ['rsconnect-python/', 'packrat/', '.svn/', '.git/', '.Rproj.user/']
 
 
 # noinspection SpellCheckingInspection
@@ -319,7 +319,6 @@ def expand_globs(directory, excludes):
     """
     work = []
     if excludes:
-        directory = abspath(directory)
         for pattern in excludes:
             file_pattern = join(directory, pattern)
             work.extend(glob.glob(file_pattern))

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -8,7 +8,7 @@ import subprocess
 import tarfile
 import tempfile
 
-from os.path import abspath, basename, dirname, exists, join, relpath, splitext
+from os.path import basename, dirname, exists, join, relpath, splitext
 
 from rsconnect.models import AppModes
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -563,7 +563,7 @@ def write_manifest_api(force, entrypoint, exclude, python, conda, force_generate
 
     with cli_feedback('Creating manifest.json'):
         environment_file_exists = write_api_manifest_json(
-            directory, entrypoint, environment, AppModes.JUPYTER_NOTEBOOK, extra_files, exclude
+            directory, entrypoint, environment, AppModes.PYTHON_API, extra_files, exclude
         )
 
     if environment_file_exists and not force_generate:

--- a/rsconnect/tests/test_actions.py
+++ b/rsconnect/tests/test_actions.py
@@ -113,16 +113,16 @@ class TestActions(TestCase):
             validate_entry_point(directory, 'app:bogus_app')
 
     def test_make_deployment_name(self):
-        self.assertEqual(_make_deployment_name('title'), 'title')
-        self.assertEqual(_make_deployment_name('Title'), 'title')
-        self.assertEqual(_make_deployment_name('My Title'), 'my_title')
-        self.assertEqual(_make_deployment_name('My  Title'), 'my_title')
-        self.assertEqual(_make_deployment_name('My _ Title'), 'my_title')
-        self.assertEqual(_make_deployment_name('My-Title'), 'my-title')
+        self.assertEqual(_make_deployment_name(None, 'title', False), 'title')
+        self.assertEqual(_make_deployment_name(None, 'Title', False), 'title')
+        self.assertEqual(_make_deployment_name(None, 'My Title', False), 'my_title')
+        self.assertEqual(_make_deployment_name(None, 'My  Title', False), 'my_title')
+        self.assertEqual(_make_deployment_name(None, 'My _ Title', False), 'my_title')
+        self.assertEqual(_make_deployment_name(None, 'My-Title', False), 'my-title')
         # noinspection SpellCheckingInspection
-        self.assertEqual(_make_deployment_name(u'M\ry\n \tT\u2103itle'), 'my_title')
-        self.assertEqual(_make_deployment_name(u'\r\n\t\u2103'), '___')
-        self.assertEqual(_make_deployment_name(u'\r\n\tR\u2103'), '__r')
+        self.assertEqual(_make_deployment_name(None, u'M\ry\n \tT\u2103itle', False), 'my_title')
+        self.assertEqual(_make_deployment_name(None, u'\r\n\t\u2103', False), '___')
+        self.assertEqual(_make_deployment_name(None, u'\r\n\tR\u2103', False), '__r')
 
     def test_default_title(self):
         self.assertEqual(_default_title('testing.txt'), 'testing')

--- a/rsconnect/tests/test_bundle.py
+++ b/rsconnect/tests/test_bundle.py
@@ -212,9 +212,10 @@ class TestBundle(TestCase):
     def test_keep_manifest_specified_file(self):
         self.assertTrue(keep_manifest_specified_file('app.R'))
         self.assertFalse(keep_manifest_specified_file('packrat/packrat.lock'))
-        self.assertTrue(keep_manifest_specified_file('rsconnect'))
-        self.assertFalse(keep_manifest_specified_file('rsconnect/bogus.file'))
+        self.assertTrue(keep_manifest_specified_file('rsconnect-python'))
+        self.assertFalse(keep_manifest_specified_file('rsconnect-python/bogus.file'))
         self.assertFalse(keep_manifest_specified_file('.svn/bogus.file'))
+        # noinspection SpellCheckingInspection
         self.assertFalse(keep_manifest_specified_file('.Rproj.user/bogus.file'))
 
     def test_manifest_bundle(self):


### PR DESCRIPTION
### Description

This change corrects 5 issues:

1.  Because of how names are now generated, they were not always unique.
1.  The exclude functionality for `deploy api` and `write-manifest-api` wasn't working.
1.  `write-manifest api` was emitting the wrong app mode in the manifest.
1.  When generating a title from the current directory (for API stuff) the resulting title wasn't meaningful.
1.  Contents of `rsconnect-python` were being incorrectly included in manifests and bundles.

Connected tp https://github.com/rstudio/connect/issues/16709

### Testing Notes / Validation Steps

- [ ] Deploying something a second time with `--new` (or any other scenario where the name of what's being deployed would match the deploy of something else) will no longer cause an error.  The name for the new deploy will now acquire a numeric suffix to make it unique.
- [ ] The `--exclude`/`-x` options of `deploy api` and `write-manifest api` will now work.
- [ ] If you deploy an API from its directory (i.e., specifying `.` as the thing to deploy), you should now end up with a useful title.
- [ ] Running `write-manifest api` should now create a manifest with `appmode` set to `python-api`.
- [ ] The contents of `rsconnect-python` which holds deployment history should no longer appear in manifests or bundles.