### PR TITLE
Exclude __pycache__ by default

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -29,6 +29,7 @@ directories_to_ignore = [
     ".git/",
     ".svn/",
     ".venv/",
+    "__pycache__/",
     "env/",
     "packrat/",
     "rsconnect-python/",


### PR DESCRIPTION
### Description

When creating a bundle for a directory, exclude the `__pycache__` which is created during local runs.

Connected to #188

### Testing Notes / Validation Steps

Run an app locally with python3, then deploy it. Download the bundle from Connect and verify that the `__pycache__` directory was not included in the bundle.
