### PR TITLE
More flexible default entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - TBD
+
+### Added
+
+- If an entrypoint is not specified with `--entrypoint`, rsconnect-python will attempt
+  to choose an entrypoint file. It looks for common names (`app.py`, `application.py`,
+  `main.py`, `api.py`). If there is a single python source file in the directory,
+  that will be used as the entrypoint.
+  rsconnect-python does not inspect the file contents to identify the object name, which must be
+  one of the default names that Connect expects (`app`, `application`, `create_app`, or `make_app`).
+
 ## [1.5.3] - 2021-05-06
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ six>=1.14.0
 toml
 twine
 wheel
+types-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ toml
 twine
 wheel
 types-six
+types-click

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ twine
 wheel
 types-six
 types-click
+types-Flask

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -423,7 +423,25 @@ def validate_manifest_file(file_or_directory):
     return file_or_directory
 
 
-def validate_entry_point(entry_point):
+def get_default_entrypoint(directory):
+    candidates = ["app", "application", "main", "api"]
+    files = set(os.listdir(directory))
+
+    for candidate in candidates:
+        filename = candidate + ".py"
+        if filename in files:
+            return candidate
+
+    # if only one python source file, use it
+    python_files = list(filter(lambda s: s.endswith(".py"), files))
+    if len(python_files) == 1:
+        return python_files[0][:-3]
+
+    logger.warning("Can't determine entrypoint; defaulting to 'app'")
+    return "app"
+
+
+def validate_entry_point(entry_point, directory):
     """
     Validates the entry point specified by the user, expanding as necessary.  If the
     user specifies nothing, a module of "app" is assumed.  If the user specifies a
@@ -433,7 +451,7 @@ def validate_entry_point(entry_point):
     :return: the fully expanded and validated entry point and the module file name..
     """
     if not entry_point:
-        entry_point = "app"
+        entry_point = get_default_entrypoint(directory)
 
     parts = entry_point.split(":")
 
