### PR TITLE
Clarify Flask API unsupported error

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -234,7 +234,7 @@ def are_apis_supported_on_server(connect_details):
 
     :param connect_details: details about a Connect server as returned by gather_server_details()
     :return: boolean True if the Connect server supports Python APIs or not or False if not.
-    :error: The RStudio Connect does not allow for Python APIs.
+    :error: The RStudio Connect server does not allow for Python APIs.
     """
     return connect_details['python']['api_enabled']
 

--- a/rsconnect/tests/test_actions.py
+++ b/rsconnect/tests/test_actions.py
@@ -52,7 +52,7 @@ class TestActions(TestCase):
 
         with self.assertRaises(api.RSConnectException) as context:
             check_server_capabilities(None, (are_apis_supported_on_server,), lambda x: no_api_support)
-        self.assertEqual(str(context.exception), 'The RStudio Connect does not allow for Python APIs.')
+        self.assertEqual(str(context.exception), 'The RStudio Connect server does not allow for Python APIs.')
 
         check_server_capabilities(None, (are_apis_supported_on_server,), lambda x: api_support)
 


### PR DESCRIPTION
Connected to https://github.com/rstudio/connect/issues/17033

```
Checking server capabilities...                  ()
[ERROR]
Error: The RStudio Connect does not allow for Python APIs.
```

This PR adds the word "server" to the above error for clarity. 