### PR TITLE
make env_vars optional

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1521,7 +1521,7 @@ def create_quarto_deployment_bundle(
     return make_quarto_source_bundle(directory, inspect, app_mode, environment, extra_files, excludes)
 
 
-def deploy_bundle(connect_server, app_id, name, title, title_is_default, bundle, env_vars):
+def deploy_bundle(connect_server, app_id, name, title, title_is_default, bundle, env_vars=None):
     """
     Deploys the specified bundle.
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -142,7 +142,7 @@ class RSConnect(HTTPServer):
         self._server.handle_bad_response(response)
         return response
 
-    def deploy(self, app_id, app_name, app_title, title_is_default, tarball, env_vars):
+    def deploy(self, app_id, app_name, app_title, title_is_default, tarball, env_vars=None):
         if app_id is None:
             # create an app if id is not provided
             app = self.app_create(app_name)


### PR DESCRIPTION
### Description

make deploy env_vars optional for backwards compatibility

fixes https://github.com/rstudio/rsconnect-jupyter/issues/326

