### PR TITLE
Error clarification and final 1.4.2 stuff.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,14 @@
-`rsconnect-python` 1.4.2 -- Unreleased
+`rsconnect-python` 1.4.2
 --------------------------------------------------------------------------------
 *   Added more helpful feedback when a "requested object does not exist" error is
     returned by Connect.
 
 *   Fixed an issue where cookie header size could grow inappropriately (#107).
+
+*   Be more distinguishing between a server that's not running Connect and a
+    credentials problem.
+
+*   Corrected the auto-completion enabling instructions.
 
 
 `rsconnect-python` 1.4.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 *   Be more distinguishing between a server that's not running Connect and a
     credentials problem.
 
-*   Corrected the auto-completion enabling instructions.
+*   Corrected the instructions to enable auto-completion.
 
 
 `rsconnect-python` 1.4.1

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -294,11 +294,12 @@ def _validate_deploy_to_args(name, url, api_key, insecure, ca_cert, api_key_is_r
     if not real_server:
         raise api.RSConnectException('You must specify one of -n/--name or -s/--server.')
 
-    connect_server = api.RSConnectServer(real_server, api_key, insecure, ca_data)
+    connect_server = api.RSConnectServer(real_server, None, insecure, ca_data)
 
     # If our info came from the command line, make sure the URL really works.
     if not from_store:
         connect_server, _ = test_server(connect_server)
+        connect_server.api_key = api_key
 
     if not connect_server.api_key:
         if api_key_is_required:


### PR DESCRIPTION
### Description

This change makes a distinction in the error we show when talking to a URL that's not Connect vs. talking to Connect with a a bad API Key.  Also, finished up the `NEWS.md` file for 1.4.2 release.

Connected to #https://github.com/rstudio/connect/issues/17083

### Testing Notes / Validation Steps

- [ ] Invoking `rsconnect details -s <url> -k <bad-api-key>` will now show different errors between when the URL doesn't appear to be Connect vs. when the API Key is what's bad.