### PR TITLE
Only write to __doc__ attr in python3.6+

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -40,9 +40,7 @@ else:
         ("conda", "contents", "error", "filename", "locale", "package_manager", "pip", "python", "source",),
         defaults=(None, "", None, "", "", "", None, None, None),
     )
-
-
-Environment.__doc__ = "Data class encapsulating values needed by various deployment and metadata functions"
+    Environment.__doc__ = "Data class encapsulating values needed by various deployment and metadata functions"
 
 
 class EnvironmentException(Exception):


### PR DESCRIPTION
### Description

because it is seemingly, inconsistently not allowed in python2 (and maybe others?)

Connected to rstudio/connect#17604

### Testing Notes / Validation Steps

this error doesn't happen anymore:

```
[2020-06-26T20:47:59.448Z] #   Traceback (most recent call last):
[2020-06-26T20:47:59.448Z] #     File "/connect/test/rsconnect-python/env_python2/bin/rsconnect", line 5, in <module>
[2020-06-26T20:47:59.448Z] #       from rsconnect.main import cli
[2020-06-26T20:47:59.448Z] #     File "/connect/test/rsconnect-python/env_python2/local/lib/python2.7/site-packages/rsconnect/main.py", line 10, in <module>
[2020-06-26T20:47:59.448Z] #       from rsconnect.actions import (
[2020-06-26T20:47:59.448Z] #     File "/connect/test/rsconnect-python/env_python2/local/lib/python2.7/site-packages/rsconnect/actions.py", line 23, in <module>
[2020-06-26T20:47:59.448Z] #       from .bundle import (
[2020-06-26T20:47:59.448Z] #     File "/connect/test/rsconnect-python/env_python2/local/lib/python2.7/site-packages/rsconnect/bundle.py", line 22, in <module>
[2020-06-26T20:47:59.448Z] #       from rsconnect.environment import Environment
[2020-06-26T20:47:59.448Z] #     File "/connect/test/rsconnect-python/env_python2/local/lib/python2.7/site-packages/rsconnect/environment.py", line 45, in <module>
[2020-06-26T20:47:59.448Z] #       Environment.__doc__ = "Data class encapsulating values needed by various deployment and metadata functions"
[2020-06-26T20:47:59.448Z] #   AttributeError: attribute '__doc__' of 'type' objects is not writable
``` 