### PR TITLE
Flip dir vs. manifest order.

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -221,8 +221,8 @@ def _get_names_to_check(file_or_directory):
     result = [file_or_directory]
 
     if isdir(file_or_directory):
-        result.append(join(file_or_directory, 'manifest.json'))
         result.append(fake_module_file_from_directory(file_or_directory))
+        result.append(join(file_or_directory, 'manifest.json'))
 
     return result
 


### PR DESCRIPTION
### Description

This change flips the check order for `rsconnect info` so that directory style is checked ahead of `manifest.json`.  That means that if an API or Dash app has been deployed both by `deploy api|dash` and by manifest, `info` will need to be given the full path to the manifest to see that deploy.

### Testing Notes / Validation Steps

See https://github.com/rstudio/connect/issues/16876#issuecomment-598905632