### PR TITLE
Remove environment directories from exclusion list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The `https_proxy` environment variable is recognized as a synonym for
   `HTTPS_PROXY`.
+- Common environment directories (`env, venv, .env, .venv`) are no longer
+  excluded by name. Environments are detected by the presence of a python
+  executable in `bin` or `Scripts` and excluded.
 
 ### Added
 - Added support for the `no_proxy` or `NO_PROXY` environment variables to specify

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -39,17 +39,13 @@ _module_pattern = re.compile(r"^[A-Za-z0-9_]+:[A-Za-z0-9_]+$")
 # noinspection SpellCheckingInspection
 directories_ignore_list = [
     ".Rproj.user/",
-    ".env/",
     ".git/",
     ".svn/",
-    ".venv/",
     "__pycache__/",
-    "env/",
     "packrat/",
     "renv/",
     "rsconnect-python/",
     "rsconnect/",
-    "venv/",
 ]
 directories_to_ignore = {Path(d) for d in directories_ignore_list}
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -537,10 +537,6 @@ class TestBundle(TestCase):
         self.assertFalse(keep_manifest_specified_file("rsconnect-python"))
         self.assertFalse(keep_manifest_specified_file("rsconnect-python/bogus.file"))
         self.assertFalse(keep_manifest_specified_file(".svn/bogus.file"))
-        self.assertFalse(keep_manifest_specified_file(".env/share/jupyter/kernels/python3/kernel.json"))
-        self.assertFalse(keep_manifest_specified_file(".venv/bin/activate"))
-        self.assertFalse(keep_manifest_specified_file("env/pyvenv.cfg"))
-        self.assertFalse(keep_manifest_specified_file("venv/lib/python3.8/site-packages/wheel/__init__.py"))
         # noinspection SpellCheckingInspection
         self.assertFalse(keep_manifest_specified_file(".Rproj.user/bogus.file"))
 


### PR DESCRIPTION
### Description

We exclude some directories from bundling, including common virtual environment directories (`env`, `venv`, `.env`, and `.venv`). With the change in https://github.com/rstudio/rsconnect-python/pull/198, virtual environment directories are excluded based on the presence of `bin/python`, so the exclusion by name is no longer needed.

### Testing Notes / Validation Steps

In the directory you are going to deploy, create a virtualenv with one of the names listed above. Ensure that it is not included in the bundle.
