### PR TITLE
Preserve exception details

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -198,8 +198,8 @@ def test_server(connect_server):
             connect_server = api.RSConnectServer(test, key, insecure, ca_data)
             result = _verify_server(connect_server)
             return connect_server, result
-        except api.RSConnectException:
-            failures.append("    %s - failed to verify as RStudio Connect." % test)
+        except api.RSConnectException as exc:
+            failures.append("    %s - failed to verify as RStudio Connect (%s)." % (test, str(exc)))
 
     # In case the user may need https instead of http...
     if len(failures) == 1 and url.startswith("http://"):


### PR DESCRIPTION
### Description

This PR preserves the details of exceptions from `verify_server`. Currently, the detailed exception messages are being discarded and they are valuable for troubleshooting.

Connected to #155

### Testing Notes / Validation Steps
Create various error conditions when adding a server via `rsconnect add`:
* a hostname that cannot be resolved
* incorrect port number
* user http when https is required

Verify that the exception details are shown. Also try this in rsconnect-jupyter's Add Server window.
