### PR TITLE
Set Python version from environment.yml if present.

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -73,6 +73,7 @@ def get_python_version(data):
             version = versions[0]
             if version.count('.') == 1:
                 version = version + '.0'
+            data['py_version_from_env_yaml'] = True
             return version
 
     v = sys.version_info

--- a/rsconnect/tests/test_environment.py
+++ b/rsconnect/tests/test_environment.py
@@ -16,7 +16,7 @@ class TestEnvironment(TestCase):
         return '.'.join(map(str, sys.version_info[:3]))
 
     def test_get_python_version(self):
-        self.assertEqual(get_python_version(), self.python_version())
+        self.assertEqual(get_python_version({'package_manager': 'pip'}), self.python_version())
 
     def test_get_default_locale(self):
         self.assertEqual(get_default_locale(lambda: ('en_US', 'UTF-8')), 'en_US.UTF-8')


### PR DESCRIPTION
### Description

This change updates environment detection to use the Python version noted in `environment.yml`.  Conda must be in play and the `environment.yml` must exist and contain a notation as to Python version.  Otherwise, the old behavior (current Python) is used.

Connected to #n/a

### Testing Notes / Validation Steps

- [ ] All non-manifest deploys still work as expected.
- [ ] All `write-manifest`s still work as expected.000