### PR TITLE
deploy_html

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1066,23 +1066,24 @@ def gather_basic_deployment_info_for_html(connect_server, app_store, path, new, 
 
     app_mode = AppModes.STATIC
     existing_app_mode = None
-    if app_id is None:
-        # Possible redeployment - check for saved metadata.
-        # Use the saved app information unless overridden by the user.
-        app_id, existing_app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
-        logger.debug("Using app mode from app %s: %s" % (app_id, app_mode))
-    else:
-        # Don't read app metadata if app-id is specified. Instead, we need
-        # to get this from Connect.
-        app = api.get_app_info(connect_server, app_id)
-        existing_app_mode = AppModes.get_by_ordinal(app.get("app_mode", 0), True)
-    if not new and existing_app_mode and app_mode != existing_app_mode:
-        msg = (
-            "Deploying with mode '%s',\n"
-            + "but the existing deployment has mode '%s'.\n"
-            + "Use the --new option to create a new deployment of the desired type."
-        ) % (app_mode.desc(), existing_app_mode.desc())
-        raise api.RSConnectException(msg)
+    if not new:
+        if app_id is None:
+            # Possible redeployment - check for saved metadata.
+            # Use the saved app information unless overridden by the user.
+            app_id, existing_app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
+            logger.debug("Using app mode from app %s: %s" % (app_id, app_mode))
+        elif app_id:
+            # Don't read app metadata if app-id is specified. Instead, we need
+            # to get this from Connect.
+            app = api.get_app_info(connect_server, app_id)
+            existing_app_mode = AppModes.get_by_ordinal(app.get("app_mode", 0), True)
+        if existing_app_mode and app_mode != existing_app_mode:
+            msg = (
+                "Deploying with mode '%s',\n"
+                + "but the existing deployment has mode '%s'.\n"
+                + "Use the --new option to create a new deployment of the desired type."
+            ) % (app_mode.desc(), existing_app_mode.desc())
+            raise api.RSConnectException(msg)
 
     default_title = not bool(title)
     title = title or _default_title(path)

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -464,7 +464,7 @@ def validate_entry_point(entry_point, directory):
     return entry_point
 
 
-def which_quarto(quarto = None):
+def which_quarto(quarto=None):
     """
     Identify a valid Quarto executable. When a Quarto location is not provided
     as input, an attempt is made to discover Quarto from the PATH and other
@@ -480,16 +480,12 @@ def which_quarto(quarto = None):
     locations = [
         # Discover using $PATH
         "quarto",
-
         # Location used by some installers, and often-added symbolic link.
         "/usr/local/bin/quarto",
-
         # Location used by some installers.
         "/opt/quarto/bin/quarto",
-
         # macOS RStudio IDE embedded installation
         "/Applications/RStudio.app/Contents/MacOS/quarto/bin/quarto",
-
         # macOS RStudio IDE electron embedded installation; location not final.
         # see: https://github.com/rstudio/rstudio/issues/10674
     ]
@@ -498,7 +494,7 @@ def which_quarto(quarto = None):
         found = shutil.which(each)
         if found:
             return found
-    raise api.RSConnectException('Unable to locate a Quarto installation.')
+    raise api.RSConnectException("Unable to locate a Quarto installation.")
 
 
 def quarto_inspect(

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1072,7 +1072,7 @@ def gather_basic_deployment_info_for_html(connect_server, app_store, path, new, 
             # Use the saved app information unless overridden by the user.
             app_id, existing_app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
             logger.debug("Using app mode from app %s: %s" % (app_id, app_mode))
-        elif app_id:
+        elif app_id is not None:
             # Don't read app metadata if app-id is specified. Instead, we need
             # to get this from Connect.
             app = api.get_app_info(connect_server, app_id)

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1065,18 +1065,24 @@ def gather_basic_deployment_info_for_html(connect_server, app_store, path, new, 
         raise api.RSConnectException("Specify either a new deploy or an app ID but not both.")
 
     app_mode = AppModes.STATIC
-    if app_id is not None:
+    existing_app_mode = None
+    if app_id is None:
+        # Possible redeployment - check for saved metadata.
+        # Use the saved app information unless overridden by the user.
+        app_id, existing_app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
+        logger.debug("Using app mode from app %s: %s" % (app_id, app_mode))
+    else:
         # Don't read app metadata if app-id is specified. Instead, we need
         # to get this from Connect.
         app = api.get_app_info(connect_server, app_id)
-        app_mode = AppModes.get_by_ordinal(app.get("app_mode", 0), True)
-
-        logger.debug("Using app mode from app %s: %s" % (app_id, app_mode))
-
-    if not new and app_id is None:
-        # Possible redeployment - check for saved metadata.
-        # Use the saved app information unless overridden by the user.
-        app_id, app_mode = app_store.resolve(connect_server.url, app_id, app_mode)
+        existing_app_mode = AppModes.get_by_ordinal(app.get("app_mode", 0), True)
+    if not new and existing_app_mode and app_mode != existing_app_mode:
+        msg = (
+            "Deploying with mode '%s',\n"
+            + "but the existing deployment has mode '%s'.\n"
+            + "Use the --new option to create a new deployment of the desired type."
+        ) % (app_mode.desc(), existing_app_mode.desc())
+        raise api.RSConnectException(msg)
 
     default_title = not bool(title)
     title = title or _default_title(path)

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -383,6 +383,7 @@ def make_manifest_bundle(manifest_path):
 
     return bundle_file
 
+
 # def make_html_bundle(path):
 #     """Create a bundle, given a manifest.
 
@@ -409,6 +410,7 @@ def make_manifest_bundle(manifest_path):
 #     bundle_file.seek(0)
 
 #     return bundle_file
+
 
 def create_glob_set(directory, excludes):
     """
@@ -534,6 +536,7 @@ def make_api_manifest(
 
     return manifest, relevant_files
 
+
 def make_html_fileslist(
     path,  # type: str
     entry_point,  # type: str
@@ -550,11 +553,11 @@ def make_html_fileslist(
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :return: the manifest and a list of the files involved.
     """
-    entry_point = entry_point or infer_entrypoint(path, 'text/html')
+    entry_point = entry_point or infer_entrypoint(path, "text/html")
     if is_environment_dir(path):
         excludes = list(excludes or []) + ["bin/", "lib/"]
 
-    relevant_files = _create_api_file_list(path, "", extra_files, excludes)    
+    relevant_files = _create_api_file_list(path, "", extra_files, excludes)
     manifest = make_html_manifest(entry_point)
 
     for rel_path in relevant_files:
@@ -562,21 +565,22 @@ def make_html_fileslist(
 
     return manifest, relevant_files
 
+
 def infer_entrypoint(path, mimetype):
     if os.path.isfile(path):
         return path
     if not os.path.isdir(path):
         raise ValueError("Entrypoint is not a valid file type or directory.")
-    
-    default_mimetype_entrypoints = {'text/html': 'index.html'}
+
+    default_mimetype_entrypoints = {"text/html": "index.html"}
     if mimetype not in default_mimetype_entrypoints:
         raise ValueError("Not supported mimetype inference.")
 
-    entrypoint_candidates = []    
+    entrypoint_candidates = []
     mimetype_dict = defaultdict(list)
 
     for subdir, dirs, files in os.walk(path):
-        for file in files:            
+        for file in files:
             abs_path = os.path.join(subdir, file)
             rel_path = os.path.relpath(abs_path, path)
             mimetype_dict[guess_type(file)[0]].append((file, rel_path))
@@ -586,6 +590,7 @@ def infer_entrypoint(path, mimetype):
             entrypoint_candidates.append(rel_path)
 
     return entrypoint_candidates.pop() if len(entrypoint_candidates) == 1 else None
+
 
 def make_html_bundle(
     path,  # type: str

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -69,7 +69,7 @@ def manifest_add_file(manifest, rel_path, base_dir):
 
     The file must be specified as a pathname relative to the notebook directory.
     """
-    path = join(base_dir, rel_path) if base_dir != rel_path else rel_path
+    path = join(base_dir, rel_path) if os.path.isdir(base_dir) else rel_path
     if "files" not in manifest:
         manifest["files"] = {}
     manifest["files"][rel_path] = {"checksum": file_checksum(path)}
@@ -124,7 +124,7 @@ def bundle_add_file(bundle, rel_path, base_dir):
 
     The file path is relative to the notebook directory.
     """
-    path = join(base_dir, rel_path) if base_dir != rel_path else rel_path
+    path = join(base_dir, rel_path) if os.path.isdir(base_dir) else rel_path
     logger.debug("adding file: %s", rel_path)
     bundle.add(path, arcname=rel_path)
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -274,6 +274,7 @@ def make_html_manifest(filename):
             "appmode": "static",
             "primary_html": filename,
         },
+        "files": {}
     }
 
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -69,7 +69,7 @@ def manifest_add_file(manifest, rel_path, base_dir):
 
     The file must be specified as a pathname relative to the notebook directory.
     """
-    path = join(base_dir, rel_path)
+    path = join(base_dir, rel_path) if base_dir != rel_path else rel_path
     if "files" not in manifest:
         manifest["files"] = {}
     manifest["files"][rel_path] = {"checksum": file_checksum(path)}
@@ -124,8 +124,8 @@ def bundle_add_file(bundle, rel_path, base_dir):
 
     The file path is relative to the notebook directory.
     """
+    path = join(base_dir, rel_path) if base_dir != rel_path else rel_path
     logger.debug("adding file: %s", rel_path)
-    path = join(base_dir, rel_path)
     bundle.add(path, arcname=rel_path)
 
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -274,7 +274,7 @@ def make_html_manifest(filename):
             "appmode": "static",
             "primary_html": filename,
         },
