### PR TITLE
Correct issues with title lifecycle.

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -672,7 +672,7 @@ def gather_basic_deployment_info_for_notebook(connect_server, app_store, file_na
     if not new and app_id is None:
         # Possible redeployment - check for saved metadata.
         # Use the saved app information unless overridden by the user.
-        app_id, title, app_mode = app_store.resolve(connect_server.url, app_id, title, app_mode)
+        app_id, app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
         if static and app_mode != AppModes.STATIC:
             raise api.RSConnectException('Cannot change app mode to "static" once deployed. '
                                          'Use --new to create a new deployment.')
@@ -711,7 +711,7 @@ def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_n
     if not new and app_id is None:
         # Possible redeployment - check for saved metadata.
         # Use the saved app information unless overridden by the user.
-        app_id, title, app_mode = app_store.resolve(connect_server.url, app_id, title, app_mode)
+        app_id, app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
 
     package_manager = source_manifest.get('python', {}).get('package_manager', {}).get('name', None)
     default_title = not bool(title)
@@ -799,7 +799,7 @@ def _gather_basic_deployment_info_for_framework(connect_server, app_store, direc
     if not new and app_id is None:
         # Possible redeployment - check for saved metadata.
         # Use the saved app information unless overridden by the user.
-        app_id, title, app_mode = app_store.resolve(connect_server.url, app_id, title, app_mode)
+        app_id, app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
 
     if directory[-1] == '/':
         directory = directory[:-1]

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -106,6 +106,7 @@ class RSConnect(HTTPServer):
 
         if app['title'] != app_title and not title_is_default:
             self._server.handle_bad_response(self.app_update(app_id, {'title': app_title}))
+            app['title'] = app_title
 
         app_bundle = self.app_upload(app_id, tarball)
 
@@ -120,6 +121,7 @@ class RSConnect(HTTPServer):
             'app_id': app_id,
             'app_guid': app['guid'],
             'app_url': app['url'],
+            'title': app['title'],
         }
 
     def wait_for_task(self, app_id, task_id, log_callback, timeout=None):

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -387,11 +387,11 @@ class AppStore(DataStore):
             app_mode=app_mode.name() if isinstance(app_mode, AppMode) else app_mode,
         ))
 
-    def resolve(self, server, app_id, title, app_mode):
+    def resolve(self, server, app_id, app_mode):
         metadata = self.get(server)
         if metadata is None:
             logger.debug('No previous deployment to this server was found; this will be a new deployment.')
-            return app_id, title, app_mode
+            return app_id, app_mode
 
         logger.debug('Found previous deployment data in %s' % self.get_path())
 
@@ -399,10 +399,6 @@ class AppStore(DataStore):
             app_id = metadata.get('app_guid') or metadata.get('app_id')
             logger.debug('Using saved app ID: %s' % app_id)
 
-        if title is None:
-            title = metadata.get('title')
-            logger.debug('Using saved title: "%s"' % title)
-
         # app mode cannot be changed on redeployment
         app_mode = AppModes.get_by_name(metadata.get('app_mode'))
-        return app_id, title, app_mode
+        return app_id, app_mode


### PR DESCRIPTION
### Description

This change completely corrects how we handle the lifecycle of the title of an app.  Before, if the title were changed in the Connect dashboard, it would be lost on a redeploy from the CLI, even if `--title` were not used.  The title for an app is now exactly what is expected in all cases.  Also the output of `rsconnect info` has been polished a bit.

Connected to https://github.com/rstudio/connect/issues/16895

### Testing Notes / Validation Steps

- [ ] New deploys should use the value of the `--title` option or a default one based on the file name (this has not changed; just make sure this isn't broken).  `rsconnect info` should reflect the correct title.
- [ ] Redeploys will now update the title only if the `--title` option is specified.
    - [ ] If it is specified, both the Connect dashboard and `rsconnect info` should reflect the given value.
    - [ ] If it is not specified, `rsconnect info` (after the deploy) should reflect the value shown by the Connect dashboard, even if the dashboard has been used to change the title since the previous deploy.

**Note:** The local value for the title (which is what's shown by `rsconnect info`) is only updated when a redeploy is performed.