### PR TITLE
Run macos tests on python 3.8 only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,11 @@ jobs:
     strategy:
       matrix:
         # TODO: work on windows-latest compatibility?
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         python-version: ['2.7', '3.5', '3.6', '3.7', '3.8']
+        include:
+        - os: macos-latest
+          python-version: '3.8'
     runs-on: ${{ matrix.os }}
     name: test (py${{ matrix.python-version }} ${{ matrix.os }})
     steps:


### PR DESCRIPTION
### Description

So that the net CI runtime isn't creeping towards 15 minutes.

### Testing Notes / Validation Steps

- tests are not run on `macos-latest` for any python versions other than `3.8`