-        "files": {}
+        "files": {},
     }
 
 
@@ -604,7 +604,6 @@ def infer_entrypoint(path, mimetype):
         mimetype_filelist[guess_type(file)[0]].append(rel_path)
         if file in default_mimetype_entrypoints[mimetype]:
             return file
-
     return mimetype_filelist[mimetype].pop() if len(mimetype_filelist[mimetype]) == 1 else None
 
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -384,34 +384,6 @@ def make_manifest_bundle(manifest_path):
     return bundle_file
 
 
-# def make_html_bundle(path):
-#     """Create a bundle, given a manifest.
-
-#     :return: a file-like object containing the bundle tarball.
-#     """
-#     # path = validate_html_path(path)
-
-#     base_dir = dirname(path)
-#     files = list(filter(keep_manifest_specified_file, path.get("files", {}).keys()))
-
-#     # if "manifest.json" in files:
-#     #     # this will be created
-#     #     files.remove("manifest.json")
-
-#     bundle_file = tempfile.TemporaryFile(prefix="rsc_bundle")
-#     with tarfile.open(mode="w:gz", fileobj=bundle_file) as bundle:
-#         # # add the manifest first in case we want to partially untar the bundle for inspection
-#         # bundle_add_buffer(bundle, "manifest.json", raw_manifest)
-
-#         for rel_path in files:
-#             bundle_add_file(bundle, rel_path, base_dir)
-
-#     # rewind file pointer
-#     bundle_file.seek(0)
-
-#     return bundle_file
-
-
 def create_glob_set(directory, excludes):
     """
     Takes a list of glob strings and produces a GlobSet for path matching.

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -549,15 +549,15 @@ def infer_entrypoint(path, mimetype):
         raise ValueError("Not supported mimetype inference.")
 
     entrypoint_candidates = []
-    mimetype_dict = defaultdict(list)
+    mimetype_filelist = defaultdict(list)
 
     for subdir, dirs, files in os.walk(path):
         for file in files:
             abs_path = os.path.join(subdir, file)
             rel_path = os.path.relpath(abs_path, path)
-            mimetype_dict[guess_type(file)[0]].append((file, rel_path))
+            mimetype_filelist[guess_type(file)[0]].append((file, rel_path))
 
-    for file, rel_path in mimetype_dict[mimetype]:
+    for file, rel_path in mimetype_filelist[mimetype]:
         if file in default_mimetype_entrypoints[mimetype]:
             entrypoint_candidates.append(rel_path)
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -576,7 +576,7 @@ def make_html_fileslist(
     if is_environment_dir(path):
         excludes = list(excludes or []) + ["bin/", "lib/"]
 
-    relevant_files = _create_api_file_list(path, "", extra_files, excludes)
+    relevant_files = _create_file_list(path, extra_files, excludes)
     manifest = make_html_manifest(entrypoint)
 
     for rel_path in relevant_files:

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -563,7 +563,29 @@ def make_html_fileslist(
     return manifest, relevant_files
 
 def infer_entrypoint(path, mimetype):
-    pass
+    if os.path.isfile(path):
+        return path
+    if not os.path.isdir(path):
+        raise ValueError("Entrypoint is not a valid file type or directory.")
+    
+    default_mimetype_entrypoints = {'text/html': 'index.html'}
+    if mimetype not in default_mimetype_entrypoints:
+        raise ValueError("Not supported mimetype inference.")
+
+    entrypoint_candidates = []    
+    mimetype_dict = defaultdict(list)
+
+    for subdir, dirs, files in os.walk(path):
+        for file in files:            
+            abs_path = os.path.join(subdir, file)
+            rel_path = os.path.relpath(abs_path, path)
+            mimetype_dict[guess_type(file)[0]].append((file, rel_path))
+
+    for file, rel_path in mimetype_dict[mimetype]:
+        if file in default_mimetype_entrypoints[mimetype]:
+            entrypoint_candidates.append(rel_path)
+
+    return entrypoint_candidates.pop() if len(entrypoint_candidates) == 1 else None
 
 def make_html_bundle(
     path,  # type: str

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -511,7 +511,7 @@ def make_api_manifest(
 
 def make_html_fileslist(
     path,  # type: str
-    entry_point,  # type: str
+    entrypoint,  # type: str
     extra_files=None,  # type: typing.Optional[typing.List[str]]
     excludes=None,  # type: typing.Optional[typing.List[str]]
 ):
@@ -525,12 +525,12 @@ def make_html_fileslist(
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :return: the manifest and a list of the files involved.
     """
