### PR TITLE
Fix content search when user has access to 0 content items

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -66,7 +66,7 @@ class RSConnect(HTTPServer):
             self.key_authorization(server.api_key)
 
     def _tweak_response(self, response):
-        return response.json_data if response.status and response.status == 200 and response.json_data else response
+        return response.json_data if response.status and response.status == 200 and response.json_data is not None else response
 
     def me(self):
         return self.get("me")


### PR DESCRIPTION
### Description

Check for None explicitly to avoid confusion with empty {} or []

closes #222

### Testing Notes / Validation Steps

Content search should now work even when the user has no content.
