### PR TITLE
Use pip list --format=freeze instead of pip freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.1] - 2020-TBD
+## [1.5.1] - 2020-11-02
 
 ### Fixed
 - Python 2 encoding error when using rsconnect-jupyter to publish a notebook containing binary data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Environments are now introspected with `pip list --format=freeze` instead of `pip freeze`,
+  since the latter injects nonexistent paths into the requirements file when run in a conda environment.
+
 ## [1.5.1] - 2020-11-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Environments are now introspected with `pip list --format=freeze` instead of `pip freeze`,
   since the latter injects nonexistent paths into the requirements file when run in a conda environment.
+  This issue started occurring when pip 20.1 added support for PEP 610 metadata.
 
 ## [1.5.1] - 2020-11-02
 

--- a/README.md
+++ b/README.md
@@ -221,11 +221,11 @@ from an alternative Python executable specified via the `--python` option or via
 rsconnect deploy notebook --python /path/to/python my-notebook.ipynb
 ```
 
-You can see the packages list that will be included by running `pip freeze` yourself,
+You can see the packages list that will be included by running `pip list --format=freeze` yourself,
 ensuring that you use the same Python that you use to run your Jupyter Notebook:
 
 ```bash
-/path/to/python -m pip freeze
+/path/to/python -m pip list --format=freeze
 ```
 
 #### Static (Snapshot) Deployment
@@ -306,11 +306,11 @@ from an alternative Python executable specified via the `--python` option or via
 rsconnect deploy api --python /path/to/python my-api/
 ```
 
-You can see the packages list that will be included by running `pip freeze` yourself,
+You can see the packages list that will be included by running `pip list --format=freeze` yourself,
 ensuring that you use the same Python that you use to run your API or application:
 
 ```bash
-/path/to/python -m pip freeze
+/path/to/python -m pip list --format=freeze
 ```
 
 ### Creating a Manifest for Future Deployment

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -194,7 +194,7 @@ def pip_freeze():
     """
     try:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "pip", "freeze"],
+            [sys.executable, "-m", "pip", "list", "--format=freeze"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ project_urls =
 install_requires =
     six>=1.14.0
     click>=7.0.0
+    pip>=10.0.0
 setup_requires =
     setuptools
     setuptools_scm>=3.4


### PR DESCRIPTION
### Description

In conda environments, `pip freeze` lists paths in the requirements.txt file which do not exist locally. This is caused by the PEP 610 metadata present for conda-installed packages, and is exposed by a change in pip 20.1b1.

Connected to #166 

### Testing Notes / Validation Steps

Publish from virtualenvs and conda envs, without an existing requirements.txt file.