-    entry_point = entry_point or infer_entrypoint(path, "text/html")
+    entrypoint = entrypoint or infer_entrypoint(path, "text/html")
     if is_environment_dir(path):
         excludes = list(excludes or []) + ["bin/", "lib/"]
 
     relevant_files = _create_api_file_list(path, "", extra_files, excludes)
-    manifest = make_html_manifest(entry_point)
+    manifest = make_html_manifest(entrypoint)
 
     for rel_path in relevant_files:
         manifest_add_file(manifest, rel_path, path)

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -274,7 +274,6 @@ def make_html_manifest(filename):
             "appmode": "static",
             "primary_html": filename,
         },
-        "files": {},
     }
 
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -550,12 +550,11 @@ def infer_entrypoint(path, mimetype):
 
     mimetype_filelist = defaultdict(list)
 
-    for _, _, files in os.walk(path):
-        for file in files:
-            mimetype_filelist[guess_type(file)[0]].append(file)
-            if file in default_mimetype_entrypoints[mimetype]:
-                return file
-        break  # stop scan after top level
+    for file in os.listdir(path):
+        if not os.path.isfile(file): continue
+        mimetype_filelist[guess_type(file)[0]].append(file)
+        if file in default_mimetype_entrypoints[mimetype]:
+            return file
 
     return mimetype_filelist[mimetype].pop() if len(mimetype_filelist[mimetype]) == 1 else None
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -598,9 +598,10 @@ def infer_entrypoint(path, mimetype):
     mimetype_filelist = defaultdict(list)
 
     for file in os.listdir(path):
