### PR TITLE
Support deploying manifests with Quarto app modes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ Options:
   -c, --cacert FILENAME           The path to trusted TLS CA certificates.
   --published                     Search only published content.
   --unpublished                   Search only unpublished content.
-  --content-type [unknown|shiny|rmd-static|rmd-shiny|static|api|tensorflow-saved-model|jupyter-static|python-api|python-dash|python-streamlit|python-bokeh|python-fastapi]
+  --content-type [unknown|shiny|rmd-static|rmd-shiny|static|api|tensorflow-saved-model|jupyter-static|python-api|python-dash|python-streamlit|python-bokeh|python-fastapi|quarto-shiny|quarto-static]
                                   Filter content results by content type.
   --r-version VERSIONSEARCHFILTER
                                   Filter content results by R version.

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -82,7 +82,7 @@ class AppModes(object):
     BOKEH_APP = AppMode(11, "python-bokeh", "Bokeh Application")
     PYTHON_FASTAPI = AppMode(12, "python-fastapi", "Python FastAPI")
     QUARTO_SHINY = AppMode(13, "quarto-shiny", "Quarto Shiny Document")
-    QUARTO_STATIC = AppMode(14, "quarto-static", "Quarto Document", ".Qmd")
+    QUARTO_STATIC = AppMode(14, "quarto-static", "Quarto Document", ".qmd")
 
     _modes = [
         UNKNOWN,

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -81,6 +81,8 @@ class AppModes(object):
     STREAMLIT_APP = AppMode(10, "python-streamlit", "Streamlit Application")
     BOKEH_APP = AppMode(11, "python-bokeh", "Bokeh Application")
     PYTHON_FASTAPI = AppMode(12, "python-fastapi", "Python FastAPI")
+    QUARTO_SHINY = AppMode(13, "quarto-shiny", "Quarto Shiny Document")
+    QUARTO_STATIC = AppMode(14, "quarto-static", "Quarto Document", ".Qmd")
 
     _modes = [
         UNKNOWN,
@@ -96,6 +98,8 @@ class AppModes(object):
         STREAMLIT_APP,
         BOKEH_APP,
         PYTHON_FASTAPI,
+        QUARTO_SHINY,
+        QUARTO_STATIC,
     ]
 
     @classmethod

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -81,8 +81,8 @@ class AppModes(object):
     STREAMLIT_APP = AppMode(10, "python-streamlit", "Streamlit Application")
     BOKEH_APP = AppMode(11, "python-bokeh", "Bokeh Application")
     PYTHON_FASTAPI = AppMode(12, "python-fastapi", "Python FastAPI")
-    QUARTO_SHINY = AppMode(13, "quarto-shiny", "Quarto Shiny Document")
-    QUARTO_STATIC = AppMode(14, "quarto-static", "Quarto Document", ".qmd")
+    SHINY_QUARTO = AppMode(13, "quarto-shiny", "Shiny Quarto Document")
+    STATIC_QUARTO = AppMode(14, "quarto-static", "Quarto Document", ".qmd")
 
     _modes = [
         UNKNOWN,
@@ -98,8 +98,8 @@ class AppModes(object):
         STREAMLIT_APP,
         BOKEH_APP,
         PYTHON_FASTAPI,
-        QUARTO_SHINY,
-        QUARTO_STATIC,
+        SHINY_QUARTO,
+        STATIC_QUARTO,
     ]
 
     @classmethod


### PR DESCRIPTION
### Description

#### Problem

`rsconnect-python` refuses to deploy Quarto manifests because it does not recognize the `quarto-static` and `quarto-shiny` appmodes.

#### Solution

- Added the new appmodes to the `AppModes` class in `models.py`.

### Testing Notes / Validation Steps

- I searched the rest of the codebase for any other places that might need appmode-specific code, but couldn't find any. There don't seem to be any appmode-specific tests, either.
- I successfully deployed Quarto projects via `rsconnect deploy manifest` that had previously failed.