### PR TITLE
Add bokeh

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -550,7 +550,7 @@ def deploy_python_api(
     and network latency, this may take a bit of time.
 
     :param connect_server: the Connect server information.
-    :param directory: the Jupyter notebook file to deploy.
+    :param directory: the app directory to deploy.
     :param extra_files: any extra files that should be included in the deploy.
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
@@ -606,7 +606,7 @@ def deploy_dash_app(
     and network latency, this may take a bit of time.
 
     :param connect_server: the Connect server information.
-    :param directory: the Jupyter notebook file to deploy.
+    :param directory: the app directory to deploy.
     :param extra_files: any extra files that should be included in the deploy.
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
@@ -662,7 +662,7 @@ def deploy_streamlit_app(
     and network latency, this may take a bit of time.
 
     :param connect_server: the Connect server information.
-    :param directory: the Jupyter notebook file to deploy.
+    :param directory: the app directory to deploy.
     :param extra_files: any extra files that should be included in the deploy.
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
@@ -699,6 +699,62 @@ def deploy_streamlit_app(
     )
 
 
+def deploy_bokeh_app(
+    connect_server,
+    directory,
+    extra_files,
+    excludes,
+    entry_point,
+    new=False,
+    app_id=None,
+    title=None,
+    python=None,
+    compatibility_mode=False,
+    force_generate=False,
+    log_callback=None,
+):
+    """
+    A function to deploy a Python Bokeh app module to Connect.  Depending on the files involved
+    and network latency, this may take a bit of time.
+
+    :param connect_server: the Connect server information.
+    :param directory: the app directory to deploy.
+    :param extra_files: any extra files that should be included in the deploy.
+    :param excludes: a sequence of glob patterns that will exclude matched files.
+    :param entry_point: the module/executable object for the WSGi framework.
+    :param new: a flag to force this as a new deploy.
+    :param app_id: the ID of an existing application to deploy new files for.
+    :param title: an optional title for the deploy.  If this is not provided, ne will
+    be generated.
+    :param python: the optional name of a Python executable.
+    :param compatibility_mode: force freezing the current environment using pip
+    instead of conda, when conda is not supported on RStudio Connect (version<=1.8.0).
+    :param force_generate: force generating "requirements.txt" or "environment.yml",
+    even if it already exists.
+    :param log_callback: the callback to use to write the log to.  If this is None
+    (the default) the lines from the deployment log will be returned as a sequence.
+    If a log callback is provided, then None will be returned for the log lines part
+    of the return tuple.
+    :return: the ultimate URL where the deployed app may be accessed and the sequence
+    of log lines.  The log lines value will be None if a log callback was provided.
+    """
+    return _deploy_by_python_framework(
+        connect_server,
+        directory,
+        extra_files,
+        excludes,
+        entry_point,
+        gather_basic_deployment_info_for_bokeh,
+        new,
+        app_id,
+        title,
+        python,
+        compatibility_mode,
+        force_generate,
+        log_callback,
+    )
+
+
 def _deploy_by_python_framework(
     connect_server,
     directory,
@@ -719,7 +775,7 @@ def _deploy_by_python_framework(
     and network latency, this may take a bit of time.
 
     :param connect_server: the Connect server information.
-    :param directory: the Jupyter notebook file to deploy.
+    :param directory: the app directory to deploy.
     :param extra_files: any extra files that should be included in the deploy.
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
@@ -929,6 +985,7 @@ def _generate_gather_basic_deployment_info_for_python(app_mode):
 gather_basic_deployment_info_for_api = _generate_gather_basic_deployment_info_for_python(AppModes.PYTHON_API)
 gather_basic_deployment_info_for_dash = _generate_gather_basic_deployment_info_for_python(AppModes.DASH_APP)
 gather_basic_deployment_info_for_streamlit = _generate_gather_basic_deployment_info_for_python(AppModes.STREAMLIT_APP)
+gather_basic_deployment_info_for_bokeh = _generate_gather_basic_deployment_info_for_python(AppModes.BOKEH_APP)
 
 
 def _gather_basic_deployment_info_for_framework(

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -18,6 +18,7 @@ from rsconnect.actions import (
     gather_basic_deployment_info_for_api,
     gather_basic_deployment_info_for_dash,
     gather_basic_deployment_info_for_streamlit,
+    gather_basic_deployment_info_for_bokeh,
     gather_basic_deployment_info_for_notebook,
     gather_basic_deployment_info_from_manifest,
     gather_server_details,
@@ -765,6 +766,7 @@ def generate_deploy_python(app_mode, alias):
                 AppModes.PYTHON_API: gather_basic_deployment_info_for_api,
                 AppModes.DASH_APP: gather_basic_deployment_info_for_dash,
                 AppModes.STREAMLIT_APP: gather_basic_deployment_info_for_streamlit,
+                AppModes.BOKEH_APP: gather_basic_deployment_info_for_bokeh,
             }[app_mode],
         )
 
@@ -774,6 +776,7 @@ def generate_deploy_python(app_mode, alias):
 deploy_api = generate_deploy_python(app_mode=AppModes.PYTHON_API, alias="api")
 deploy_dash_app = generate_deploy_python(app_mode=AppModes.DASH_APP, alias="dash")
 deploy_streamlit_app = generate_deploy_python(app_mode=AppModes.STREAMLIT_APP, alias="streamlit")
+deploy_bokeh_app = generate_deploy_python(app_mode=AppModes.BOKEH_APP, alias="bokeh")
 
 
 # noinspection SpellCheckingInspection
@@ -797,7 +800,7 @@ def _deploy_by_framework(
     gatherer,
 ):
     """
-    A common function for deploying APIs, Dash and Streamlit apps, etc.
+    A common function for deploying APIs, as well as Dash, Streamlit, and Bokeh apps.
 
     :param name: the nickname of the Connect server to use.
     :param server: the URL of the Connect server to use.
@@ -1009,6 +1012,7 @@ def generate_write_manifest_python(app_mode, alias):
 write_manifest_api = generate_write_manifest_python(AppModes.PYTHON_API, alias="api")
 write_manifest_dash = generate_write_manifest_python(AppModes.DASH_APP, alias="dash")
 write_manifest_streamlit = generate_write_manifest_python(AppModes.STREAMLIT_APP, alias="streamlit")
+write_manifest_bokeh = generate_write_manifest_python(AppModes.BOKEH_APP, alias="bokeh")
 
 
 # noinspection SpellCheckingInspection
@@ -1016,7 +1020,7 @@ def _write_framework_manifest(
     overwrite, entrypoint, exclude, python, conda, force_generate, verbose, directory, extra_files, app_mode,
 ):
     """
-    A common function for writing manifests for APIs, Dash & Streamlit apps, etc.
+    A common function for writing manifests for APIs as well as Dash, Streamlit, and Bokeh apps.
 
     :param overwrite: overwrite the manifest.json, if it exists.
     :param entrypoint: the entry point for the thing being deployed.

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -46,6 +46,7 @@ class AppModes(object):
     PYTHON_API = AppMode(8, "python-api", "Python API")
     DASH_APP = AppMode(9, "python-dash", "Dash Application")
     STREAMLIT_APP = AppMode(10, "python-streamlit", "Streamlit Application")
+    BOKEH_APP = AppMode(11, "python-bokeh", "Bokeh Application")
 
     _modes = [
         UNKNOWN,
@@ -59,6 +60,7 @@ class AppModes(object):
         PYTHON_API,
         DASH_APP,
         STREAMLIT_APP,
+        BOKEH_APP,
     ]
 
     @classmethod

--- a/rsconnect/tests/test_actions.py
+++ b/rsconnect/tests/test_actions.py
@@ -27,6 +27,7 @@ from rsconnect.actions import (
     deploy_python_api,
     deploy_dash_app,
     deploy_streamlit_app,
+    deploy_bokeh_app,
     gather_basic_deployment_info_for_api,
     create_notebook_deployment_bundle,
     create_api_deployment_bundle,
@@ -245,6 +246,32 @@ class TestActions(TestCase):
 
     def test_deploy_streamlit_app_docs(self):
         self.assertTrue("Streamlit app" in deploy_streamlit_app.__doc__)
+
+    def test_deploy_bokeh_app_signature(self):
+        self.assertEqual(
+            str(signature(deploy_bokeh_app)),
+            "({})".format(
+                ", ".join(
+                    [
+                        "connect_server",
+                        "directory",
+                        "extra_files",
+                        "excludes",
+                        "entry_point",
+                        "new=False",
+                        "app_id=None",
+                        "title=None",
+                        "python=None",
+                        "compatibility_mode=False",
+                        "force_generate=False",
+                        "log_callback=None",
+                    ]
+                )
+            ),
+        )
+
+    def test_deploy_bokeh_app_docs(self):
+        self.assertTrue("Bokeh app" in deploy_bokeh_app.__doc__)
 
     def test_gather_basic_deployment_info_for_api_validates(self):
         directory = get_api_path("flask")

--- a/rsconnect/tests/test_models.py
+++ b/rsconnect/tests/test_models.py
@@ -29,8 +29,8 @@ class TestModels(TestCase):
         descriptions = []
         extensions = []
 
-        self.assertEqual(len(defined), 11)
-        self.assertEqual(len(modes), 11)
+        self.assertEqual(len(defined), 12)
+        self.assertEqual(len(modes), 12)
 
         # This makes sure all named mode constants appear in the modes list.
         for name in defined:


### PR DESCRIPTION
### Description

Adds `python-bokeh` as a known app mode for manifest creation and deployment.

### Testing Notes / Validation Steps
Deploy a bokeh app with `rsconnect deploy bokeh`. Create a manifest with `rsconnect write-manifest bokeh` and deploy using that manifest.
