### PR TITLE
LoggerAdapter is missing setLevel() in 2.7.

### DIFF
--- a/rsconnect/log.py
+++ b/rsconnect/log.py
@@ -22,5 +22,14 @@ class RSLogger(LoggerAdapter):
             msg = click.style(' %s' % msg, fg='green')
         return msg, kwargs
 
+    def setLevel(self, level):
+        """
+        Set the specified level on the underlying logger.
+
+        **Note:** This is present in newer Python versions but since it's missing
+        from 2.7, we replicate it here.
+        """
+        self.logger.setLevel(level)
+
 
 logger = RSLogger()


### PR DESCRIPTION
### Description

This change adds a `setLevel()` method to our `RSLogger` class.  This is necessary because the `LoggerAdapter` class in 2.7 is missing this method.

### Testing Notes / Validation Steps

- [ ] Connect builds start working again.