### PR TITLE
Jsk fix search hang

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -316,6 +316,8 @@ def retrieve_matching_apps(connect_server, filters=None, limit=None, mapping_fun
 
             if not maximum:
                 maximum = response['total']
+            else:
+                maximum = min(maximum, response['total'])
 
             applications = response['applications']
             returned = response['count']

--- a/rsconnect/tests/test_environment.py
+++ b/rsconnect/tests/test_environment.py
@@ -48,7 +48,7 @@ class TestEnvironment(TestCase):
 
         # these are the dependencies declared in our setup.py
         self.assertIn('six', contents)
-        self.assertIn('Click', contents)
+        self.assertIn('click', contents.lower())
 
         pip_version = result.pop('pip')
         self.assertTrue(version_re.match(pip_version))


### PR DESCRIPTION
### Description

This change corrects a paging error while doing an app search that was causing an infinite loop.  A test was adjusted to account for a change in case for the Click package that occurred between v7.0 and v7.1.

### Testing Notes / Validation Steps

- [ ] App searching in `rsconnect-jupyter` should no longer hang.