### PR TITLE
Return output on version info fail

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -78,7 +78,7 @@ def get_conda_version(conda):
         match = version_re.search(stdout)
         if match:
             return match.group()
-        msg = "Failed to get version of conda from the output of: %s" % (' '.join(args))
+        msg = "Failed to get version of conda from the output of: %s - output was: %s" % (' '.join(args), stdout)
         raise EnvironmentException(msg)
     except Exception as exception:
         raise EnvironmentException("Error getting conda version: %s" % str(exception))


### PR DESCRIPTION
- When we can't parse the version it will be helpful to know what the output was.