### PR TITLE
Ensure latest wheel is not cached

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,5 +147,6 @@ sync-to-s3:
 .PHONY: sync-latest-to-s3
 sync-latest-to-s3:
 	aws s3 cp --acl bucket-owner-full-control \
+		--cache-control max-age=0 \
 		$(BDIST_WHEEL) \
 		$(S3_PREFIX)/latest/rsconnect_python-latest-py2.py3-none-any.whl


### PR DESCRIPTION
### Description

so that it really is latest

Connected to rstudio/connect#17604

### Testing Notes / Validation Steps

- the object pulled through the CDN at <https://cdn.rstudio.com/connect/rsconnect-python/latest/rsconnect_python-latest-py2.py3-none-any.whl> should always match the most recently uploaded object