### PR TITLE
fix version matching for later versions of conda

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -75,7 +75,7 @@ def get_conda_version(conda):
         args = [conda, '-V']
         proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         stdout, stderr = proc.communicate()
-        match = version_re.search(stdout)
+        match = version_re.search(stdout or stderr)
         if match:
             return match.group()
         msg = "Failed to get version of conda from the output of: %s - standard output: %s; standard error: %s" % \


### PR DESCRIPTION
Conda used to output the version via `stdout`, but newer versions use `stderr`. Let's support both.

Before:

```
Inspecting Python environment...                 [ERROR]
Error: Error getting conda version: Failed to get version of conda from the output of: /opt/bin/conda -V

(python3.6env) MacBook-Pro:rsconnect-python questionsleep$ /opt/bin/conda -V
conda 4.7.12
```

After:

```
(python2.7env) MacBook-Pro:rsconnect-python questionsleep$ rsconnect deploy notebook -n dogfood -t "conda 2.7 content" -C -v ~/Git/PythonDataScienceHandbook/notebooks/05.01-What-Is-Machine-Learning.ipynb
Checking arguments...                            DEBUG:rsconnect:Found previous deployment data in /Users/questionsleep/Git/PythonDataScienceHandbook/notebooks/rsconnect-python/05.01-What-Is-Machine-Learning.json
DEBUG:rsconnect:Using saved app ID: cf844dd6-b2de-4cee-ac55-ee59cf611f8e
[OK]
    Deploying /Users/questionsleep/Git/PythonDataScienceHandbook/notebooks/05.01-What-Is-Machine-Learning.ipynb to server "https://rsc.radixu.com"
    Warning: the existing manifest.json file will not be used or considered.
Ensuring conda is supported...                   DEBUG:rsconnect:Performing: GET /__api__/server_settings
DEBUG:rsconnect:Response: 200 OK
DEBUG:rsconnect:--> {"version":"1.8.1-5880","build":"\"598162c\"","about":"RStudio Connect v1.8.1-5880","authentication":{"handles_credentials":false,"handles_login":true,"external_user_data":true,"external_user_search":true,"groups_enabled":true,"external_group_data":false,"unique_usernames":true,"name_editable_by":"provider","email_editable_by":"provider","username_editable_by":"adminandself","role_editable_by":"adminandself","challenge_response_enabled":false,"name":"OAuth2","notice":"NOTICE: Other users will be able to see your full name and email address in RStudio Connect."},"license":{"ts":1583517982527,"status":"activated","expiration":1759276800000,"days-left":2035,"edition":"","cores":"0","connections":"0","has-key":true,"has-trial":false,"type":"local","shiny-users":"0","users":"0","user-activity-days":"365","allow-apis":"1"},"google_analytics_tracking_id":"UA-36850640-5","viewer_kiosk":false,"mail_all":false,"mail_configured":true,"recent_visibility":"viewer","public_warning":"This server is intended for internal development and should not be considered stable for production applications.","logged_in_warning":"Please remember that this server is intended for internal development and should not be considered stable for production applications.","logout_url":"__logout__","metrics_rrd_enabled":true,"metrics_instrumentation":true,"customized_landing":false,"self_registration":true,"prohibited_usernames":["connect","apps","users","groups","setpassword","user-completion","confirm","recent","reports","plots","unpublished","settings","metrics","tokens","help","login","welcome","register","resetpassword","content"],"username_validator":"default","viewers_can_only_see_themselves":false,"http_warning":false,"queue_ui":true,"v1_dev_api":false,"license_expiration_ui_warning":true,"runtimes":["R","Python"],"dashboard_build_guid_based_routes":false,"dashboard_fail_id_based_routes":false,"expanded_view_ui":true,"default_content_list_view":"compact","maximum_app_image_size":10000000,"server_settings_toggler":true,"vue_logs_panel":false,"vue_web_sudo_login":false,"vue_vars_panel":false,"git_enabled":true,"git_available":true,"documentation_dashboard":false,"conda_supported":false}
DEBUG:rsconnect:Performing: GET /__api__/v1/server_settings/python
DEBUG:rsconnect:Response: 200 OK
DEBUG:rsconnect:--> {"installations":[{"version":"2.7.15"},{"version":"3.7.2"}],"api_enabled":true,"conda_enabled":true}
[OK]
Inspecting Python environment...                 DEBUG:rsconnect:Python: /Users/questionsleep/.conda/envs/python2.7env/bin/python
DEBUG:rsconnect:Python: /Users/questionsleep/.conda/envs/python2.7env/bin/python
DEBUG:rsconnect:Environment: {u'conda': u'4.7.12',
 u'contents': u'name: python2.7env\nchannels:\n  - defaults\ndependencies:\n  - alabaster=0.7.12=py27_0\n  - anaconda=2019.10=py27_0\n  - anaconda-client=1.7.2=py27_0\n  - anaconda-project=0.8.3=py_0\n  - appnope=0.1.0=py27hb466136_0\n  - appscript=1.1.0=py27h1de35cc_0\n  - asn1crypto=1.0.1=py27_0\n  - astroid=1.6.5=py27_0\n  - astropy=2.0.9=py27h1d22016_0\n  - atomicwrites=1.3.0=py27_1\n  - attrs=19.2.0=py_0\n  - babel=2.7.0=py_0\n  - backports=1.0=py_2\n  - backports.functools_lru_cache=1.5=py_2\n  - backports.os=0.1.1=py27_0\n  - backports.shutil_get_terminal_size=1.0.0=py27_2\n  - backports_abc=0.5=py27h6972548_0\n  - beautifulsoup4=4.8.0=py27_0\n  - bitarray=1.0.1=py27h1de35cc_0\n  - bkcharts=0.2=py27haafc882_0\n  - blas=1.0=mkl\n  - bleach=3.1.0=py27_0\n  - blosc=1.16.3=hd9629dc_0\n  - bokeh=1.3.4=py27_0\n  - boto=2.49.0=py27_0\n  - bottleneck=1.2.1=py27h1d22016_1\n  - bzip2=1.0.8=h1de35cc_0\n  - ca-certificates=2019.8.28=0\n  - cdecimal=2.3=py27h1de35cc_3\n  - certifi=2019.9.11=py27_0\n  - cffi=1.12.3=py27hb5b8e2f_0\n  - chardet=3.0.4=py27_1003\n  - click=7.0=py27_0\n  - cloudpickle=1.2.2=py_0\n  - clyent=1.2.2=py27_1\n  - colorama=0.4.1=py27_0\n  - configparser=4.0.2=py27_0\n  - contextlib2=0.6.0=py_0\n  - cryptography=2.7=py27ha12b0ac_0\n  - curl=7.65.3=ha441bb4_0\n  - cycler=0.10.0=py27hfc73c78_0\n  - cython=0.29.13=py27h0a44026_0\n  - cytoolz=0.10.0=py27h1de35cc_0\n  - dask=1.2.2=py_0\n  - dask-core=1.2.2=py_0\n  - dbus=1.13.6=h90a0687_0\n  - decorator=4.4.0=py27_1\n  - defusedxml=0.6.0=py_0\n  - distributed=1.28.1=py27_0\n  - docutils=0.15.2=py27_0\n  - entrypoints=0.3=py27_0\n  - enum34=1.1.6=py27_1\n  - et_xmlfile=1.0.1=py27hc42f929_0\n  - expat=2.2.6=h0a44026_0\n  - fastcache=1.1.0=py27h1de35cc_0\n  - filelock=3.0.12=py_0\n  - flask=1.1.1=py_0\n  - freetype=2.9.1=hb4e5f40_0\n  - funcsigs=1.0.2=py27hb9f6266_0\n  - functools32=3.2.3.2=py27_1\n  - future=0.17.1=py27_0\n  - futures=3.3.0=py27_0\n  - get_terminal_size=1.0.0=h7520d66_0\n  - gettext=0.19.8.1=h15daf44_3\n  - gevent=1.4.0=py27h1de35cc_0\n  - glib=2.56.2=hd9629dc_0\n  - glob2=0.7=py_0\n  - gmp=6.1.2=hb37e062_1\n  - gmpy2=2.0.8=py27h6ef4df4_2\n  - greenlet=0.4.15=py27h1de35cc_0\n  - grin=1.2.1=py27_4\n  - h5py=2.9.0=py27h3134771_0\n  - hdf5=1.10.4=hfa1e0ec_0\n  - heapdict=1.0.1=py_0\n  - html5lib=1.0.1=py27_0\n  - icu=58.2=h4b95b61_1\n  - idna=2.8=py27_0\n  - imageio=2.6.0=py27_0\n  - imagesize=1.1.0=py27_0\n  - importlib_metadata=0.23=py27_0\n  - intel-openmp=2019.4=233\n  - ipaddress=1.0.22=py27_0\n  - ipykernel=4.10.0=py27_0\n  - ipython=5.8.0=py27_0\n  - ipython_genutils=0.2.0=py27h8b9a179_0\n  - ipywidgets=7.5.1=py_0\n  - isort=4.3.21=py27_0\n  - itsdangerous=1.1.0=py27_0\n  - jbig=2.1=h4d881f8_0\n  - jdcal=1.4.1=py_0\n  - jedi=0.15.1=py27_0\n  - jinja2=2.10.3=py_0\n  - jpeg=9b=he5867d9_2\n  - jsonschema=3.0.2=py27_0\n  - jupyter=1.0.0=py27_7\n  - jupyter_client=5.3.3=py27_1\n  - jupyter_console=5.2.0=py27_1\n  - jupyter_core=4.5.0=py_0\n  - jupyterlab=0.33.11=py27_0\n  - jupyterlab_launcher=0.11.2=py27h28b3542_0\n  - keyring=18.0.0=py27_0\n  - kiwisolver=1.1.0=py27h0a44026_0\n  - krb5=1.16.1=hddcf347_7\n  - lazy-object-proxy=1.4.2=py27h1de35cc_0\n  - libarchive=3.3.3=h786848e_5\n  - libcurl=7.65.3=h051b688_0\n  - libcxx=4.0.1=hcfea43d_1\n  - libcxxabi=4.0.1=hcfea43d_1\n  - libedit=3.1.20181209=hb402a30_0\n  - libffi=3.2.1=h475c297_4\n  - libgfortran=3.0.1=h93005f0_2\n  - libiconv=1.15=hdd342a3_7\n  - liblief=0.9.0=h2a1bed3_2\n  - libpng=1.6.37=ha441bb4_0\n  - libsodium=1.0.16=h3efe00b_0\n  - libssh2=1.8.2=ha12b0ac_0\n  - libtiff=4.0.10=hcb84e12_2\n  - libxml2=2.9.9=hf6e021a_1\n  - libxslt=1.1.33=h33a18ac_0\n  - linecache2=1.0.0=py27_0\n  - llvmlite=0.29.0=py27h98b8051_0\n  - locket=0.2.0=py27ha10513d_1\n  - lxml=4.4.1=py27hef8c89e_0\n  - lz4-c=1.8.1.2=h1de35cc_0\n  - lzo=2.10=h362108e_2\n  - markupsafe=1.1.1=py27h1de35cc_0\n  - matplotlib=2.2.3=py27h54f8f79_0\n  - mccabe=0.6.1=py27_1\n  - mistune=0.8.4=py27h1de35cc_0\n  - mkl=2019.4=233\n  - mkl-service=2.3.0=py27hfbe908c_0\n  - mkl_fft=1.0.14=py27h5e564d8_0\n  - mkl_random=1.1.0=py27ha771720_0\n  - mock=3.0.5=py27_0\n  - more-itertools=5.0.0=py27_0\n  - mpc=1.1.0=h6ef4df4_1\n  - mpfr=4.0.1=h3018a27_3\n  - mpmath=1.1.0=py27_0\n  - msgpack-python=0.6.1=py27h04f5b5a_1\n  - multipledispatch=0.6.0=py27_0\n  - nbconvert=5.6.0=py27_1\n  - nbformat=4.4.0=py27hddc86d0_0\n  - ncurses=6.1=h0a44026_1\n  - networkx=2.2=py27_1\n  - nltk=3.4.5=py27_0\n  - nose=1.3.7=py27_2\n  - notebook=5.7.8=py27_0\n  - numba=0.45.1=py27h6440ff4_0\n  - numexpr=2.7.0=py27h7413580_0\n  - numpy=1.16.5=py27hacdab7b_0\n  - numpy-base=1.16.5=py27h6575580_0\n  - numpydoc=0.9.1=py_0\n  - olefile=0.46=py27_0\n  - openpyxl=2.6.3=py_0\n  - openssl=1.1.1d=h1de35cc_2\n  - packaging=19.2=py_0\n  - pandas=0.24.2=py27h0a44026_0\n  - pandoc=2.2.3.2=0\n  - pandocfilters=1.4.2=py27_1\n  - parso=0.5.1=py_0\n  - partd=1.0.0=py_0\n  - path.py=11.5.0=py27_0\n  - pathlib2=2.3.5=py27_0\n  - patsy=0.5.1=py27_0\n  - pcre=8.43=h0a44026_0\n  - pep8=1.7.1=py27_0\n  - pexpect=4.7.0=py27_0\n  - pickleshare=0.7.5=py27_0\n  - pillow=6.2.0=py27hb68e598_0\n  - pip=19.2.3=py27_0\n  - pkginfo=1.5.0.1=py27_0\n  - pluggy=0.13.0=py27_0\n  - ply=3.11=py27_0\n  - portaudio=19.6.0=h41429eb_1\n  - prometheus_client=0.7.1=py_0\n  - prompt_toolkit=1.0.15=py27h4a7b9c2_0\n  - psutil=5.6.3=py27h1de35cc_0\n  - ptyprocess=0.6.0=py27_0\n  - py=1.8.0=py27_0\n  - py-lief=0.9.0=py27h1413db1_2\n  - pyaudio=0.2.11=py27h1de35cc_1\n  - pycodestyle=2.5.0=py27_0\n  - pycosat=0.6.3=py27h1de35cc_0\n  - pycparser=2.19=py27_0\n  - pycrypto=2.6.1=py27h1de35cc_9\n  - pycurl=7.43.0.3=py27ha12b0ac_0\n  - pyflakes=2.1.1=py27_0\n  - pygments=2.4.2=py_0\n  - pylint=1.9.2=py27_0\n  - pyodbc=4.0.27=py27h0a44026_0\n  - pyopenssl=19.0.0=py27_0\n  - pyparsing=2.4.2=py_0\n  - pyqt=5.9.2=py27h655552a_2\n  - pyrsistent=0.15.4=py27h1de35cc_0\n  - pysocks=1.7.1=py27_0\n  - pytables=3.5.2=py27h5bccee9_1\n  - pytest=4.6.2=py27_0\n  - python=2.7.16=h97142e2_7\n  - python-dateutil=2.8.0=py27_0\n  - python-libarchive-c=2.8=py27_13\n  - python.app=2=py27_9\n  - pytz=2019.3=py_0\n  - pywavelets=1.0.3=py27h1d22016_1\n  - pyyaml=5.1.1=py27h1de35cc_0\n  - pyzmq=18.1.0=py27h0a44026_0\n  - qt=5.9.7=h468cd18_1\n  - qtawesome=0.6.0=py_0\n  - qtconsole=4.5.5=py_0\n  - qtpy=1.9.0=py_0\n  - readline=7.0=h1de35cc_5\n  - requests=2.22.0=py27_0\n  - ripgrep=0.10.0=hc07d326_0\n  - rope=0.14.0=py_0\n  - ruamel_yaml=0.15.46=py27h1de35cc_0\n  - scandir=1.10.0=py27h1de35cc_0\n  - scikit-image=0.14.2=py27h0a44026_0\n  - scikit-learn=0.20.3=py27h27c97d8_0\n  - scipy=1.2.1=py27h1410ff5_0\n  - seaborn=0.9.0=py27_0\n  - send2trash=1.5.0=py27_0\n  - setuptools=41.4.0=py27_0\n  - simplegeneric=0.8.1=py27_2\n  - singledispatch=3.4.0.3=py27he22c18d_0\n  - sip=4.19.8=py27h0a44026_0\n  - six=1.12.0=py27_0\n  - snappy=1.1.7=he62c110_3\n  - snowballstemmer=2.0.0=py_0\n  - sortedcollections=1.1.2=py27_0\n  - sortedcontainers=2.1.0=py27_0\n  - soupsieve=1.9.3=py27_0\n  - sphinx=1.8.5=py27_0\n  - sphinxcontrib=1.0=py27_1\n  - sphinxcontrib-websupport=1.1.2=py_0\n  - spyder=3.3.6=py27_0\n  - spyder-kernels=0.5.2=py27_0\n  - sqlalchemy=1.3.9=py27h1de35cc_0\n  - sqlite=3.30.0=ha441bb4_0\n  - ssl_match_hostname=3.7.0.1=py27_0\n  - statsmodels=0.10.1=py27h1d22016_0\n  - subprocess32=3.5.4=py27h1de35cc_0\n  - sympy=1.4=py27_0\n  - tbb=2019.8=h04f5b5a_0\n  - tblib=1.4.0=py_0\n  - terminado=0.8.2=py27_0\n  - testpath=0.4.2=py27_0\n  - tk=8.6.8=ha441bb4_0\n  - toolz=0.10.0=py_0\n  - tornado=5.1.1=py27h1de35cc_0\n  - tqdm=4.36.1=py_0\n  - traceback2=1.4.0=py27_0\n  - traitlets=4.3.3=py27_0\n  - typing=3.7.4.1=py27_0\n  - unicodecsv=0.14.1=py27h170f95c_0\n  - unittest2=1.1.0=py27_0\n  - unixodbc=2.3.7=h1de35cc_0\n  - urllib3=1.24.2=py27_0\n  - wcwidth=0.1.7=py27h817c265_0\n  - webencodings=0.5.1=py27_1\n  - werkzeug=0.16.0=py_0\n  - wheel=0.33.6=py27_0\n  - widgetsnbextension=3.5.1=py27_0\n  - wrapt=1.11.2=py27h1de35cc_0\n  - wurlitzer=1.0.3=py27_0\n  - xlrd=1.2.0=py27_0\n  - xlsxwriter=1.2.1=py_0\n  - xlwings=0.15.10=py27_0\n  - xlwt=1.2.0=py27hbeec4ae_0\n  - xz=5.2.4=h1de35cc_4\n  - yaml=0.1.7=hc338f04_2\n  - zeromq=4.3.1=h0a44026_3\n  - zict=1.0.0=py_0\n  - zipp=0.6.0=py_0\n  - zlib=1.2.11=h1de35cc_3\n  - zstd=1.3.7=h5bba6e5_0\n  - pip:\n    - rsconnect-python==1.3.2.9999\nprefix: /Users/questionsleep/.conda/envs/python2.7env\n\n',
 u'filename': u'environment.yml',
 u'locale': u'en_US.UTF-8',
 u'package_manager': u'conda',
 u'pip': u'19.2.3',
 u'python': u'2.7.16',
 u'source': u'conda_env_export'}
[OK]
Creating deployment bundle...                    DEBUG:rsconnect:manifest: {'locale': u'en_US.UTF-8', 'python': {'version': u'2.7.16', 'package_manager': {'version': u'4.7.12', 'name': u'conda', 'package_file': u'environment.yml'}}, 'version': 1, 'files': {u'environment.yml': {'checksum': '1088e5f4cac25e74e9da7c5dffb632e1'}, '05.01-What-Is-Machine-Learning.ipynb': {'checksum': '64c2bda218ad63f1b83c7f52f8a499e7'}}, 'metadata': {'appmode': 'jupyter-static', 'entrypoint': '05.01-What-Is-Machine-Learning.ipynb'}}
DEBUG:rsconnect:added buffer: manifest.json
DEBUG:rsconnect:added buffer: environment.yml
DEBUG:rsconnect:added file: /Users/questionsleep/Git/PythonDataScienceHandbook/notebooks/05.01-What-Is-Machine-Learning.ipynb
[OK]
Uploading bundle...                              DEBUG:rsconnect:Performing: GET /__api__/applications/cf844dd6-b2de-4cee-ac55-ee59cf611f8e
DEBUG:rsconnect:Response: 200 OK
DEBUG:rsconnect:--> {"id":3803,"guid":"cf844dd6-b2de-4cee-ac55-ee59cf611f8e","access_type":"acl","connection_timeout":null,"read_timeout":null,"init_timeout":null,"idle_timeout":null,"max_processes":null,"min_processes":null,"max_conns_per_process":null,"load_factor":null,"url":"https://rsc.radixu.com/content/3803/","vanity_url":false,"name":"a_notebook_with_the_same_title2","title":"conda 2.7 content","bundle_id":6963,"app_mode":7,"content_category":"","has_parameters":false,"created_time":"2020-03-06T14:55:59.234642Z","last_deployed_time":"2020-03-06T19:43:49.022046Z","r_version":null,"py_version":"2.7.15","build_status":2,"run_as":null,"run_as_current_user":false,"description":"","app_role":"owner","owner_first_name":"Toni","owner_last_name":"Noble","owner_username":"toni","owner_guid":"facd3756-e217-47a6-a7fc-9a8e8ece0794","owner_email":"toni@rstudio.com","owner_locked":false,"is_scheduled":false,"git":null,"users":null,"groups":null,"vanities":null}
DEBUG:rsconnect:Performing: POST /__api__/applications/cf844dd6-b2de-4cee-ac55-ee59cf611f8e/upload
DEBUG:rsconnect:Response: 200 OK
DEBUG:rsconnect:--> {"id":6985,"app_id":3803,"created_time":"2020-03-06T19:55:38.29196Z","updated_time":"2020-03-06T19:55:38.295240918Z","r_version":null,"py_version":null,"build_status":0,"size":9856,"active":false,"AppGUID":"cf844dd6-b2de-4cee-ac55-ee59cf611f8e"}
DEBUG:rsconnect:Performing: POST /__api__/applications/cf844dd6-b2de-4cee-ac55-ee59cf611f8e/deploy
DEBUG:rsconnect:Response: 200 OK
DEBUG:rsconnect:--> {"id":"Rx2tHQc7rqRzzZbQ","user_id":152,"status":["Building Jupyter notebook...","Bundle requested Python version 2.7.16; using /opt/Python/2.7.15/bin/python2.7 which has version 2.7.15"],"result":null,"finished":false,"code":0,"error":"","last_status":2}
[OK]
Saving deployment data...                        [OK]

Deployment log:
```

Testing Notes:

- [ ] Deploying content via Conda (`rsconnect deploy notebook -C -s <server> <notebook>`) works.
