### PR TITLE
md5 fallback for FIPS mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for generating md5 file upload checksums, even if Python's `hashlib`
-  was configured for FIPS mode.
+  was configured for FIPS mode. The fallback uses the `usedforsecurity` option which is
+  available in Python 3.9 and later.
 
 
 ## [1.5.2] - 2021-04-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Support for generating md5 file upload checksums, even if Python's `hashlib`
+  was configured for FIPS mode.
+
+
 ## [1.5.2] - 2021-04-02
 
 ### Added

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -75,10 +75,20 @@ def manifest_add_buffer(manifest, filename, buf):
     manifest["files"][filename] = {"checksum": buffer_checksum(buf)}
 
 
+def make_hasher():
+    try:
+        return hashlib.md5()
+    except Exception:
+        # md5 is not available in FIPS mode, see if the usedforsecurity option is available
+        # (it was added in python 3.9). We set usedforsecurity=False since we are only
+        # using this for a file upload integrity check.
+        return hashlib.md5(usedforsecurity=False)
+
+
 def file_checksum(path):
     """Calculate the md5 hex digest of the specified file"""
     with open(path, "rb") as f:
-        m = hashlib.md5()
+        m = make_hasher()
         chunk_size = 64 * 1024
 
         chunk = f.read(chunk_size)
@@ -90,7 +100,7 @@ def file_checksum(path):
 
 def buffer_checksum(buf):
     """Calculate the md5 hex digest of a buffer (str or bytes)"""
-    m = hashlib.md5()
+    m = make_hasher()
     m.update(to_bytes(buf))
     return m.hexdigest()
 


### PR DESCRIPTION
### Description

We compute file and buffer checksums to support a file upload integrity check, using `hashlib.md5` which is in the Python standard library. It's possible to have a python installation where this function is not available or requires special handling; this is related to building openssl in FIPS mode. This PR enables a fallback mode if hashlib.md5 is not available, by trying md5 with the `usedforsecurity` option set to False (this is new in Python 3.9).

Connected to #174 

### Testing Notes / Validation Steps

Test deploying content, on a normal python installation and one which is configured for FIPS (where `hashlib.md5` requires the `usedforsecurity` parameter to be False in order to function).
