### PR TITLE
Remove API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The rsconnect-python CLI and library
+# The rsconnect-python CLI
 
 !!! warning
 
@@ -6,8 +6,8 @@
     [official announcement](https://www.rstudio.com/blog/rstudio-connect-2021-08-python-updates/)
     for details about this decision.
 
-This package provides both a CLI (command-line interface) and a library for interacting
-with and deploying to RStudio Connect. The library is also used by the
+This package provides a CLI (command-line interface) for interacting
+with and deploying to RStudio Connect. This is also used by the
 [`rsconnect-jupyter`](https://github.com/rstudio/rsconnect-jupyter) package to deploy
 Jupyter notebooks via the Jupyter web console. Many types of content supported by RStudio
 Connect may be deployed by this package, including WSGI-style APIs, Dash, Streamlit, and

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: 'RStudio Connect: rsconnect-python Library'
+site_name: 'RStudio Connect: rsconnect-python'
 
 markdown_extensions:
   - toc:
@@ -14,11 +14,9 @@ markdown_extensions:
 plugins:
   - macros
   - search
-  - mkapi
 
 nav:
   - index.md
-  - API: mkapi/api/rsconnect
   - changelog.md
 
 theme:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
 Pygments
 markdown
 markdown-include
-mkapi
 mkdocs
 mkdocs-exclude
 mkdocs-macros-plugin


### PR DESCRIPTION
This PR removes the API docs, which are currently hosted at https://docs.rstudio.com/rsconnect-python/api/rsconnect/.

The functions documented there are mostly internal implementation details and are not suited for public consumption.

Fixes #208 