### PR TITLE
We need better HTTP timeout handling.

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -51,10 +51,12 @@ class RSConnectServer(object):
 
 
 class RSConnect(HTTPServer):
-    def __init__(self, server, cookies=None):
+    def __init__(self, server, cookies=None, timeout=30):
         if cookies is None:
             cookies = server.cookie_jar
-        super(RSConnect, self).__init__(append_to_path(server.url, '__api__'), server.insecure, server.ca_data, cookies)
+        super(RSConnect, self).__init__(
+            append_to_path(server.url, '__api__'), server.insecure, server.ca_data, cookies, timeout
+        )
         self._server = server
 
         if server.api_key:
@@ -280,7 +282,7 @@ def do_bundle_deploy(connect_server, app_id, name, title, title_is_default, bund
     :return: application information about the deploy.  This includes the ID of the
     task that may be queried for deployment progress.
     """
-    with RSConnect(connect_server) as client:
+    with RSConnect(connect_server, timeout=120) as client:
         result = client.deploy(app_id, name, title, title_is_default, bundle)
         connect_server.handle_bad_response(result)
         return result

--- a/rsconnect/tests/test_http_support.py
+++ b/rsconnect/tests/test_http_support.py
@@ -13,7 +13,7 @@ class TestHTTPSupport(TestCase):
 
     def test_create_ssl_checks(self):
         with self.assertRaises(ValueError):
-            _create_ssl_connection(None, None, True, 'fake')
+            _create_ssl_connection(None, None, True, 'fake', 10)
 
     def test_append_to_path(self):
         self.assertEqual(append_to_path('path/', '/sub'), 'path/sub')


### PR DESCRIPTION
### Description

Our HTTP client support was using an often too-short timeout value.  It would especially fire on the deployment of large bundles.  This change makes the HTTP client timeout values easier to specify and, for bundle deploys, specifies a larger value.

* Deploy bundle calls now have a timeout of 2 minutes.
* All other calls now have a timeout of 30 seconds.

Connected to #n/a

### Testing Notes / Validation Steps

- [ ] Timeouts should now obey the above rules.