### PR TITLE
limit reference stripping to file: urls

### DIFF
--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -224,7 +224,8 @@ def pip_freeze():
 
 
 def strip_ref(line):
-    return line.split(" @ ", 1)[0].strip()
+    # remove erroneous conda build paths that will break pip install
+    return line.split(" @ file:", 1)[0].strip()
 
 
 def exclude(line):


### PR DESCRIPTION
### Description

We remove some direct URL references which are left behind from conda build. The current behavior removes all direct references, which causes problems for some requirements output from pip freeze (`package @ git+https://github.com/...`). This PR limits the stripping to only affect `file:` URLs such as those left behind by conda.

### Testing Notes / Validation Steps

Deploy from conda environments and verify that the generated requirements.txt file in the uploaded bundle does not contain conda path references. 

Deploy using a requirements.txt file that was generated by running `pip freeze` in an environment where a package was installed from github and appears as `package @ git+https://github.com/...`. Verify that the git package reference was passed through as-is.

