### PR TITLE
Don't delete from s3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ sync-latest-to-s3:
 
 .PHONY: sync-latest-docs-to-s3
 sync-latest-docs-to-s3:
-	aws s3 sync --delete --acl bucket-owner-full-control \
+	aws s3 sync --acl bucket-owner-full-control \
 		--cache-control max-age=0 \
 		docs/site/ \
 		$(S3_PREFIX)/latest/docs/


### PR DESCRIPTION
This PR addresses the master branch action failures on syncing docs to s3. Currently, pushing the files works but the delete portion of the sync is failing. Until we get to root cause on that, this PR disables deletion.
