### PR TITLE
Insulate against not-yet-generated version.py

### DIFF
--- a/rsconnect/__init__.py
+++ b/rsconnect/__init__.py
@@ -1,1 +1,4 @@
-from rsconnect.version import version as VERSION  # noqa
+try:
+    from rsconnect.version import version as VERSION  # noqa
+except ImportError:
+    VERSION = "NOTSET"  # noqa


### PR DESCRIPTION
### Description

So that attempts to use from source don't immediately explode.

Connected to rstudio/connect#17745

### Testing Notes / Validation Steps

- library is usable from a fresh git clone, albeit without version information