### PR TITLE
Show task result

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==22.1.0; python_version >= '3.6'
+black==22.3.0; python_version >= '3.6'
 click>=7.0.0
 coverage
 flake8

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -237,12 +237,17 @@ class RSConnect(HTTPServer):
                         if data or type:
                             log_callback("%s (%s)" % (data, type))
 
+                    err = task_status.get("error")
+                    if err:
+                        log_callback(err)
+
                     exit_code = task_status["code"]
                     if exit_code != 0:
                         exit_status = "Task exited with status %d." % exit_code
-                        log_callback("Task failed. %s" % exit_status)
                         if raise_on_error:
                             raise RSConnectException(exit_status)
+                        else:
+                            log_callback("Task failed. %s" % exit_status)
                     return log_lines, task_status
 
     @staticmethod

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -230,6 +230,13 @@ class RSConnect(HTTPServer):
                 self._server.handle_bad_response(task_status)
                 last_status = self.output_task_log(task_status, last_status, log_callback)
                 if task_status["finished"]:
+                    result = task_status.get("result")
+                    if isinstance(result, dict):
+                        data = result.get("data", "")
+                        type = result.get("type", "")
+                        if data or type:
+                            log_callback("%s (%s)" % (data, type))
+
                     exit_code = task_status["code"]
                     if exit_code != 0:
                         exit_status = "Task exited with status %d." % exit_code

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -239,7 +239,7 @@ class RSConnect(HTTPServer):
 
                     err = task_status.get("error")
                     if err:
-                        log_callback(err)
+                        log_callback("Error from Connect server: " + err)
 
                     exit_code = task_status["code"]
                     if exit_code != 0:


### PR DESCRIPTION
### Description

If a deployment fails, show the result from Connect. This ensures that there will be an error shown even in cases where the deployment fails before the build or rendering process can be kicked off. For example, this can occur if there isn't a matching Python version available.

### Testing Notes / Validation Steps

Deploy content which requests a Python version not available at Connect. The easiest way to do this is by editing an existing manifest and using `rsconnect deploy manifest`.

