### PR TITLE
Respect existing title on redeploys.

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -677,7 +677,8 @@ def gather_basic_deployment_info_for_notebook(connect_server, app_store, file_na
             raise api.RSConnectException('Cannot change app mode to "static" once deployed. '
                                          'Use --new to create a new deployment.')
 
-    title, default_title = (title, False) if title else (_default_title(file_name), True)
+    default_title = not bool(title)
+    title = title or _default_title(file_name)
 
     return app_id, _make_deployment_name(connect_server, title, app_id is None), title, default_title, app_mode
 
@@ -713,7 +714,8 @@ def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_n
         app_id, title, app_mode = app_store.resolve(connect_server.url, app_id, title, app_mode)
 
     package_manager = source_manifest.get('python', {}).get('package_manager', {}).get('name', None)
-    title, default_title = (title, False) if title else (_default_title_from_manifest(source_manifest, file_name), True)
+    default_title = not bool(title)
+    title = title or _default_title_from_manifest(source_manifest, file_name)
 
     return app_id, _make_deployment_name(connect_server, title, app_id is None), title, default_title, app_mode,\
         package_manager
@@ -802,7 +804,8 @@ def _gather_basic_deployment_info_for_framework(connect_server, app_store, direc
     if directory[-1] == '/':
         directory = directory[:-1]
 
-    title, default_title = (title, False) if title else (_default_title(directory), True)
+    default_title = not bool(title)
+    title = title or _default_title(directory)
 
     return entry_point, app_id, _make_deployment_name(connect_server, title, app_id is None), title, default_title,\
         app_mode


### PR DESCRIPTION
### Description

This change updates the deploy logic to not update an application's title on a redeploy unless specifically requested to do so.  Prior to this, if the `--title` option was omitted, the library would invent a default title which, if different from the one in Connect would overwrite whatever was there.  This is bad if the user has used Connect to change the title.

Connected to https://github.com/rstudio/connect/issues/16895

### Testing Notes / Validation Steps

1.  Deploy a piece of content as a new deploy.
1.  Use the Connect dashboard to change its title.
1.  Redeploy the same piece of content.

- [ ] On step 3, leaving out the `--title`/`-t` option should leave the title unchanged in Connect.
- [ ] On step 3, specifying the `--title`/`-t` option should update the title in Connect.