### PR TITLE
Allow setting environment variables during deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- You can now set environment variables for the deployed content with the `-E` option.
+  These will be passed to RStudio Connect during the deployment process,
+  so they are available in your code whenever it runs within RStudio Connect.
+
 ## [1.7.0] - 2022-01-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - You can now set environment variables for the deployed content with the `-E` option.
   These will be passed to RStudio Connect during the deployment process,
   so they are available in your code whenever it runs within RStudio Connect.
+  Requires RStudio Connect version 1.8.6 or later.
 
 ## [1.7.0] - 2022-01-10
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,20 @@ containing the API or application.
 When using `rsconnect deploy manifest`, the title is derived from the primary
 filename referenced in the manifest.
 
+### Environment Variables
+You can set environment variables during deployment. Their names and values will be
+passed to RStudio Connect during deployment so you can use them in your code.
+
+For example, if `notebook.ipynb` contains
+```python
+print(os.environ["MYVAR"])
+```
+
+You can set the value of `MYVAR` that will be set when your code runs in RStudio Connect:
+```bash
+rsconnect deploy notebook --environment MYVAR='hello world' notebook.ipynb
+```
+
 ### Network Options
 
 When specifying information that `rsconnect` needs to be able to interact with RStudio

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1281,7 +1281,7 @@ def create_api_deployment_bundle(
     return make_api_bundle(directory, entry_point, app_mode, environment, extra_files, excludes)
 
 
-def deploy_bundle(connect_server, app_id, name, title, title_is_default, bundle):
+def deploy_bundle(connect_server, app_id, name, title, title_is_default, bundle, env_vars):
     """
     Deploys the specified bundle.
 
@@ -1291,10 +1291,11 @@ def deploy_bundle(connect_server, app_id, name, title, title_is_default, bundle)
     :param title: the title for the deploy.
     :param title_is_default: a flag noting whether the title carries a defaulted value.
     :param bundle: the bundle to deploy.
+    :param env_vars: list of (name, value) pairs for the app environment
     :return: application information about the deploy.  This includes the ID of the
     task that may be queried for deployment progress.
     """
-    return api.do_bundle_deploy(connect_server, app_id, name, title, title_is_default, bundle)
+    return api.do_bundle_deploy(connect_server, app_id, name, title, title_is_default, bundle, env_vars)
 
 
 def spool_deployment_log(connect_server, app, log_callback):

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -92,6 +92,10 @@ class RSConnect(HTTPServer):
     def app_update(self, app_id, updates):
         return self.post("applications/%s" % app_id, body=updates)
 
+    def app_add_environment_vars(self, app_guid, env_vars):
+        env_body = [dict(name=kv[0], value=kv[1]) for kv in env_vars]
+        return self.patch("v1/content/%s/environment" % app_guid, body=env_body)
+
     def app_deploy(self, app_id, bundle_id=None):
         return self.post("applications/%s/deploy" % app_id, body={"bundle": bundle_id})
 
@@ -132,12 +136,13 @@ class RSConnect(HTTPServer):
         self._server.handle_bad_response(response)
         return response
 
-    def deploy(self, app_id, app_name, app_title, title_is_default, tarball):
+    def deploy(self, app_id, app_name, app_title, title_is_default, tarball, env_vars):
         if app_id is None:
             # create an app if id is not provided
             app = self.app_create(app_name)
             self._server.handle_bad_response(app)
             app_id = app["id"]
+
             # Force the title to update.
             title_is_default = False
         else:
@@ -145,6 +150,11 @@ class RSConnect(HTTPServer):
             # raise an error
             app = self.app_get(app_id)
             self._server.handle_bad_response(app)
+
+        app_guid = app["guid"]
+        if env_vars:
+            result = self.app_add_environment_vars(app_guid, env_vars)
+            self._server.handle_bad_response(result)
 
         if app["title"] != app_title and not title_is_default:
             self._server.handle_bad_response(self.app_update(app_id, {"title": app_title}))
@@ -317,7 +327,7 @@ def get_app_config(connect_server, app_id):
         return result
 
 
-def do_bundle_deploy(connect_server, app_id, name, title, title_is_default, bundle):
+def do_bundle_deploy(connect_server, app_id, name, title, title_is_default, bundle, env_vars):
     """
     Deploys the specified bundle.
 
@@ -327,11 +337,12 @@ def do_bundle_deploy(connect_server, app_id, name, title, title_is_default, bund
     :param title: the title for the deploy.
     :param title_is_default: a flag noting whether the title carries a defaulted value.
     :param bundle: the bundle to deploy.
+    :param env_vars: list of NAME=VALUE pairs for the app environment
     :return: application information about the deploy.  This includes the ID of the
     task that may be queried for deployment progress.
     """
     with RSConnect(connect_server, timeout=120) as client:
-        result = client.deploy(app_id, name, title, title_is_default, bundle)
+        result = client.deploy(app_id, name, title, title_is_default, bundle, env_vars)
         connect_server.handle_bad_response(result)
         return result
 

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -213,15 +213,20 @@ class HTTPServer(object):
     def post(self, path, query_params=None, body=None):
         return self.request("POST", path, query_params, body)
 
+    def patch(self, path, query_params=None, body=None):
+        return self.request("PATCH", path, query_params, body)
+
     def request(self, method, path, query_params=None, body=None, maximum_redirects=5, decode_response=True):
         path = self._get_full_path(path)
         extra_headers = None
-        if isinstance(body, dict):
+        if isinstance(body, (dict, list)):
             body = json.dumps(body).encode("utf-8")
             extra_headers = {"Content-Type": "application/json; charset=utf-8"}
         return self._do_request(method, path, query_params, body, maximum_redirects, extra_headers, decode_response)
 
-    def _do_request(self, method, path, query_params, body, maximum_redirects, extra_headers=None, decode_response=True):
+    def _do_request(
+        self, method, path, query_params, body, maximum_redirects, extra_headers=None, decode_response=True
+    ):
         full_uri = path
         if query_params is not None:
             full_uri = "%s?%s" % (path, urlencode(query_params))

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -126,7 +126,14 @@ def content_args(func):
         help="Existing app ID or GUID to replace. Cannot be used with --new.",
     )
     @click.option("--title", "-t", help="Title of the content (default is the same as the filename).")
-    @click.option("--environment", "-E", "env_vars", multiple=True, callback=validate_env_vars)
+    @click.option(
+        "--environment",
+        "-E",
+        "env_vars",
+        multiple=True,
+        callback=validate_env_vars,
+        help="Set an environment variable as NAME=VALUE. May be specified multiple times. [v1.8.6+]",
+    )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)


### PR DESCRIPTION
### Description

This is a little side project I did around the holidays.

You can specify environment variables with the new `-E` or `--environment` options to the `rsconnect deploy` commands, for example `rsconnect deploy api -n myserver -E NAME=VALUE .`. The environment variables will be set on the app right after it's created, before the bundle is uploaded and deployed, so they are present during the first render/run of the content on Connect.

### Testing Notes / Validation Steps

Deploy a notebook and an app that requires an environment variable to be set in order for the code to run. You can do this by using something like `print("NAME", os.environ["NAME"])` in the code.
* Deploy without `-E` and see that it fails (at render time for a notebook, or at run time for an app).
* Redeploy with `-E NAME=me` (don't use `--new` so it reuses the app). See that the variable is set in Connect, and the app/notebook runs correctly.
* Deploy again with `-E NAME=you` and see that the variable in Connect has been updated with the new value.
* Try using multiple `-E` options on the command line. All of them should take effect, if you specify unique names. (Duplicate names will cause Connect to return an error).

