### PR TITLE
Jsk extra files fix

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -454,7 +454,9 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
 @click.option('--entrypoint', '-e', help='The module and executable object which serves as the entry point for the '
                                          'WSGi framework of choice (defaults to app:app)')
 @click.option('--exclude', '-x', multiple=True,
-              help='Specify a glob pattern for ignoring files when building the bundle. This option may be repeated/')
+              help='Specify a glob pattern for ignoring files when building the bundle. Note that your shell may try '
+                   'to expand this which will not do what you expect. Generally, it\'s safest to quote the pattern. '
+                   'This option may be repeated.')
 @click.option('--new', '-N', is_flag=True,
               help='Force a new deployment, even if there is saved metadata from a previous deployment. '
                    'Cannot be used with --app-id.')
@@ -575,7 +577,9 @@ def write_manifest_notebook(force, python, conda, force_generate, verbose, file,
 @click.option('--entrypoint', '-e', help='The module and executable object which serves as the entry point for the '
                                          'WSGi framework of choice (defaults to app:app)')
 @click.option('--exclude', '-x', multiple=True,
-              help='Specify a glob pattern for ignoring files when building the bundle. This option may be repeated/')
+              help='Specify a glob pattern for ignoring files when building the bundle. Note that your shell may try '
+                   'to expand this which will not do what you expect. Generally, it\'s safest to quote the pattern. '
+                   'This option may be repeated.')
 @click.option('--python', '-p', type=click.Path(exists=True),
               help='Path to Python interpreter whose environment should be used. ' +
                    'The Python environment must have the rsconnect-python package installed.')


### PR DESCRIPTION
### Description

This change makes sure we are consistent in how, and where, we validate any extra files that the user specifies.  It also does some minor tidying of terminal output and some help improvement.

Connected to https://github.com/rstudio/connect/issues/16775
Connected to https://github.com/rstudio/connect/issues/16408

### Testing Notes / Validation Steps

- [ ] All commands that accept extra files should no longer double-append directory information when `rsconnect` is run outside of the directory involved and work correctly.
- [ ] Running a command builds a bundle (the `deploy` commands) with `-v` will now show the file names added to the bundle in a visually cleaner way.
- [ ] The help for the `--exclude`/`-x` should now be more complete.