### PR TITLE
quarto: write-manifest and deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so they are available in your code whenever it runs within RStudio Connect.
   Requires RStudio Connect version 1.8.6 or later.
 
+- You can now deploy Quarto projects. This requires RStudio Connect release
+  2021.08.0 or later. Use `rsconnect deploy quarto` to deploy, or `rsconnect
+  write-manifest quarto` to create a manifest file.
+
 ## [1.7.1] - 2022-02-15
 
 ### Added

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -527,8 +527,16 @@ def write_quarto_manifest_json(
     manifest, _ = make_quarto_manifest(directory, inspect, app_mode, environment, extra_files, excludes)
     manifest_path = join(directory, "manifest.json")
 
+    write_manifest_json(manifest_path, manifest)
+
+
+def write_manifest_json(manifest_path, manifest):
+    """
+    Write the manifest data as JSON to the named manifest.json with a trailing newline.
+    """
     with open(manifest_path, "w") as f:
         json.dump(manifest, f, indent=2)
+        f.write("\n")
 
 
 def deploy_jupyter_notebook(
@@ -1458,8 +1466,7 @@ def write_notebook_manifest_json(
     for rel_path in extra_files:
         manifest_add_file(manifest_data, rel_path, directory)
 
-    with open(manifest_path, "w") as f:
-        json.dump(manifest_data, f, indent=2)
+    write_manifest_json(manifest_path, manifest_data)
 
     return exists(join(directory, environment.filename))
 
@@ -1520,8 +1527,7 @@ def write_api_manifest_json(
     manifest, _ = make_api_manifest(directory, entry_point, app_mode, environment, extra_files, excludes)
     manifest_path = join(directory, "manifest.json")
 
-    with open(manifest_path, "w") as f:
-        json.dump(manifest, f, indent=2)
+    write_manifest_json(manifest_path, manifest)
 
     return exists(join(directory, environment.filename))
 

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -494,7 +494,7 @@ def quarto_inspect(
     """
     args = [quarto, "inspect", target]
     try:
-        inspect_json = check_output(args, universal_newlines=True)
+        inspect_json = check_output(args, universal_newlines=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         raise api.RSConnectException("Error inspecting target: %s" % e.output)
     return json.loads(inspect_json)

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -523,7 +523,14 @@ def write_quarto_manifest_json(
     excludes=None,
 ):
     """
-    Does something. TBD.
+    Creates and writes a manifest.json file for the given Quarto project.
+
+    :param directory: The directory containing the Quarto project.
+    :param inspect: The parsed JSON from a 'quarto inspect' against the project.
+    :param app_mode: The application mode to assume.
+    :param environment: The (optional) Python environment to use.
+    :param extra_files: Any extra files to include in the manifest.
+    :param excludes: A sequence of glob patterns to exclude when enumerating files to bundle.
     """
 
     extra_files = validate_extra_files(directory, extra_files)
@@ -1173,6 +1180,16 @@ def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_n
 
 
 def gather_basic_deployment_info_for_quarto(connect_server, app_store, directory, new, app_id, title):
+    """
+    Helps to gather the necessary info for performing a deployment.
+
+    :param connect_server: The Connect server information.
+    :param app_store: The store for the specified Quarto project directory.
+    :param directory: The target Quarto project directory.
+    :param new: A flag to force a new deployment.
+    :param app_id: The identifier of the content to redeploy.
+    :param title: The content title (optional). A default title is generated when one is not provided.
+    """
     _validate_title(title)
 
     if new and app_id:

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -464,10 +464,11 @@ def validate_entry_point(entry_point, directory):
     return entry_point
 
 
-def which_quarto(quarto):
+def which_quarto(quarto = None):
     """
-    Identify a valid Quarto executable. Attempts to find Quarto on the PATH
-    and in well-known locations when one is not provided as input.
+    Identify a valid Quarto executable. When a Quarto location is not provided
+    as input, an attempt is made to discover Quarto from the PATH and other
+    well-known locations.
     """
     if quarto:
         found = shutil.which(quarto)

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -463,6 +463,7 @@ def validate_entry_point(entry_point, directory):
 
     return entry_point
 
+
 def locate_quarto(quarto):
     """
     Identify a valid Quarto executable. Attempts to find Quarto on the PATH
@@ -485,9 +486,9 @@ def locate_quarto(quarto):
 
 
 def quarto_inspect(
-        quarto,
-        target,
-        check_output=subprocess.check_output,
+    quarto,
+    target,
+    check_output=subprocess.check_output,
 ):
     """
     Runs 'quarto inspect' against the target and returns its output as a
@@ -509,19 +510,20 @@ def validate_quarto_engines(inspect):
     engines = inspect.get("engines", [])
     unsupported = [engine for engine in engines if engine not in supported]
     if unsupported:
-        raise api.RSConnectException('The following Quarto engine(s) are not supported: %s' % ", ".join(unsupported))
+        raise api.RSConnectException("The following Quarto engine(s) are not supported: %s" % ", ".join(unsupported))
     return engines
 
 
 def write_quarto_manifest_json(
-        directory,
-        inspect,
-        app_mode = AppModes.STATIC_QUARTO,
-        environment = None,
-        extra_files = None,
-        excludes = None,
+    directory,
+    inspect,
+    app_mode=AppModes.STATIC_QUARTO,
+    environment=None,
+    extra_files=None,
+    excludes=None,
 ):
     """
+    Does something. TBD.
     """
 
     extra_files = validate_extra_files(directory, extra_files)
@@ -1170,13 +1172,7 @@ def gather_basic_deployment_info_from_manifest(connect_server, app_store, file_n
     )
 
 
-def gather_basic_deployment_info_for_quarto(
-        connect_server,
-        app_store,
-        directory,
-        new,
-        app_id,
-        title):
+def gather_basic_deployment_info_for_quarto(connect_server, app_store, directory, new, app_id, title):
     _validate_title(title)
 
     if new and app_id:
@@ -1217,7 +1213,6 @@ def gather_basic_deployment_info_for_quarto(
         default_title,
         app_mode,
     )
-
 
 
 def _generate_gather_basic_deployment_info_for_python(app_mode):
@@ -1415,7 +1410,7 @@ def create_quarto_deployment_bundle(
     extra_files,
     excludes,
     app_mode,
-        inspect, 
+    inspect,
     environment,
     extra_files_need_validating=True,
 ):
@@ -1614,6 +1609,7 @@ def write_api_manifest_json(
     write_manifest_json(manifest_path, manifest)
 
     return exists(join(directory, environment.filename))
+
 
 def write_environment_file(environment, directory):
     """

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -643,7 +643,6 @@ def make_quarto_manifest(
     if environment:
         extra_files = list(extra_files or []) + [environment.filename]
 
-    # TODO: Exclude inspect.formats.html.html.pandoc.output-file
     excludes = (excludes or [])
     excludes = excludes + [".quarto"]
 
@@ -651,6 +650,13 @@ def make_quarto_manifest(
     output_dir = project_config.get("output-dir", None)
     if output_dir:
         excludes = excludes + [output_dir]
+    else:
+        render_targets = project_config.get("render", [])
+        for target in render_targets:
+            t, _ = splitext(target)
+            # TODO: Single-file inspect would give inspect.formats.html.pandoc.output-file
+            # For foo.qmd, we would get an output-file=foo.html, but foo_files is not available.
+            excludes = excludes + [t + ".html", t + "_files"]
 
     relevant_files = _create_quarto_file_list(directory, extra_files, excludes)
     manifest = make_source_manifest(

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -50,7 +50,7 @@ def make_source_manifest(
 
     manifest = {
         "version": 1,
-    }
+    }  # type: typing.Dict[str, typing.Any]
 
     # When adding locale, add it early so it is ordered immediately after
     # version.

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -303,7 +303,9 @@ def make_quarto_source_bundle(
     excludes=None,  # type: typing.Optional[typing.List[str]]
 ):
     # type: (...) -> typing.IO[bytes]
-    """Create a bundle containing the specified Quarto content and (optional) python environment.
+    """
+    Create a bundle containing the specified Quarto content and (optional)
+    python environment.
 
     Returns a file-like object containing the bundle tarball.
     """
@@ -660,14 +662,14 @@ def make_quarto_manifest(
 ):
     # type: (...) -> typing.Tuple[typing.Dict[str, typing.Any], typing.List[str]]
     """
-    Makes a manifest for an QUARTO.
+    Makes a manifest for a Quarto project.
 
-    :param directory: the directory containing the files to deploy.
-    :param entry_point: the main entry point for the QUARTO.
-    :param app_mode: the app mode to use.
-    :param environment: the Python environment information.
-    :param extra_files: a sequence of any extra files to include in the bundle.
-    :param excludes: a sequence of glob patterns that will exclude matched files.
+    :param directory: The directory containing the Quarto project.
+    :param inspect: The parsed JSON from a 'quarto inspect' against the project.
+    :param app_mode: The application mode to assume.
+    :param environment: The (optional) Python environment to use.
+    :param extra_files: Any extra files to include in the manifest.
+    :param excludes: A sequence of glob patterns to exclude when enumerating files to bundle.
     :return: the manifest and a list of the files involved.
     """
     if environment:

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -41,12 +41,12 @@ directories_to_ignore = [
 
 # noinspection SpellCheckingInspection
 def make_source_manifest(
-        app_mode,
-        environment = None,
-        entrypoint = None,
-        quarto_inspection = None
+    app_mode,  # type: AppMode
+    environment=None,  # type: typing.Optional[Environment]
+    entrypoint=None,  # type: typing.Optional[str]
+    quarto_inspection=None,  # type: typing.Optional[typing.Dict[str, typing.Any]]
 ):
-    # type: (str, Environment, AppMode) -> typing.Dict[str, typing.Any]
+    # type: (...) -> typing.Dict[str, typing.Any]
 
     manifest = {
         "version": 1,
@@ -56,8 +56,7 @@ def make_source_manifest(
     # version.
     if environment:
         manifest["locale"] = environment.locale
-        
-    # noinspection SpellCheckingInspection
+
     manifest["metadata"] = {
         "appmode": app_mode.name(),
     }
@@ -90,7 +89,7 @@ def make_source_manifest(
         }
 
     manifest["files"] = {}
-    
+
     return manifest
 
 
@@ -297,7 +296,7 @@ def make_notebook_source_bundle(
 
 def make_quarto_source_bundle(
     directory,  # type: str
-    inspect, # type: typing.Dict[str, typing.Any]
+    inspect,  # type: typing.Dict[str, typing.Any]
     app_mode,  # type: AppMode
     environment=None,  # type: Environment
     extra_files=None,  # type:  typing.Optional[typing.List[str]]
@@ -604,6 +603,7 @@ def make_api_bundle(
 
     return bundle_file
 
+
 def _create_quarto_file_list(
     directory,  # type: str
     extra_files=None,  # type: typing.Optional[typing.List[str]]
@@ -652,7 +652,7 @@ def _create_quarto_file_list(
 
 def make_quarto_manifest(
     directory,  # type: str
-    inspect, # type: typing.Dict[str, typing.Any]
+    inspect,  # type: typing.Dict[str, typing.Any]
     app_mode,  # type: AppMode
     environment=None,  # type: typing.Optional[Environment]
     extra_files=None,  # type: typing.Optional[typing.List[str]]

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -831,9 +831,7 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
 @deploy.command(
     name="quarto",
     short_help="Deploy Quarto content to RStudio Connect [v2021.08.0+].",
-    help=(
-        "Deploy Quarto content to RStudio Connect."
-    ),
+    help="Deploy Quarto content to RStudio Connect.",
 )
 @server_args
 @content_args
@@ -932,9 +930,7 @@ def deploy_quarto(
                 _warn_on_ignored_requirements(directory, environment.filename)
 
     with cli_feedback("Creating deployment bundle"):
-        bundle = create_quarto_deployment_bundle(
-            directory, extra_files, exclude, app_mode, inspect, environment, False
-        )
+        bundle = create_quarto_deployment_bundle(directory, extra_files, exclude, app_mode, inspect, environment, False)
     _deploy_bundle(
         connect_server,
         app_store,
@@ -947,6 +943,7 @@ def deploy_quarto(
         bundle,
         env_vars,
     )
+
 
 def generate_deploy_python(app_mode, alias, min_version):
     # noinspection SpellCheckingInspection
@@ -1265,6 +1262,7 @@ def write_manifest_notebook(
         with cli_feedback("Creating %s" % environment.filename):
             write_environment_file(environment, base_dir)
 
+
 @write_manifest.command(
     name="quarto",
     short_help="Create a manifest.json file for Quarto content.",
@@ -1314,7 +1312,14 @@ def write_manifest_notebook(
     type=click.Path(exists=True, dir_okay=False, file_okay=True),
 )
 def write_manifest_quarto(
-        overwrite, exclude, quarto, python, force_generate, verbose, directory, extra_files,
+    overwrite,
+    exclude,
+    quarto,
+    python,
+    force_generate,
+    verbose,
+    directory,
+    extra_files,
 ):
     set_verbosity(verbose)
     with cli_feedback("Checking arguments"):
@@ -1345,7 +1350,7 @@ def write_manifest_quarto(
         else:
             with cli_feedback("Creating %s" % environment.filename):
                 write_environment_file(environment, directory)
-        
+
     with cli_feedback("Creating manifest.json"):
         write_quarto_manifest_json(
             directory,

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -15,6 +15,7 @@ from .actions import (
     cli_feedback,
     create_api_deployment_bundle,
     create_notebook_deployment_bundle,
+    create_quarto_deployment_bundle,
     deploy_bundle,
     describe_manifest,
     gather_basic_deployment_info_for_api,
@@ -23,6 +24,7 @@ from .actions import (
     gather_basic_deployment_info_for_streamlit,
     gather_basic_deployment_info_for_bokeh,
     gather_basic_deployment_info_for_notebook,
+    gather_basic_deployment_info_for_quarto,
     gather_basic_deployment_info_from_manifest,
     gather_server_details,
     get_python_env_info,
@@ -824,6 +826,127 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
         env_vars,
     )
 
+
+# noinspection SpellCheckingInspection,DuplicatedCode
+@deploy.command(
+    name="quarto",
+    short_help="Deploy Quarto content to RStudio Connect [v2021.08.0+].",
+    help=(
+        "Deploy Quarto content to RStudio Connect."
+    ),
+)
+@server_args
+@content_args
+@click.option(
+    "--exclude",
+    "-x",
+    multiple=True,
+    help=(
+        "Specify a glob pattern for ignoring files when building the bundle. Note that your shell may try "
+        "to expand this which will not do what you expect. Generally, it's safest to quote the pattern. "
+        "This option may be repeated."
+    ),
+)
+@click.option(
+    "--quarto",
+    "-q",
+    type=click.Path(exists=True),
+    help="Path to Quarto installation.",
+)
+@click.option(
+    "--python",
+    "-p",
+    type=click.Path(exists=True),
+    help=(
+        "Path to Python interpreter whose environment should be used. "
+        "The Python environment must have the rsconnect package installed."
+    ),
+)
+@click.option(
+    "--force-generate",
+    "-g",
+    is_flag=True,
+    help='Force generating "requirements.txt", even if it already exists.',
+)
+@click.argument("directory", type=click.Path(exists=True, dir_okay=True, file_okay=False))
+@click.argument(
+    "extra_files",
+    nargs=-1,
+    type=click.Path(exists=True, dir_okay=False, file_okay=True),
+)
+def deploy_quarto(
+    name,
+    server,
+    api_key,
+    insecure,
+    cacert,
+    new,
+    app_id,
+    title,
+    exclude,
+    quarto,
+    python,
+    force_generate,
+    verbose,
+    directory,
+    extra_files,
+    env_vars,
+):
+    set_verbosity(verbose)
+
+    with cli_feedback("Checking arguments"):
+        module_file = fake_module_file_from_directory(directory)
+        app_store = AppStore(module_file)
+        connect_server = _validate_deploy_to_args(name, server, api_key, insecure, cacert)
+        extra_files = validate_extra_files(directory, extra_files)
+        (
+            app_id,
+            deployment_name,
+            title,
+            default_title,
+            app_mode,
+        ) = gather_basic_deployment_info_for_quarto(connect_server, app_store, directory, new, app_id, title)
+
+    click.secho('    Deploying %s to server "%s"' % (directory, connect_server.url))
+
+    _warn_on_ignored_manifest(directory)
+
+    with cli_feedback("Inspecting Quarto project"):
+        quarto = locate_quarto(quarto)
+        logger.debug("Quarto: %s" % quarto)
+        inspect = quarto_inspect(quarto, directory)
+        engines = validate_quarto_engines(inspect)
+
+    python = None
+    environment = None
+    if "jupyter" in engines:
+        _warn_if_no_requirements_file(directory)
+        _warn_if_environment_directory(directory)
+
+        with cli_feedback("Inspecting Python environment"):
+            python, environment = get_python_env_info(module_file, python, False, force_generate)
+
+            _warn_on_ignored_conda_env(environment)
+
+            if force_generate:
+                _warn_on_ignored_requirements(directory, environment.filename)
+
+    with cli_feedback("Creating deployment bundle"):
+        bundle = create_quarto_deployment_bundle(
+            directory, extra_files, exclude, app_mode, inspect, environment, False
+        )
+    _deploy_bundle(
+        connect_server,
+        app_store,
+        directory,
+        app_id,
+        app_mode,
+        deployment_name,
+        title,
+        default_title,
+        bundle,
+        env_vars,
+    )
 
 def generate_deploy_python(app_mode, alias, min_version):
     # noinspection SpellCheckingInspection

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -29,7 +29,6 @@ from .actions import (
     gather_server_details,
     get_python_env_info,
     is_conda_supported_on_server,
-    locate_quarto,
     quarto_inspect,
     set_verbosity,
     spool_deployment_log,
@@ -40,6 +39,7 @@ from .actions import (
     validate_file_is_notebook,
     validate_manifest_file,
     validate_quarto_engines,
+    which_quarto,
     write_api_manifest_json,
     write_environment_file,
     write_notebook_manifest_json,
@@ -910,7 +910,7 @@ def deploy_quarto(
     _warn_on_ignored_manifest(directory)
 
     with cli_feedback("Inspecting Quarto project"):
-        quarto = locate_quarto(quarto)
+        quarto = which_quarto(quarto)
         logger.debug("Quarto: %s" % quarto)
         inspect = quarto_inspect(quarto, directory)
         engines = validate_quarto_engines(inspect)
@@ -1330,7 +1330,7 @@ def write_manifest_quarto(
             raise api.RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Quarto project"):
-        quarto = locate_quarto(quarto)
+        quarto = which_quarto(quarto)
         logger.debug("Quarto: %s" % quarto)
         inspect = quarto_inspect(quarto, directory)
         engines = validate_quarto_engines(inspect)


### PR DESCRIPTION
### Description

Still in-flight; lots of cribbing from notebook / API workflows.

More to follow.

* Supports whole-directory (project) deployment.
* Does not support single-document targeting.
* Supports "markdown" and "jupyter" Quarto engines.
* Does not support the "knitr" Quarto engine.

### Testing Notes / Validation Steps

Given a directory containing a Quarto project, its manifest can be generated and/or deployed like:

```bash
rsconnect write-manifest quarto quarto-website
rsconnect deploy quarto -s "${SERVER}" quarto-website
```

If you attempt to interact with Quarto content that uses the "knitr" engine, an error is produced:

```bash
rsconnect write-manifest quarto --overwrite quarto-website-r
# => Error: The following Quarto engine(s) are not supported: knitr
```

It is an error when Quarto cannot be found:

```bash
touch not-quarto
rsconnect write-manifest quarto --quarto=not-quarto quarto-website
# => Error: The Quarto installation, "not-quarto", does not exist or is not executable.
```