@@ -1010,7 +1028,7 @@ def _gather_basic_deployment_info_for_framework(
     be generated.
     :return: the entry point, app ID, name, title and mode for the deployment.
     """
-    entry_point = validate_entry_point(entry_point)
+    entry_point = validate_entry_point(entry_point, directory)
 
     _validate_title(title)
 
@@ -1128,7 +1146,7 @@ def create_api_deployment_bundle(
     are properly qualified first.
     :return: the bundle.
     """
-    entry_point = validate_entry_point(entry_point)
+    entry_point = validate_entry_point(entry_point, directory)
 
     if extra_files_need_validating:
         extra_files = validate_extra_files(directory, extra_files)

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -248,7 +248,10 @@ def make_html_manifest(filename):
     # noinspection SpellCheckingInspection
     return {
         "version": 1,
-        "metadata": {"appmode": "static", "primary_html": filename,},
+        "metadata": {
+            "appmode": "static",
+            "primary_html": filename,
+        },
     }
 
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1060,7 +1060,7 @@ def _write_framework_manifest(
     set_verbosity(verbose)
 
     with cli_feedback("Checking arguments"):
-        entrypoint = validate_entry_point(entrypoint)
+        entrypoint = validate_entry_point(entrypoint, directory)
         extra_files = validate_extra_files(directory, extra_files)
         manifest_path = join(directory, "manifest.json")
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -148,7 +149,9 @@ class TestActions(TestCase):
         _validate_title("1" * 1024)
 
     def test_validate_entry_point(self):
-        with tempfile.TemporaryDirectory() as directory:
+        directory = tempfile.mkdtemp()
+
+        try:
             self.assertEqual(validate_entry_point(None, directory), "app")
             self.assertEqual(validate_entry_point("app", directory), "app")
             self.assertEqual(validate_entry_point("app:app", directory), "app:app")
@@ -163,6 +166,8 @@ class TestActions(TestCase):
                     with open(join(directory, "main.py"), "w") as f:
                         f.close()
                         self.assertEqual(validate_entry_point(None, directory), "main")
+        finally:
+            shutil.rmtree(directory)
 
     def test_make_deployment_name(self):
         self.assertEqual(_make_deployment_name(None, "title", False), "title")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -87,7 +87,8 @@ class TestActions(TestCase):
         with self.assertRaises(api.RSConnectException) as context:
             check_server_capabilities(None, (are_apis_supported_on_server,), lambda x: no_api_support)
         self.assertEqual(
-            str(context.exception), "The RStudio Connect server does not allow for Python APIs.",
+            str(context.exception),
+            "The RStudio Connect server does not allow for Python APIs.",
         )
 
         check_server_capabilities(None, (are_apis_supported_on_server,), lambda x: api_support)
@@ -124,13 +125,15 @@ class TestActions(TestCase):
         with self.assertRaises(api.RSConnectException) as context:
             check_server_capabilities(None, (fake_cap,), lambda x: None)
         self.assertEqual(
-            str(context.exception), "The server does not satisfy the fake_cap capability check.",
+            str(context.exception),
+            "The server does not satisfy the fake_cap capability check.",
         )
 
         with self.assertRaises(api.RSConnectException) as context:
             check_server_capabilities(None, (fake_cap_with_doc,), lambda x: None)
         self.assertEqual(
-            str(context.exception), "The server does not satisfy the fake_cap_with_doc capability check.",
+            str(context.exception),
+            "The server does not satisfy the fake_cap_with_doc capability check.",
         )
 
     def test_validate_title(self):
@@ -197,7 +200,8 @@ class TestActions(TestCase):
         self.assertEqual(validate_extra_files(directory, None), [])
         self.assertEqual(validate_extra_files(directory, []), [])
         self.assertEqual(
-            validate_extra_files(directory, [join(directory, "index.htm")]), ["index.htm"],
+            validate_extra_files(directory, [join(directory, "index.htm")]),
+            ["index.htm"],
         )
 
     def test_deploy_python_api_validates(self):
@@ -314,7 +318,14 @@ class TestActions(TestCase):
 
 
 @pytest.mark.parametrize(
-    ("file_name", "python", "conda_mode", "force_generate", "expected_python", "expected_environment",),
+    (
+        "file_name",
+        "python",
+        "conda_mode",
+        "force_generate",
+        "expected_python",
+        "expected_environment",
+    ),
     [
         pytest.param(
             "path/to/file.py",
@@ -373,13 +384,23 @@ class TestActions(TestCase):
     ],
 )
 def test_get_python_env_info(
-    monkeypatch, file_name, python, conda_mode, force_generate, expected_python, expected_environment,
+    monkeypatch,
+    file_name,
+    python,
+    conda_mode,
+    force_generate,
+    expected_python,
+    expected_environment,
 ):
     def fake_which_python(python, env=os.environ):
         return expected_python
 
     def fake_inspect_environment(
-        python, directory, conda_mode=False, force_generate=False, check_output=subprocess.check_output,
+        python,
+        directory,
+        conda_mode=False,
+        force_generate=False,
+        check_output=subprocess.check_output,
     ):
         return expected_environment
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,7 +104,12 @@ class TestModels(TestCase):
 
         for case in cases:
             matcher = GlobMatcher(case[0])
-            msg = "Pattern: %s, Path: %s, expected: %s, got: %s" % (case[0], case[1], case[2], not case[2],)
+            msg = "Pattern: %s, Path: %s, expected: %s, got: %s" % (
+                case[0],
+                case[1],
+                case[2],
+                not case[2],
+            )
             self.assertEqual(matcher.matches(case[1]), case[2], msg)
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
### Description

This PR provides a method of choosing an entrypoint if none was specified with the `--entrypoint` parameter. Previously, the default was hardcoded to `app` which will fail if there is no `app.py`.

### Testing Notes / Validation Steps

Deploy typical example apps without specifying an entrypoint.