### PR TITLE
Expand `RETICULATE_PYTHON` path in `which_python()`

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -110,7 +110,7 @@ def which_python(python, env=os.environ):
         return python
 
     if "RETICULATE_PYTHON" in env:
-        return env["RETICULATE_PYTHON"]
+        return os.path.expanduser(env["RETICULATE_PYTHON"])
 
     return sys.executable
 


### PR DESCRIPTION
### Description

If the `RETICULATE_PYTHON` environment variable refers to a user's home directory with a tilde, instead of as an absolute path, functions that invoke subprocesses with `which_python()` will fail.

This PR runs `os.path.expanduser()` on `RETICULATE_PYTHON` to ensure that it is reachable by subprocess commands, even if the environment variable contains an un-expanded path.

This is probably pretty rare, because most environment variables are set in the shell and are thus expanded before they're stored, but we had this issue crop up, and it seems better to protect against this error.

### Testing Notes / Validation Steps

I was able to replicate the issue that a customer was facing, and this change fixed that issue.

All tests passed locally, except for an unrelated test in `which_python()` which also fails locally on `master`. Tests pass in CI.