### PR TITLE
Give the user better feedback on some I/O errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 `rsconnect-python` 1.4.5
 --------------------------------------------------------------------------------
+*   Provide clearer feedback when errors happen while building bundles from a
+    manifest.
+
 *   Fix output alignment under Python 2.
 
 *   Pin required versions of the `click` and `six` libraries that we use.


### PR DESCRIPTION
### Description

This change catches I/O errors (such as file not found) that occur while building a bundle for deploying from a manifest.  Prior to this change, a traceback was displayed.  Now, the user is given proper guidance about next steps.

Connected to #https://github.com/rstudio/connect/issues/17262

### Testing Notes / Validation Steps

See https://github.com/rstudio/connect/issues/17262#issuecomment-615270088

Now, more appropriate error information and next step guidance will be displayed.

- [ ] Proofread new feedback for completeness and correctness.