### PR TITLE
Do not automatically add an application object to the entrypoint

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -412,9 +412,6 @@ def validate_entry_point(entry_point):
     if not entry_point:
         entry_point = 'app'
 
-    if ':' not in entry_point:
-        entry_point = '%s:%s' % (entry_point, entry_point)
-
     parts = entry_point.split(':')
 
     if len(parts) > 2:
@@ -730,7 +727,7 @@ def gather_basic_deployment_info_for_api(connect_server, app_store, directory, e
     :param directory: the primary file being deployed.
     :param entry_point: the entry point for the API in '<module>:<object> format.  if
     the object name is omitted, it defaults to the module name.  If nothing is specified,
-    it defaults to 'app:app'.
+    it defaults to 'app'.
     :param new: a flag noting whether we should force a new deployment.
     :param app_id: the ID of the app to redeploy.
     :param title: an optional title.  If this isn't specified, a default title will
@@ -751,7 +748,7 @@ def gather_basic_deployment_info_for_dash(connect_server, app_store, directory, 
     :param directory: the primary file being deployed.
     :param entry_point: the entry point for the API in '<module>:<object> format.  if
     the object name is omitted, it defaults to the module name.  If nothing is specified,
-    it defaults to 'app:app'.
+    it defaults to 'app'.
     :param new: a flag noting whether we should force a new deployment.
     :param app_id: the ID of the app to redeploy.
     :param title: an optional title.  If this isn't specified, a default title will
@@ -773,7 +770,7 @@ def _gather_basic_deployment_info_for_framework(connect_server, app_store, direc
     :param directory: the primary file being deployed.
     :param entry_point: the entry point for the API in '<module>:<object> format.  if
     the object name is omitted, it defaults to the module name.  If nothing is specified,
-    it defaults to 'app:app'.
+    it defaults to 'app'.
     :param new: a flag noting whether we should force a new deployment.
     :param app_id: the ID of the app to redeploy.
     :param app_mode: the app mode to use.

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -489,7 +489,7 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
 @click.option('--cacert', '-c', envvar='CONNECT_CA_CERTIFICATE', type=click.File(),
               help='The path to trusted TLS CA certificates.')
 @click.option('--entrypoint', '-e', help='The module and executable object which serves as the entry point for the '
-                                         'WSGi framework of choice (defaults to app:app)')
+                                         'WSGi framework of choice (defaults to app)')
 @click.option('--exclude', '-x', multiple=True,
               help='Specify a glob pattern for ignoring files when building the bundle. Note that your shell may try '
                    'to expand this which will not do what you expect. Generally, it\'s safest to quote the pattern. '
@@ -530,7 +530,7 @@ def deploy_api(name, server, api_key, insecure, cacert, entrypoint, exclude, new
 @click.option('--cacert', '-c', envvar='CONNECT_CA_CERTIFICATE', type=click.File(),
               help='The path to trusted TLS CA certificates.')
 @click.option('--entrypoint', '-e', help='The module and executable object which serves as the entry point for the '
-                                         'Dash application (defaults to app:app)')
+                                         'Dash application (defaults to app)')
 @click.option('--exclude', '-x', multiple=True,
               help='Specify a glob pattern for ignoring files when building the bundle. Note that your shell may try '
                    'to expand this which will not do what you expect. Generally, it\'s safest to quote the pattern. '
@@ -686,7 +686,7 @@ def write_manifest_notebook(overwrite, python, conda, force_generate, verbose, f
                              'are created in the same directory as the API code.')
 @click.option('--overwrite', '-o', is_flag=True, help='Overwrite manifest.json, if it exists.')
 @click.option('--entrypoint', '-e', help='The module and executable object which serves as the entry point for the '
-                                         'WSGi framework of choice (defaults to app:app)')
+                                         'WSGi framework of choice (defaults to app)')
 @click.option('--exclude', '-x', multiple=True,
               help='Specify a glob pattern for ignoring files when building the bundle. Note that your shell may try '
                    'to expand this which will not do what you expect. Generally, it\'s safest to quote the pattern. '
@@ -715,7 +715,7 @@ def write_manifest_api(overwrite, entrypoint, exclude, python, conda, force_gene
                              'are created in the same directory as the API code.')
 @click.option('--overwrite', '-o', is_flag=True, help='Overwrite manifest.json, if it exists.')
 @click.option('--entrypoint', '-e', help='The module and executable object which serves as the entry point for the '
-                                         'Dash application (defaults to app:app)')
+                                         'Dash application (defaults to app)')
 @click.option('--exclude', '-x', multiple=True,
               help='Specify a glob pattern for ignoring files when building the bundle. Note that your shell may try '
                    'to expand this which will not do what you expect. Generally, it\'s safest to quote the pattern. '

--- a/rsconnect/tests/test_actions.py
+++ b/rsconnect/tests/test_actions.py
@@ -100,8 +100,9 @@ class TestActions(TestCase):
         _validate_title('1' * 1024)
 
     def test_validate_entry_point(self):
-        self.assertEqual(validate_entry_point(None), 'app:app')
-        self.assertEqual(validate_entry_point('app'), 'app:app')
+        self.assertEqual(validate_entry_point(None), 'app')
+        self.assertEqual(validate_entry_point('app'), 'app')
+        self.assertEqual(validate_entry_point('app:app'), 'app:app')
 
         with self.assertRaises(RSConnectException):
             validate_entry_point('x:y:z')


### PR DESCRIPTION
If the object name in the entrypoint is omitted, Connect will follow the default lookup order as outlined by Flask. First, looking for the app object under the names `app` or `application`, then looking for a factory function named `create_app` or `make_app` and calling it.

This is helpful because the Flask tutorial uses a factory function (so it won't work without this change and the corresponding Connect PR).
