### PR TITLE
Fix typo in add command help text.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 *   Pin required versions of the `click` and `six` libraries that we use.
 
+*   Help text touch up.
+
 
 `rsconnect-python` 1.4.4
 --------------------------------------------------------------------------------

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -78,7 +78,7 @@ def _test_server_and_api(server, api_key, insecure, ca_cert):
 
 
 # noinspection SpellCheckingInspection
-@cli.command(short_help='Define a nickname for an RStuio Connect server.',
+@cli.command(short_help='Define a nickname for an RStudio Connect server.',
              help='Associate a simple nickname with the information needed to interact with an RStudio Connect server. '
                   'Specifying an existing nickname will cause its stored information to be replaced by what is given '
                   'on the command line.')


### PR DESCRIPTION
### Description

This change corrects a typo in the short help text for the `add` command.

Connected to #n/a

### Testing Notes / Validation Steps

- [ ] Proofread the change.