### PR TITLE
Exclude known virtualenv dirs from bundle

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -14,12 +14,16 @@ from rsconnect.models import AppModes, GlobSet
 # From https://github.com/rstudio/rsconnect/blob/485e05a26041ab8183a220da7a506c9d3a41f1ff/R/bundle.R#L85-L88
 # noinspection SpellCheckingInspection
 directories_to_ignore = [
-    "rsconnect/",
-    "rsconnect-python/",
-    "packrat/",
-    ".svn/",
-    ".git/",
     ".Rproj.user/",
+    ".env/",
+    ".git/",
+    ".svn/",
+    ".venv/",
+    "env/",
+    "packrat/",
+    "rsconnect-python/",
+    "rsconnect/",
+    "venv/",
 ]
 
 

--- a/rsconnect/tests/test_bundle.py
+++ b/rsconnect/tests/test_bundle.py
@@ -194,6 +194,10 @@ class TestBundle(TestCase):
         self.assertTrue(keep_manifest_specified_file("rsconnect-python"))
         self.assertFalse(keep_manifest_specified_file("rsconnect-python/bogus.file"))
         self.assertFalse(keep_manifest_specified_file(".svn/bogus.file"))
+        self.assertFalse(keep_manifest_specified_file(".env/share/jupyter/kernels/python3/kernel.json"))
+        self.assertFalse(keep_manifest_specified_file(".venv/bin/activate"))
+        self.assertFalse(keep_manifest_specified_file("env/pyvenv.cfg"))
+        self.assertFalse(keep_manifest_specified_file("venv/lib/python3.8/site-packages/wheel/__init__.py"))
         # noinspection SpellCheckingInspection
         self.assertFalse(keep_manifest_specified_file(".Rproj.user/bogus.file"))
 


### PR DESCRIPTION
### Description

...as described in connected issue.

This change explicitly _does not_ attempt to tackle the concept of an `.rscignore` file. I would like to do that work, but I believe it is a good bit more involved given how many functions currently exist with the expectation that a list of excludes are optionally provided.

Connected to rstudio/connect#17267

### Testing Notes / Validation Steps

- in-repo virtualenv directories of the following names are automatically excluded from the bundle:
    - `.env/`
    - `.venv/`
    - `env/`
    - `venv/`