### PR TITLE
A few minor fixes.

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -13,6 +13,7 @@ from rsconnect import api
 from .bundle import make_api_bundle, make_api_manifest, make_manifest_bundle,  make_notebook_html_bundle, \
     make_notebook_source_bundle, make_source_manifest, manifest_add_buffer, manifest_add_file, read_manifest_file
 from .environment import EnvironmentException
+from .log import logger
 from .metadata import AppStore
 from .models import AppModes
 
@@ -20,7 +21,6 @@ import click
 from six.moves.urllib_parse import urlparse
 
 line_width = 45
-logger = logging.getLogger('rsconnect')
 _module_pattern = re.compile(r'^[A-Za-z0-9_]+:[A-Za-z0-9_]+$')
 _name_sub_pattern = re.compile(r'[^A-Za-z0-9_ -]+')
 _repeating_sub_pattern = re.compile(r'_+')
@@ -39,6 +39,7 @@ def cli_feedback(label):
     if label:
         pad = line_width - len(label)
         click.secho(label + '... ' + ' ' * pad, nl=False, fg='bright_white')
+        logger.set_in_feedback(True)
 
     def passed():
         if label:
@@ -61,6 +62,8 @@ def cli_feedback(label):
         if click.get_current_context('verbose'):
             traceback.print_exc()
         failed('Internal error: ' + str(exc))
+    finally:
+        logger.set_in_feedback(False)
 
 
 def set_verbosity(verbose):

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -371,7 +371,7 @@ def validate_extra_files(directory, extra_files):
     result = []
     if extra_files:
         for extra in extra_files:
-            extra_file = relpath(directory, extra)
+            extra_file = relpath(extra, directory)
             # It's an error if we have to leave the given dir to get to the extra
             # file.
             if extra_file.startswith('../'):
@@ -392,7 +392,7 @@ def validate_manifest_file(file_or_directory):
     """
     if isdir(file_or_directory):
         file_or_directory = join(file_or_directory, 'manifest.json')
-    elif basename(file_or_directory) != 'manifest.json' or not exists(file_or_directory):
+    if basename(file_or_directory) != 'manifest.json' or not exists(file_or_directory):
         raise api.RSConnectException('A manifest.json file or a directory containing one is required here.')
     return file_or_directory
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1,8 +1,8 @@
-import logging
 import time
 from _ssl import SSLError
 
 from rsconnect.http_support import HTTPResponse, HTTPServer, append_to_path
+from rsconnect.log import logger
 from rsconnect.models import AppModes
 
 
@@ -10,9 +10,6 @@ class RSConnectException(Exception):
     def __init__(self, message):
         super(RSConnectException, self).__init__(message)
         self.message = message
-
-
-logger = logging.getLogger('rsconnect')
 
 
 class RSConnectServer(object):

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -17,7 +17,7 @@ from rsconnect.models import AppModes, GlobSet
 log = logging.getLogger('rsconnect')
 # From https://github.com/rstudio/rsconnect/blob/485e05a26041ab8183a220da7a506c9d3a41f1ff/R/bundle.R#L85-L88
 # noinspection SpellCheckingInspection
-directories_to_ignore = ['rsconnect-python/', 'packrat/', '.svn/', '.git/', '.Rproj.user/']
+directories_to_ignore = ['rsconnect/', 'rsconnect-python/', 'packrat/', '.svn/', '.git/', '.Rproj.user/']
 
 
 # noinspection SpellCheckingInspection
@@ -381,7 +381,7 @@ def create_api_file_list(directory, requirements_file_name, extra_files=None, ex
     for rel_path in extra_files:
         file_list.append((None, rel_path))
 
-    return sorted(file_list)
+    return sorted(file_list, key=lambda paths: paths[1])
 
 
 def make_api_manifest(directory, entry_point, app_mode, environment, extra_files=None, excludes=None):

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -3,17 +3,16 @@ This file provides an HTTP API (wrapped around the standard library via six) tai
 our needs.
 """
 import json
-import logging
 import socket
 import ssl
 
 from rsconnect import VERSION
+from rsconnect.log import logger
 from six.moves import http_client as http
 from six.moves.http_cookies import SimpleCookie
 from six.moves.urllib_parse import urlparse, urlencode, urljoin
 
 
-logger = logging.getLogger('rsconnect')
 _user_agent = "rsconnect-python/%s" % VERSION
 
 

