### PR TITLE
Address a few nits and a bug

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -188,7 +188,7 @@ def test_server(connect_server):
     key = connect_server.api_key
     insecure = connect_server.insecure
     ca_data = connect_server.ca_data
-    failures = ["Invalid server URL: %s" % url]
+    failures = []
     for test in _to_server_check_list(url):
         try:
             connect_server = api.RSConnectServer(test, key, insecure, ca_data)
@@ -198,8 +198,8 @@ def test_server(connect_server):
             failures.append("    %s - failed to verify as RStudio Connect." % test)
 
     # In case the user may need https instead of http...
-    if len(failures) == 2 and url.startswith("http://"):
-        failures.append('    Do you need to use "https://%s?"' % url[7:])
+    if len(failures) == 1 and url.startswith("http://"):
+        failures.append('    Do you need to use "https://%s"?' % url[7:])
 
     # If we're here, nothing worked.
     raise api.RSConnectException("\n".join(failures))

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -47,7 +47,7 @@ class RSConnectServer(object):
                         error = "The Connect server reported an error: %s" % response.json_data["error"]
                     raise RSConnectException(error)
                 raise RSConnectException(
-                    "Received and unexpected response from RStudio Connect: %s %s" % (response.status, response.reason)
+                    "Received an unexpected response from RStudio Connect: %s %s" % (response.status, response.reason)
                 )
 
 

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -75,10 +75,10 @@ def detect_environment(dirname, force_generate=False, conda_mode=False, conda=No
 
     if result is not None:
         if conda_mode and result["package_manager"] != "conda":
-            return {
-                "error": 'Conda was requested but no activated Conda environment was found. See "conda activate '
+            return Environment(
+                error='Conda was requested but no activated Conda environment was found. See "conda activate '
                 '--help" for more information.'
-            }
+            )
 
         result["python"] = get_python_version(Environment(**result))
         result["pip"] = get_version("pip")


### PR DESCRIPTION
### Description

found during rsconnect-juptyer testing

Connected to rstudio/connect#17780

### Testing Notes / Validation Steps

- deployment via `rsconnect-jupyter` does not fail when the `conda` path is taken