### PR TITLE
Better error message on app mode mismatch

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1035,7 +1035,14 @@ def _gather_basic_deployment_info_for_framework(
     if not new and app_id is None:
         # Possible redeployment - check for saved metadata.
         # Use the saved app information unless overridden by the user.
-        app_id, app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
+        app_id, existing_app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
+        if existing_app_mode and app_mode != existing_app_mode:
+            msg = (
+                "Deploying with mode '%s',\n"
+                + "but the existing deployment has mode '%s'.\n"
+                + "Use the --new option to create a new deployment of the desired type."
+            ) % (app_mode.desc(), existing_app_mode.desc())
+            raise api.RSConnectException(msg)
 
     if directory[-1] == "/":
         directory = directory[:-1]


### PR DESCRIPTION
### Description

This PR adds a check of the app mode being deployed vs. the saved metadata. A mismatch is considered an error, since the deployment will fail at Connect if allowed to proceed. A message is shown advising use of `--new` to create a new deployment on the desired type. 

Connected to #https://github.com/rstudio/connect/issues/17727

### Testing Notes / Validation Steps
* Deploy an app or API.
* Attempt to redeploy the same directory as a different app mode. It should fail showing the message.
* Redeploy the same directory as the original app mode. It should succeed.
