### PR TITLE
Fix bug - remove image from deploy_html

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1038,7 +1038,6 @@ def deploy_html(
     entrypoint,
     extra_files,
     excludes,
-    image,
 ):
     set_verbosity(verbose)
 
@@ -1059,7 +1058,7 @@ def deploy_html(
 
     with cli_feedback("Creating deployment bundle"):
         try:
-            bundle = make_html_bundle(path, entrypoint, image, extra_files, excludes)
+            bundle = make_html_bundle(path, entrypoint, "", extra_files, excludes)
         except IOError as error:
             msg = "Unable to include the file %s in the bundle: %s" % (
                 error.filename,


### PR DESCRIPTION
### Description

Attempting to use `rsconnect deploy html` produces the following error:

```
❯ rsconnect deploy html index.html *.json -t vitessce -n colorado
Traceback (most recent call last):
  File "/Users/edavidaja/.local/bin/rsconnect", line 8, in <module>
    sys.exit(cli())
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/rsconnect/main.py", line 116, in wrapper
    return func(*args, **kwargs)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/rsconnect/main.py", line 169, in wrapper
    return func(*args, **kwargs)
TypeError: deploy_html() missing 1 required positional argument: 'image'

vitessce-ex on  main [?] via R v4.1.2
❯ rsconnect deploy html index.html *.json -t vitessce -n colorado --image
Usage: rsconnect deploy html [OPTIONS] PATH [EXTRA_FILES]...
Try 'rsconnect deploy html --help' for help.

Error: No such option: --image Did you mean --name?

vitessce-ex on  main [?] via R v4.1.2
❯ rsconnect deploy html index.html *.json -t vitessce -n rstudioservices
Traceback (most recent call last):
  File "/Users/edavidaja/.local/bin/rsconnect", line 8, in <module>
    sys.exit(cli())
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/rsconnect/main.py", line 116, in wrapper
    return func(*args, **kwargs)
  File "/Users/edavidaja/.local/pipx/venvs/rsconnect-python/lib/python3.8/site-packages/rsconnect/main.py", line 169, in wrapper
    return func(*args, **kwargs)
TypeError: deploy_html() missing 1 required positional argument: 'image'
```

The error was caused in the non-removal of the image parameter into the callback function for deploying html. (The CLI interface was updated to remove image after it was deemed unnecessary but the implicit call from the CLI was not updated.)

Closes: rstudio/connect#21509

### Testing Notes / Validation Steps

I've added an HTML bundle to the `connect-content` repo to be used here. The following instructions will use the `dev-connect` workflow (assumed to be working) as well as the `connect-content` repo.

1. Start your connect server

```bash
# from within your connect repo
just start-dev-connect
```

2. Set up your python environment on the rsconnect-python branch:

```bash
# Within your repo
git checkout sagerb-fix-deploy-html-requiring-image
# Setup a virtual python environment
python3 -m venv .venv
# Activate the virtual environment
source .venv/bin/activate
# install our requirements into the virtual environment
pip install -r requirements.txt
# install rsconnect-python with a symbolic link to the locations repository, 
# meaning any changes to code in there will automatically be reflected
pip install -e ./
```

3. Deploy the html bundle

```bash
# from the venv python environment set up in step 2
# cd into your connect-content repo
git fetch
git pull
cd bundles/html
rsconnect deploy manifest -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf . 
```

4. Verify success and then navigate to page

You should see:

![2022-05-23 at 1 49 PM](https://user-images.githubusercontent.com/17675905/169903851-5c1f583d-adab-4f35-b9e1-817164f8162c.jpg)
