### PR TITLE
Use an alternate token for repo dispatch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,7 +157,7 @@ jobs:
     steps:
     - uses: actions/github-script@v2
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.DISPATCH_TOKEN }}
         script: |
           github.repos.createDispatchEvent({
             owner: 'rstudio',


### PR DESCRIPTION
### Description

as the default `GITHUB_TOKEN` generated in actions does not have the necessary scope to create a repo dispatch event on rstudio/rsconnect-jupyter

Connected to rstudio/connect#17604

### Testing Notes / Validation Steps

- once merged, any `push` events to `master` will trigger the `dispatch` job, and it will actually work