### PR TITLE
Revert changes to auth header

### DIFF
--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -177,7 +177,7 @@ class HTTPServer(object):
         self._ca_data = ca_data
         self._cookies = cookies if cookies is not None else CookieJar()
         self._timeout = timeout
-        self._headers = {"User-Agent": _user_agent, "Authorization": "notEmpty"}
+        self._headers = {"User-Agent": _user_agent}
         self._conn = None
 
         self._inject_cookies()


### PR DESCRIPTION
### Description

Revert the recent change to add a nonempty Authorization header by default, since this causes key validation errors.

### Testing Notes / Validation Steps

Deploy to Connect without a proxy. Run Connect tests.

