### PR TITLE
Explicitly add importlib-metadata as dev dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ funcsigs = "*"
 ipython = "*"
 pytest = "*"
 pytest-cov = "*"
+importlib-metadata = "*"
 
 [packages]
 click = ">=7.0.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8772116de801ee99bb6fa1254e478fa5f2dc5b0dc4ba79e4f80bf65ae2be9bdf"
+            "sha256": "67aeeb23ef1a428e7318be4b3b0ab0101eda72fed75fb9f108f0e679b41aac92"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -475,6 +475,14 @@
             "index": "pypi",
             "version": "==1.0.2"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
+                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+            ],
+            "index": "pypi",
+            "version": "==1.6.0"
+        },
         "ipython": {
             "hashes": [
                 "sha256:5b241b84bbf0eb085d43ae9d46adf38a13b45929ca7774a740990c2c242534bb",
@@ -710,6 +718,14 @@
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.1.0"
         }
     }
 }


### PR DESCRIPTION
### Description

as this is needed by pluggy, but pluggy or some other package doesn't
declare it as a dependency, probably because it's stdlib in Python 3.8+

### Testing Notes / Validation Steps

everything still works, and running tests locally via docker works for all pythons