### PR TITLE
Fix python2 encoding issue

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -31,7 +31,7 @@ from .bundle import (
     manifest_add_file,
     read_manifest_file,
 )
-from .environment import Environment, EnvironmentException
+from .environment import Environment, MakeEnvironment, EnvironmentException
 from .log import logger
 from .metadata import AppStore
 from .models import AppModes
@@ -141,7 +141,7 @@ def inspect_environment(
         environment_json = check_output(args, universal_newlines=True)
     except subprocess.CalledProcessError as e:
         raise api.RSConnectException("Error inspecting environment: %s" % e.output)
-    return Environment(**json.loads(environment_json))  # type: ignore
+    return MakeEnvironment(**json.loads(environment_json))  # type: ignore
 
 
 def _verify_server(connect_server):

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -96,8 +96,11 @@ def buffer_checksum(buf):
 
 
 def to_bytes(s):
-    if hasattr(s, "encode"):
+    if isinstance(s, bytes):
+        return s
+    elif hasattr(s, "encode"):
         return s.encode("utf-8")
+    logger.warning("can't encode to bytes: %s" % type(s).__name__)
     return s
 
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -42,7 +42,7 @@ from rsconnect.actions import (
     which_python,
 )
 from rsconnect.api import RSConnectException, RSConnectServer
-from rsconnect.environment import Environment
+from rsconnect.environment import MakeEnvironment
 
 from .test_data_util import get_manifest_path, get_api_path, get_dir
 
@@ -322,7 +322,7 @@ class TestActions(TestCase):
             False,
             False,
             sys.executable,
-            Environment(
+            MakeEnvironment(
                 conda=None,
                 filename="requirements.txt",
                 locale="en_US.UTF-8",
@@ -337,7 +337,7 @@ class TestActions(TestCase):
             False,
             False,
             sys.executable,
-            Environment(
+            MakeEnvironment(
                 conda=None,
                 filename="requirements.txt",
                 locale="en_US.UTF-8",
@@ -352,7 +352,7 @@ class TestActions(TestCase):
             True,
             True,
             "/very/serious/whython",
-            Environment(
+            MakeEnvironment(
                 conda="/opt/Conda/bin/conda",
                 filename="requirements.txt",
                 locale="en_US.UTF-8",
@@ -367,7 +367,7 @@ class TestActions(TestCase):
             False,
             True,
             "unused",
-            Environment(error="Could not even do things"),
+            MakeEnvironment(error="Could not even do things"),
             id="exploding",
         ),
     ],

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import sys
 import tarfile
@@ -12,6 +13,7 @@ from rsconnect.bundle import (
     make_notebook_html_bundle,
     make_notebook_source_bundle,
     keep_manifest_specified_file,
+    to_bytes,
 )
 from .test_data_util import get_dir
 
@@ -20,6 +22,17 @@ class TestBundle(TestCase):
     @staticmethod
     def python_version():
         return u".".join(map(str, sys.version_info[:3]))
+
+    def test_to_bytes(self):
+        self.assertEqual(to_bytes(b"abc123"), b"abc123")
+        self.assertEqual(to_bytes(b"\xc3\xa5bc123"), b"\xc3\xa5bc123")
+        self.assertEqual(to_bytes(b"\xff\xffabc123"), b"\xff\xffabc123")
+
+        self.assertEqual(to_bytes("abc123"), b"abc123")
+        self.assertEqual(to_bytes("åbc123"), b"\xc3\xa5bc123")
+
+        self.assertEqual(to_bytes(u"abc123"), b"abc123")
+        self.assertEqual(to_bytes(u"åbc123"), b"\xc3\xa5bc123")
 
     def test_source_bundle1(self):
         self.maxDiff = 5000

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -7,6 +7,7 @@ from os.path import dirname, join
 from rsconnect.environment import (
     Environment,
     EnvironmentException,
+    MakeEnvironment,
     detect_environment,
     get_default_locale,
     get_python_version,
@@ -23,7 +24,7 @@ class TestEnvironment(TestCase):
 
     def test_get_python_version(self):
         self.assertEqual(
-            get_python_version(Environment(package_manager="pip")), self.python_version(),
+            get_python_version(MakeEnvironment(package_manager="pip")), self.python_version(),
         )
 
     def test_get_default_locale(self):
@@ -40,7 +41,7 @@ class TestEnvironment(TestCase):
         self.assertIsInstance(result.locale, str)
         self.assertIn(".", result.locale)
 
-        expected = Environment(
+        expected = MakeEnvironment(
             contents="numpy\npandas\nmatplotlib\n",
             filename="requirements.txt",
             locale=result.locale,
@@ -63,7 +64,7 @@ class TestEnvironment(TestCase):
         self.assertIsInstance(result.locale, str)
         self.assertIn(".", result.locale)
 
-        expected = Environment(
+        expected = MakeEnvironment(
             contents=result.contents,
             filename="requirements.txt",
             locale=result.locale,


### PR DESCRIPTION
### Description

This PR fixes `to_bytes` so it doesn't attempt to re-encode bytes objects.

Connected to #156 

### Testing Notes / Validation Steps

Use rsconnect-jupyter to publish a notebook that includes binary data in output cells.

For example, create a notebook with an input cell `!cat filename.jpeg` (where filename.jpeg is a file in the notebook directory). Execute the input cell, then attempt to publish the notebook.