-        if not os.path.isfile(file):
+        rel_path = os.path.join(path, file)
+        if not os.path.isfile(rel_path):
             continue
-        mimetype_filelist[guess_type(file)[0]].append(file)
+        mimetype_filelist[guess_type(file)[0]].append(rel_path)
         if file in default_mimetype_entrypoints[mimetype]:
             return file
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -551,7 +551,8 @@ def infer_entrypoint(path, mimetype):
     mimetype_filelist = defaultdict(list)
 
     for file in os.listdir(path):
-        if not os.path.isfile(file): continue
+        if not os.path.isfile(file):
+            continue
         mimetype_filelist[guess_type(file)[0]].append(file)
         if file in default_mimetype_entrypoints[mimetype]:
             return file

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -70,7 +70,8 @@ def manifest_add_file(manifest, rel_path, base_dir):
     The file must be specified as a pathname relative to the notebook directory.
     """
     path = join(base_dir, rel_path)
-
+    if "files" not in manifest:
+        manifest["files"] = {}
     manifest["files"][rel_path] = {"checksum": file_checksum(path)}
 
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -548,20 +548,16 @@ def infer_entrypoint(path, mimetype):
     if mimetype not in default_mimetype_entrypoints:
         raise ValueError("Not supported mimetype inference.")
 
-    entrypoint_candidates = []
     mimetype_filelist = defaultdict(list)
 
-    for subdir, dirs, files in os.walk(path):
+    for _, _, files in os.walk(path):
         for file in files:
-            abs_path = os.path.join(subdir, file)
-            rel_path = os.path.relpath(abs_path, path)
-            mimetype_filelist[guess_type(file)[0]].append((file, rel_path))
+            mimetype_filelist[guess_type(file)[0]].append(file)
+            if file in default_mimetype_entrypoints[mimetype]:
+                return file
+        break  # stop scan after top level
 
-    for file, rel_path in mimetype_filelist[mimetype]:
-        if file in default_mimetype_entrypoints[mimetype]:
-            entrypoint_candidates.append(rel_path)
-
-    return entrypoint_candidates.pop() if len(entrypoint_candidates) == 1 else None
+    return mimetype_filelist[mimetype].pop() if len(mimetype_filelist[mimetype]) == 1 else None
 
 
 def make_html_bundle(

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -517,7 +517,9 @@ def _create_file_list(
                 abs_path = os.path.join(subdir, file)
                 rel_path = os.path.relpath(abs_path, path)
 
-                if keep_manifest_specified_file(rel_path) and (rel_path in extra_files or not glob_set.matches(abs_path)):
+                if keep_manifest_specified_file(rel_path) and (
+                    rel_path in extra_files or not glob_set.matches(abs_path)
+                ):
                     file_list.append(rel_path)
                     # Don't add extra files more than once.
                     if rel_path in extra_files:

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -40,7 +40,7 @@ def _get_proxy():
     parsed = urlparse(proxyURL)
     if parsed.scheme not in ["https"]:
         raise Exception("HTTPS_PROXY scheme must be https://")
-    redacted_url = "{}://".format(parsed.scheme) 
+    redacted_url = "{}://".format(parsed.scheme)
     if parsed.username:
         redacted_url += "{}:{}@".format(parsed.username, "REDACTED")
     redacted_url += "{}:{}".format(parsed.hostname, parsed.port or 8080)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1036,6 +1036,7 @@ def deploy_html(
         env_vars,
     )
 
+
 def generate_deploy_python(app_mode, alias, min_version):
     # noinspection SpellCheckingInspection
     @deploy.command(

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -873,6 +873,7 @@ def deploy_html(
     excludes,
 ):
     set_verbosity(verbose)
+    path = abspath(path)
 
     with cli_feedback("Checking arguments"):
         connect_server = _validate_deploy_to_args(name, server, api_key, insecure, cacert)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -850,17 +850,11 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
         "This option may be repeated."
     ),
 )
-@click.option(
-    "--extra_files",
-    required=False,
-    type=click.Path(exists=True, dir_okay=True, file_okay=True),
-)
-@click.option(
-    "--path",
-    "-p",
-    required=True,
-    type=click.Path(exists=True, dir_okay=True, file_okay=True),
-    help=("File or directory of the html content."),
+@click.argument("path", type=click.Path(exists=True, dir_okay=True, file_okay=True))
+@click.argument(
+    "extra_files",
+    nargs=-1,
+    type=click.Path(exists=True, dir_okay=False, file_okay=True),
 )
 def deploy_html(
     name,

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -997,7 +997,6 @@ def deploy_html(
     excludes,
 ):
     set_verbosity(verbose)
-    path = abspath(path)
 
     with cli_feedback("Checking arguments"):
         connect_server = _validate_deploy_to_args(name, server, api_key, insecure, cacert)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 from os.path import abspath, dirname, exists, isdir, join
 
+
 import click
 from six import text_type
 
@@ -826,6 +827,12 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
     )
 
 
+# noinspection SpellCheckingInspection,DuplicatedCode
+@deploy.command(
+    name="html",
+    short_help="Deploy html content to RStudio Connect.",
+    help=("Deploy an html file, or directory of html files with entrypoint, to RStudio Connect."),
+)
 @server_args
 @content_args
 @click.option(
@@ -834,7 +841,7 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
     help=("The name of the html file that is the landing page."),
 )
 @click.option(
-    "--exclude",
+    "--excludes",
     "-x",
     multiple=True,
     help=(
@@ -843,13 +850,19 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
         "This option may be repeated."
     ),
 )
-@click.argument("directory", type=click.Path(exists=True, dir_okay=True, file_okay=False))
-@click.argument(
-    "extra_files",
-    nargs=-1,
-    type=click.Path(exists=True, dir_okay=False, file_okay=True),
+@click.option(
+    "--extra_files",
+    required=False,
+    type=click.Path(exists=True, dir_okay=True, file_okay=True),
 )
-@click.argument("path", type=click.Path(exists=True, dir_okay=True, file_okay=True))
+# @click.argument("path", type=click.Path(exists=True, dir_okay=True, file_okay=True), help=("File or directory of the html content."))
+@click.option(
+    "--path",
+    "-p",
+    required=True,
+    type=click.Path(exists=True, dir_okay=True, file_okay=True),
+    help=("File or directory of the html content."),
+)
 def deploy_html(
     name,
     server,

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -57,8 +57,6 @@ from .bundle import (
     is_environment_dir,
     make_manifest_bundle,
     make_html_bundle,
-    make_html_manifest,
-    infer_entrypoint,
 )
 from .log import logger, LogOutputFormat
 from .metadata import ServerStore, AppStore

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -819,7 +819,8 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
         bundle,
         env_vars,
     )
-    
+
+
 @server_args
 @content_args
 @click.argument("file", type=click.Path(exists=True, dir_okay=True, file_okay=True))

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -53,7 +53,13 @@ from .actions_content import (
 )
 
 from . import api, VERSION
-from .bundle import is_environment_dir, make_manifest_bundle, make_html_bundle
+from .bundle import (
+    is_environment_dir,
+    make_manifest_bundle,
+    make_html_bundle,
+    make_html_manifest,
+    infer_entrypoint,
+)
 from .log import logger, LogOutputFormat
 from .metadata import ServerStore, AppStore
 from .models import (
@@ -64,10 +70,6 @@ from .models import (
     VersionSearchFilterParamType,
 )
 
-from bundle import (
-    make_html_manifest,
-    infer_entrypoint,
-)
 
 server_store = ServerStore()
 future_enabled = False

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -830,7 +830,7 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
 @click.option(
     "--entrypoint",
     "-e",
-    help=("The module and executable object which serves as the entry point for the html landing page."),
+    help=("The name of the html file that is the landing page."),
 )
 @click.option(
     "--exclude",

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -24,6 +24,7 @@ from .actions import (
     gather_basic_deployment_info_for_bokeh,
     gather_basic_deployment_info_for_notebook,
     gather_basic_deployment_info_from_manifest,
+    gather_basic_deployment_info_for_html,
     gather_server_details,
     get_python_env_info,
     is_conda_supported_on_server,
@@ -877,7 +878,7 @@ def deploy_html(
             title,
             default_title,
             app_mode,
-        ) = gather_basic_deployment_info_for_notebook(connect_server, app_store, path, new, app_id, title, True)
+        ) = gather_basic_deployment_info_for_html(connect_server, app_store, path, new, app_id, title)
 
     click.secho('    Deploying %s to server "%s"' % (path, connect_server.url))
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -855,7 +855,6 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
     required=False,
     type=click.Path(exists=True, dir_okay=True, file_okay=True),
 )
-# @click.argument("path", type=click.Path(exists=True, dir_okay=True, file_okay=True), help=("File or directory of the html content."))
 @click.option(
     "--path",
     "-p",

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -832,7 +832,7 @@ def deploy_manifest(name, server, api_key, insecure, cacert, new, app_id, title,
 @click.option(
     "--entrypoint",
     "-e",
-    help=("The module and executable object which serves as the entry point for the deployment."),
+    help=("The module and executable object which serves as the entry point for the html landing page."),
 )
 @click.option(
     "--exclude",


### PR DESCRIPTION
### Description

Better support for deployment of static html files and bundles.

### QA/Testing

User should be able to deploy html content by passing a path (file or directory) to the new `deploy html` command

`rsconnect deploy html -n server index.html extra_file`

`rsconnect deploy html -n server folder`

