### PR TITLE
#107: Keep cookie header from becoming unnecessarily large.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 *   Added more helpful feedback when a "requested object does not exist" error is
     returned by Connect.
 
+*   Fixed an issue where cookie header size could grow inappropriately (#107).
+
 
 `rsconnect-python` 1.4.1
 --------------------------------------------------------------------------------

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1,7 +1,7 @@
 import time
 from _ssl import SSLError
 
-from rsconnect.http_support import HTTPResponse, HTTPServer, append_to_path
+from rsconnect.http_support import HTTPResponse, HTTPServer, append_to_path, CookieJar
 from rsconnect.log import logger
 from rsconnect.models import AppModes
 
@@ -28,7 +28,7 @@ class RSConnectServer(object):
         self.insecure = insecure
         self.ca_data = ca_data
         # This is specifically not None.
-        self.cookie_jar = []
+        self.cookie_jar = CookieJar()
 
     def handle_bad_response(self, response):
         if isinstance(response, HTTPResponse):


### PR DESCRIPTION
### Description

This change replaces the ever-growing list approach to caching cookie values to a dictionary.  It appears with the right combination of clusters/reverse proxies, `rsconnect` could continually grow the value of the `Cookie` header to larger than can be handled.

Connected to #107 

### Testing Notes / Validation Steps

The key place where this error was appearing was during the printing out of the deploy task log output.  The longer the deploy log output, the more likely the error is to appear (prior to the fix).

- [ ] In a non-clustered environment, everything still works.
- [ ] In a clustered environment everything should still work.
- [ ] The presence of a load balancer should not cause this to appear.