### PR TITLE
Make file/directory exclusions work.

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -422,12 +422,6 @@ def validate_entry_point(directory, entry_point):
     if not exists(file_name):
         raise api.RSConnectException('Could not find module file %s.' % file_name)
 
-    with open(file_name) as fd:
-        content = fd.read()
-
-    if not re.search('^%s = ' % parts[1], content, re.MULTILINE):
-        raise api.RSConnectException('The file, %s, does not contain an assignment to "%s".' % (file_name, parts[1]))
-
     return entry_point, file_name
 
 

--- a/rsconnect/tests/test_actions.py
+++ b/rsconnect/tests/test_actions.py
@@ -109,9 +109,6 @@ class TestActions(TestCase):
         with self.assertRaises(RSConnectException):
             validate_entry_point(directory, 'bob:app')
 
-        with self.assertRaises(RSConnectException):
-            validate_entry_point(directory, 'app:bogus_app')
-
     def test_make_deployment_name(self):
         self.assertEqual(_make_deployment_name(None, 'title', False), 'title')
         self.assertEqual(_make_deployment_name(None, 'Title', False), 'title')


### PR DESCRIPTION
### Description

This change fixes a problem with `--exclude`/`-x` usage on the `deploy api` and `write-manifest api` commands where hidden files would be inappropriately included.  Also, if the user specifies a directory to exclude, the library will add the requisite `/**/*` glob pattern as it will be problematic for users to remember that.

Connected to https://github.com/rstudio/connect/issues/16750

### Testing Notes / Validation Steps

The following items apply to both the `deploy api` and `write-manifest api` commands.

- [ ] Excluding a directory with a `<dir>/**/*` pattern should work correctly.
- [ ] Excluding a directory with just its name should also now work.
- [ ] Any hidden files in an excluded directory should not be present in a manifest or bundle.
- [ ] Any files under a hidden directory belonging to an excluded directory should not be present in a manifest or bundle.