### PR TITLE
Git ref fix

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -224,7 +224,7 @@ def pip_freeze():
 
 
 def strip_ref(line):
-    return line.split("@", 1)[0].strip()
+    return line.split(" @ ", 1)[0].strip()
 
 
 def exclude(line):

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -228,7 +228,7 @@ def strip_ref(line):
 
 
 def exclude(line):
-    return line and line.startswith('setuptools') and 'post' in line
+    return line and line.startswith("setuptools") and "post" in line
 
 
 def conda_env_export(conda):
@@ -276,11 +276,11 @@ def main():
         if "c" in flags:
             conda_mode = True
         envinfo = detect_environment(directory, force_generate, conda_mode)._asdict()
-        if 'contents' in envinfo:
-            keepers = list(map(strip_ref, envinfo['contents'].split('\n')))
+        if "contents" in envinfo:
+            keepers = list(map(strip_ref, envinfo["contents"].split("\n")))
             if not conda_mode:
                 keepers = [line for line in keepers if not exclude(line)]
-            envinfo['contents'] = '\n'.join(keepers)
+            envinfo["contents"] = "\n".join(keepers)
 
         json.dump(
             envinfo, sys.stdout, indent=4,


### PR DESCRIPTION
### Description

When cleaning up a requirements.txt file produced by `pip freeze`, one of the steps is to remove the direct URL references left over from the conda package build process.

In a conda environment, the output of `pip freeze` looks like:
```
attrs @ file:///tmp/build/80754af9/attrs_1604765588209/work
```

We need to strip the `@` sign and everything after it on the line, since those reference paths that only ever existed on the host that built the conda package.

The current stripping is too aggressive and mangles git references that include a refspec, e.g. 
```
-e git+https://github.com/user/package.git@main#egg=package
```


### Testing Notes / Validation Steps

Deploy content that from an environment that includes a package installed from a git branch (not just from a git repo), or whose requirements.txt includes such a package. The simplest way is to create a requirements.txt that includes a git reference like the one above. Verify that the requirements.txt file in the bundle uploaded to Connect includes the full git reference.

Also deploy from a conda environment where `pip freeze` produces lines like the `attrs` example above, or add that line to requirements.txt. Verify that the requirements.txt file in the bundle uploaded to Connect correctly excludes the conda build path.