### PR TITLE
add python 3.9 to CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         # TODO: work on windows-latest compatibility?
         os: [ubuntu-latest]
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
         include:
         - os: macos-latest
-          python-version: '3.8'
+          python-version: '3.9'
     runs-on: ${{ matrix.os }}
     name: test (py${{ matrix.python-version }} ${{ matrix.os }})
     steps:


### PR DESCRIPTION
### Description

This PR updates the github actions setup to include python 3.9 tests.
