### PR TITLE
Make Conda support completely opt-in with appropriate messaging.

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -96,7 +96,7 @@ def which_python(python, env=os.environ):
     return sys.executable
 
 
-def inspect_environment(python, directory, compatibility_mode=False, force_generate=False,
+def inspect_environment(python, directory, conda_mode=False, force_generate=False,
                         check_output=subprocess.check_output):
     """Run the environment inspector using the specified python binary.
 
@@ -104,7 +104,7 @@ def inspect_environment(python, directory, compatibility_mode=False, force_gener
     or containing an "error" field if an error occurred.
     """
     flags = []
-    if compatibility_mode:
+    if conda_mode:
         flags.append('c')
     if force_generate:
         flags.append('f')
@@ -808,15 +808,14 @@ def _gather_basic_deployment_info_for_framework(connect_server, app_store, direc
         app_mode
 
 
-def get_python_env_info(file_name, python, compatibility_mode, force_generate):
+def get_python_env_info(file_name, python, conda_mode, force_generate):
     """
     Gathers the python and environment information relating to the specified file
     with an eye to deploy it.
 
     :param file_name: the primary file being deployed.
     :param python: the optional name of a Python executable.
-    :param compatibility_mode: force freezing the current environment using pip
-    instead of conda, when conda is not supported on RStudio Connect (version<=1.8.0).
+    :param conda_mode: inspect the environment assuming Conda
     :param force_generate: force generating "requirements.txt" or "environment.yml",
     even if it already exists.
     :return: information about the version of Python in use plus some environmental
@@ -824,8 +823,7 @@ def get_python_env_info(file_name, python, compatibility_mode, force_generate):
     """
     python = which_python(python)
     logger.debug('Python: %s' % python)
-    environment = inspect_environment(python, dirname(file_name), compatibility_mode=compatibility_mode,
-                                      force_generate=force_generate)
+    environment = inspect_environment(python, dirname(file_name), conda_mode=conda_mode, force_generate=force_generate)
     if 'error' in environment:
         raise api.RSConnectException(environment['error'])
     logger.debug('Python: %s' % python)

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -46,7 +46,8 @@ def detect_environment(dirname, force_generate=False, conda_mode=False, conda=No
 
     if result is not None:
         if conda_mode and result['package_manager'] != 'conda':
-            return {'error': 'Conda was requested but no Conda environment was found.'}
+            return {'error': 'Conda was requested but no activated Conda environment was found. See "conda activate '
+                             '--help" for more information.'}
 
         result['python'] = get_python_version(result)
         result['pip'] = get_version('pip')

--- a/rsconnect/tests/test_environment.py
+++ b/rsconnect/tests/test_environment.py
@@ -67,7 +67,7 @@ class TestEnvironment(TestCase):
     def test_conda_env_export(self):
         fake_conda = join(dirname(__file__), 'testdata', 'fake_conda.sh')
         result = detect_environment(
-            get_dir('conda1'), compatibility_mode=False, force_generate=True, conda=fake_conda
+            get_dir('conda1'), conda_mode=True, force_generate=True, conda=fake_conda
         )
         self.assertEqual(result['source'], 'conda_env_export')
         self.assertEqual(result['conda'], '1.0.0')
@@ -75,6 +75,6 @@ class TestEnvironment(TestCase):
 
         fake_broken_conda = join(dirname(__file__), 'testdata', 'fake_broken_conda.sh')
         self.assertRaises(
-            EnvironmentException, detect_environment, get_dir('conda1'), compatibility_mode=False,
+            EnvironmentException, detect_environment, get_dir('conda1'), conda_mode=True,
             force_generate=True, conda=fake_broken_conda
         )


### PR DESCRIPTION
### Description

This change makes support for Conda environments a completely opt-in exercise.  Prior to this, it would attempt to auto-detect and, if an active Conda environment was found, would deploy using Conda semantics even without the `--conda` command line option.  This led to some confusing situations.  Some things to note:

- If `--conda` is specified but no active Conda environment exists, an error is now produced.
- If `--conda` is _not_ specified but there _is_ an active Conda environment, a note about that is shown to the user noting that `pip` will be used for the deploy and the Conda env will be ignored.

    > **Note:** To avoid prematurely advertising Conda support, this message is only displayed if the `--future` flag is included; without that flag the message is suppressed.

Connected to https://github.com/rstudio/connect/issues/17291
Connected to https://github.com/rstudio/connect/issues/17292

### Reviewer Notes

This change required replacing references to `compatibility_mode` with `conda_mode` and had the effect of flipping the meaningful value.  Special attention should be paid here.

### Testing Notes / Validation Steps

- [ ] Specifying the `--conda` flag on all Python-type content `deploy` and `write-manifest` commands where no Conda env is present should produce an error.
- [ ] Leaving the `--conda` flag off on all Python-type content `deploy` and `write-manifest` commands should deploy using `pip` semantics both with and without an active Conda env.
- [ ] Leaving off the `--conda` flag on all Python-type content `deploy` and `write-manifest` commands when there is an active Conda environment should produce a note to the user about the package manager that will be used.  **Note:** You must specify the `--future` flag immediately after `rsconnect` for this message to appear; it is conditionally hidden until the `--conda` flag itself is no longer hidden.