### PR TITLE
Revert the usage of the --from-history Conda option.

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -188,7 +188,7 @@ def conda_env_export(conda):
     """
     try:
         proc = subprocess.Popen(
-            [conda, 'env', 'export', '--from-history'], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            [conda, 'env', 'export'], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             universal_newlines=True)
         conda_stdout, conda_stderr = proc.communicate()
         conda_status = proc.returncode


### PR DESCRIPTION
### Description

This change removes the `--from-history` flag from the `conda env export` command we use to freeze the environment.  Having the flag allows for less specificity, especially of Python version, than we want to cope with.

Connected to https://github.com/rstudio/connect/issues/17329

### Testing Notes / Validation Steps

- [ ] The issues brought up in the connected issue should no longer occur.