--- a/rsconnect/log.py
+++ b/rsconnect/log.py
@@ -1,0 +1,26 @@
+from logging import getLogger, LoggerAdapter
+
+import click
+
+
+class RSLogger(LoggerAdapter):
+    def __init__(self):
+        super(RSLogger, self).__init__(getLogger('rsconnect'), {})
+        self._in_feedback = False
+        self._have_feedback_output = False
+
+    def set_in_feedback(self, value):
+        self._in_feedback = value
+        self._have_feedback_output = False
+
+    def process(self, msg, kwargs):
+        msg, kwargs = super(RSLogger, self).process(msg, kwargs)
+        if self._in_feedback:
+            if not self._have_feedback_output:
+                print()
+                self._have_feedback_output = True
+            msg = click.style(' %s' % msg, fg='green')
+        return msg, kwargs
+
+
+logger = RSLogger()

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -415,14 +415,14 @@ def deploy_notebook(name, server, api_key, insecure, cacert, static, new, app_id
 @click.option('--app-id', '-a', help='Existing app ID or GUID to replace. Cannot be used with --new.')
 @click.option('--title', '-t', help='Title of the content (default is the same as the filename).')
 @click.option('--verbose', '-v', is_flag=True, help='Print detailed messages.')
-@click.argument('file', type=click.Path(exists=True, dir_okay=False, file_okay=True))
+@click.argument('file', type=click.Path(exists=True, dir_okay=True, file_okay=True))
 def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title, verbose, file):
     set_verbosity(verbose)
 
     with cli_feedback('Checking arguments'):
-        app_store = AppStore(file)
         connect_server = _validate_deploy_to_args(name, server, api_key, insecure, cacert)
         file = validate_manifest_file(file)
+        app_store = AppStore(file)
 
         app_id, deployment_name, title, app_mode, package_manager = \
             gather_basic_deployment_info_from_manifest(connect_server, app_store, file, new, app_id, title)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1,6 +1,5 @@
 import logging
 import textwrap
-import threading
 from os.path import abspath, dirname, exists, join
 
 import click

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -40,7 +40,7 @@ def cli():
     certificate file to use for TLS.  The last two items are only relevant if the
     URL specifies the "https" protocol.
     """
-    threading.local().is_cli = True
+    pass
 
 
 @cli.command(help='Show the version of the rsconnect-python package.')

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -2,15 +2,13 @@
 import base64
 import hashlib
 import json
-import logging
 import os
 import sys
 from os.path import abspath, basename, dirname, exists, join
 
 from rsconnect import api
+from rsconnect.log import logger
 from rsconnect.models import AppMode, AppModes
-
-logger = logging.getLogger('rsconnect')
 
 
 def config_dirname(platform=sys.platform, env=os.environ):

--- a/rsconnect/tests/test_actions.py
+++ b/rsconnect/tests/test_actions.py
@@ -1,13 +1,15 @@
 import os
 import sys
+from os.path import dirname, join
 from unittest import TestCase
 
 from rsconnect import api
 
 from rsconnect.actions import _default_title, _default_title_from_manifest, which_python, _to_server_check_list, \
     _verify_server, check_server_capabilities, are_apis_supported_on_server, is_conda_supported_on_server, \
-    _make_deployment_name, _validate_title, validate_entry_point
+    _make_deployment_name, _validate_title, validate_entry_point, validate_extra_files
 from rsconnect.api import RSConnectException, RSConnectServer
+from rsconnect.tests.test_data_util import get_manifest_path
 
 
 class TestActions(TestCase):
@@ -135,3 +137,17 @@ class TestActions(TestCase):
         # noinspection SpellCheckingInspection
         m = {'metadata': {'entrypoint': 'module:object'}}
         self.assertEqual(_default_title_from_manifest(m, 'dir/to/manifest.json'), '0to')
+
+    def test_validate_extra_files(self):
+        # noinspection SpellCheckingInspection
+        directory = dirname(get_manifest_path('shinyapp'))
+
+        with self.assertRaises(RSConnectException):
+            validate_extra_files(directory, ['../other_dir/file.txt'])
+
+        with self.assertRaises(RSConnectException):
+            validate_extra_files(directory, ['not_a_file.txt'])
+
+        self.assertEqual(validate_extra_files(directory, None), [])
+        self.assertEqual(validate_extra_files(directory, []), [])
+        self.assertEqual(validate_extra_files(directory, [join(directory, 'index.htm')]), ['index.htm'])

--- a/rsconnect/tests/test_bundle.py
+++ b/rsconnect/tests/test_bundle.py
@@ -212,6 +212,8 @@ class TestBundle(TestCase):
     def test_keep_manifest_specified_file(self):
         self.assertTrue(keep_manifest_specified_file('app.R'))
         self.assertFalse(keep_manifest_specified_file('packrat/packrat.lock'))
+        self.assertTrue(keep_manifest_specified_file('rsconnect'))
+        self.assertFalse(keep_manifest_specified_file('rsconnect/bogus.file'))
         self.assertTrue(keep_manifest_specified_file('rsconnect-python'))
         self.assertFalse(keep_manifest_specified_file('rsconnect-python/bogus.file'))
         self.assertFalse(keep_manifest_specified_file('.svn/bogus.file'))


### PR DESCRIPTION
### Description

This change fixes several bugs:

- `< not supported` error when specifying extra files.
- `Is a directory` error when specifying extra files.
- `deploy manifest` does not accept a directory containing a `manifest.json` file as documented.

Connected to https://github.com/rstudio/connect/issues/16793
Connected to https://github.com/rstudio/connect/issues/16694

### Testing Notes / Validation Steps

See https://github.com/rstudio/connect/issues/16793#issuecomment-597089772 and https://github.com/rstudio/connect/issues/16694#issuecomment-597096087