### PR TITLE
Switch image parameters to be optional at public api layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - You can now deploy static content such as html and its associated assets with 
   `rsconnect deploy html`.
 
+- An optional `image` parameter has been added to the applicable functions to support
+  target content image. This parameter defaults to `None` if not provided.
+
 ## [1.7.1] - 2022-02-15
 
 ### Added

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1535,7 +1535,6 @@ def create_notebook_deployment_bundle(
                 hide_all_input,
                 hide_tagged_input,
                 image=image,
-                check_output=None,
             )
         except subprocess.CalledProcessError as exc:
             # Jupyter rendering failures are often due to

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1029,7 +1029,7 @@ def _deploy_by_python_framework(
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
     :param gatherer: the function to use to gather basic information.
-    :param image: an optional docker image for off-host execution. Previous default = None.
+    :param image: the docker image to be specified for off-host execution. Use None if not specified.
     :param new: a flag to force this as a new deploy. Previous default = False.
     :param app_id: the ID of an existing application to deploy new files for. Previous default = None.
     :param title: an optional title for the deploy.  If this is not provided, one will
@@ -1501,7 +1501,7 @@ def create_notebook_deployment_bundle(
     extra_files_need_validating: bool,
     hide_all_input: bool,
     hide_tagged_input: bool,
-    image: str,
+    image: str = None,
 ) -> typing.IO[bytes]:
     """
     Create an in-memory bundle, ready to deploy.
@@ -1511,7 +1511,6 @@ def create_notebook_deployment_bundle(
     :param app_mode: the mode of the app being deployed.
     :param python: information about the version of Python being used.
     :param environment: environmental information.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param extra_files_need_validating: a flag indicating whether the list of extra
      files should be validated or not.  Part of validating includes qualifying each
     with the parent directory of the notebook file.  If you provide False here, make
@@ -1519,6 +1518,7 @@ def create_notebook_deployment_bundle(
     :param hide_all_input: if True, will hide all input cells when rendering output. Previous default = False.
     :param hide_tagged_input: If True, will hide input code cells with
     the 'hide_input' tag when rendering output.  Previous default = False.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
 
     :return: the bundle.
     """
@@ -1673,7 +1673,7 @@ def create_notebook_manifest_and_environment_file(
     force: bool,
     hide_all_input: bool,
     hide_tagged_input: bool,
-    image: str,
+    image: str = None,
 ) -> None:
     """
     Creates and writes a manifest.json file for the given notebook entry point file.
@@ -1711,7 +1711,7 @@ def write_notebook_manifest_json(
     extra_files: typing.List[str],
     hide_all_input: bool,
     hide_tagged_input: bool,
-    image: str,
+    image: str = None,
 ) -> bool:
     """
     Creates and writes a manifest.json file for the given entry point file.  If
@@ -1728,7 +1728,7 @@ def write_notebook_manifest_json(
     :param hide_all_input: if True, will hide all input cells when rendering output. Previous default = False.
     :param hide_tagged_input: If True, will hide input code cells with the 'hide_input' tag
     when rendering output.  Previous default = False.
-    :param image: an optional docker image for off-host execution. Previous default = None.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: whether or not the environment file (requirements.txt, environment.yml,
     etc.) that goes along with the manifest exists.
     """

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -533,7 +533,7 @@ def write_quarto_manifest_json(
     environment: Environment,
     extra_files: typing.List[str],
     excludes: typing.List[str],
-    image: str,
+    image: str = None,
 ) -> None:
     """
     Creates and writes a manifest.json file for the given Quarto project.
@@ -544,11 +544,11 @@ def write_quarto_manifest_json(
     :param environment: The (optional) Python environment to use.
     :param extra_files: Any extra files to include in the manifest.
     :param excludes: A sequence of glob patterns to exclude when enumerating files to bundle.
-    :param image: the docker image to be specified for off-host execution (or None if no image is specified).
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     """
 
     extra_files = validate_extra_files(directory, extra_files)
-    manifest, _ = make_quarto_manifest(directory, inspect, app_mode, image, environment, extra_files, excludes)
+    manifest, _ = make_quarto_manifest(directory, inspect, app_mode, environment, extra_files, excludes, image)
     manifest_path = join(directory, "manifest.json")
 
     write_manifest_json(manifest_path, manifest)
@@ -567,7 +567,6 @@ def deploy_jupyter_notebook(
     connect_server: api.RSConnectServer,
     file_name: str,
     extra_files: typing.List[str],
-    image: str,
     new: bool,
     app_id: int,
     title: str,
@@ -578,6 +577,7 @@ def deploy_jupyter_notebook(
     log_callback: typing.Callable,
     hide_all_input: bool,
     hide_tagged_input: bool,
+    image: str = None,
 ) -> typing.Tuple[typing.Any, typing.List]:
     """
     A function to deploy a Jupyter notebook to Connect.  Depending on the files involved
@@ -586,7 +586,6 @@ def deploy_jupyter_notebook(
     :param connect_server: the Connect server information.
     :param file_name: the Jupyter notebook file to deploy.
     :param extra_files: any extra files that should be included in the deploy.
-    :param image: an optional docker image for off-host execution, previous default = None.
     :param new: a flag indicating a new deployment, previous default = False.
     :param app_id: the ID of an existing application to deploy new files for, previous default = None.
     :param title: an optional title for the deploy.  If this is not provided, one will
@@ -605,6 +604,7 @@ def deploy_jupyter_notebook(
     :param hide_all_input: if True, will hide all input cells when rendering output.  Previous default = False.
     :param hide_tagged_input: If True, will hide input code cells with the 'hide_input' tag when rendering
     output. Previous default = False.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the ultimate URL where the deployed app may be accessed and the sequence
     of log lines.  The log lines value will be None if a log callback was provided.
     """
@@ -670,7 +670,6 @@ def _finalize_deploy(
     (the default) the lines from the deployment log will be returned as a sequence.
     If a log callback is provided, then None will be returned for the log lines part
     of the return tuple.
-    :param image: an optional docker image for off-host execution.
     :return: the ultimate URL where the deployed app may be accessed and the sequence
     of log lines.  The log lines value will be None if a log callback was provided.
     """
@@ -707,7 +706,6 @@ def deploy_python_api(
     extra_files: typing.List[str],
     excludes: typing.List[str],
     entry_point: str,
-    image: str,
     new: bool,
     app_id: int,
     title: str,
@@ -715,6 +713,7 @@ def deploy_python_api(
     conda_mode: bool,
     force_generate: bool,
     log_callback: typing.Callable,
+    image: str = None,
 ) -> typing.Tuple[str, typing.Union[list, None]]:
     """
     A function to deploy a Python WSGi API module to Connect.  Depending on the files involved
@@ -725,7 +724,6 @@ def deploy_python_api(
     :param extra_files: any extra files that should be included in the deploy.
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param new: a flag to force this as a new deploy. Previous default = False.
     :param app_id: the ID of an existing application to deploy new files for. Previous default = None.
     :param title: an optional title for the deploy.  If this is not provided, one will
@@ -739,6 +737,7 @@ def deploy_python_api(
     (the default) the lines from the deployment log will be returned as a sequence.
     If a log callback is provided, then None will be returned for the log lines part
     of the return tuple. Previous default = None.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the ultimate URL where the deployed app may be accessed and the sequence
     of log lines.  The log lines value will be None if a log callback was provided.
     """
@@ -766,7 +765,6 @@ def deploy_python_fastapi(
     extra_files: typing.List[str],
     excludes: typing.List[str],
     entry_point: str,
-    image: str,
     new: bool,
     app_id: int,
     title: str,
@@ -774,6 +772,7 @@ def deploy_python_fastapi(
     conda_mode: bool,
     force_generate: bool,
     log_callback: typing.Callable,
+    image: str = None,
 ) -> typing.Tuple[str, typing.Union[list, None]]:
     """
     A function to deploy a Python ASGI API module to RStudio Connect.  Depending on the files involved
@@ -784,7 +783,6 @@ def deploy_python_fastapi(
         :param extra_files: any extra files that should be included in the deploy.
         :param excludes: a sequence of glob patterns that will exclude matched files.
         :param entry_point: the module/executable object for the WSGi framework.
-        :param image: an optional docker image for off-host execution. Previous default = None.
         :param new: a flag to force this as a new deploy. Previous default = False.
         :param app_id: the ID of an existing application to deploy new files for. Previous default = None.
         :param title: an optional title for the deploy.  If this is not provided, one will
@@ -798,6 +796,7 @@ def deploy_python_fastapi(
         (the default) the lines from the deployment log will be returned as a sequence.
         If a log callback is provided, then None will be returned for the log lines part
         of the return tuple. Previous default = None.
+        :param image: the optional docker image to be specified for off-host execution. Default = None.
         :return: the ultimate URL where the deployed app may be accessed and the sequence
         of log lines.  The log lines value will be None if a log callback was provided.
     """
@@ -825,7 +824,6 @@ def deploy_dash_app(
     extra_files: typing.List[str],
     excludes: typing.List[str],
     entry_point: str,
-    image: str,
     new: bool,
     app_id: int,
     title: str,
@@ -833,6 +831,7 @@ def deploy_dash_app(
     conda_mode: bool,
     force_generate: bool,
     log_callback: typing.Callable,
+    image: str = None,
 ) -> typing.Tuple[str, typing.Union[list, None]]:
     """
     A function to deploy a Python Dash app module to Connect.  Depending on the files involved
@@ -843,7 +842,6 @@ def deploy_dash_app(
     :param extra_files: any extra files that should be included in the deploy.
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param new: a flag to force this as a new deploy. Previous default = False.
     :param app_id: the ID of an existing application to deploy new files for. Previous default = None.
     :param title: an optional title for the deploy.  If this is not provided, one will
@@ -857,6 +855,7 @@ def deploy_dash_app(
     (the default) the lines from the deployment log will be returned as a sequence.
     If a log callback is provided, then None will be returned for the log lines part
     of the return tuple. Previous default = None.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the ultimate URL where the deployed app may be accessed and the sequence
     of log lines.  The log lines value will be None if a log callback was provided.
     """
@@ -884,7 +883,6 @@ def deploy_streamlit_app(
     extra_files: typing.List[str],
     excludes: typing.List[str],
     entry_point: str,
-    image: str,
     new: bool,
     app_id: int,
     title: str,
@@ -892,6 +890,7 @@ def deploy_streamlit_app(
     conda_mode: bool,
     force_generate: bool,
     log_callback: typing.Callable,
+    image: str = None,
 ) -> typing.Tuple[str, typing.Union[list, None]]:
     """
     A function to deploy a Python Streamlit app module to Connect.  Depending on the files involved
@@ -902,7 +901,6 @@ def deploy_streamlit_app(
     :param extra_files: any extra files that should be included in the deploy.
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param new: a flag to force this as a new deploy. Previous default = False.
     :param app_id: the ID of an existing application to deploy new files for. Previous default = None.
     :param title: an optional title for the deploy.  If this is not provided, one will
@@ -916,6 +914,7 @@ def deploy_streamlit_app(
     (the default) the lines from the deployment log will be returned as a sequence.
     If a log callback is provided, then None will be returned for the log lines part
     of the return tuple. Previous default = None.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the ultimate URL where the deployed app may be accessed and the sequence
     of log lines.  The log lines value will be None if a log callback was provided.
     """
@@ -943,7 +942,6 @@ def deploy_bokeh_app(
     extra_files: typing.List[str],
     excludes: typing.List[str],
     entry_point: str,
-    image: str,
     new: bool,
     app_id: int,
     title: str,
@@ -951,6 +949,7 @@ def deploy_bokeh_app(
     conda_mode: bool,
     force_generate: bool,
     log_callback: typing.Callable,
+    image: str = None,
 ) -> typing.Tuple[str, typing.Union[list, None]]:
     """
     A function to deploy a Python Bokeh app module to Connect.  Depending on the files involved
@@ -961,7 +960,6 @@ def deploy_bokeh_app(
     :param extra_files: any extra files that should be included in the deploy.
     :param excludes: a sequence of glob patterns that will exclude matched files.
     :param entry_point: the module/executable object for the WSGi framework.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param new: a flag to force this as a new deploy. Previous default = False.
     :param app_id: the ID of an existing application to deploy new files for. Previous default = None.
     :param title: an optional title for the deploy.  If this is not provided, one will
@@ -975,6 +973,7 @@ def deploy_bokeh_app(
     (the default) the lines from the deployment log will be returned as a sequence.
     If a log callback is provided, then None will be returned for the log lines part
     of the return tuple. Previous default = None.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the ultimate URL where the deployed app may be accessed and the sequence
     of log lines.  The log lines value will be None if a log callback was provided.
     """
@@ -1056,7 +1055,7 @@ def _deploy_by_python_framework(
         force_generate=force_generate,
     )
     bundle = create_api_deployment_bundle(
-        directory, extra_files, excludes, entry_point, app_mode, environment, image, True
+        directory, extra_files, excludes, entry_point, app_mode, environment, True, image
     )
     return _finalize_deploy(
         connect_server,
@@ -1142,7 +1141,6 @@ def gather_basic_deployment_info_for_notebook(
     :param title: an optional title.  If this isn't specified, a default title will
     be generated.
     :param static: a flag to note whether a static document should be deployed.
-    :param image: an optional docker image for off-host execution.
     :return: the app ID, name, title information and mode for the deployment.
     """
     validate_file_is_notebook(file_name)
@@ -1541,8 +1539,8 @@ def create_api_deployment_bundle(
     entry_point: str,
     app_mode: AppMode,
     environment: Environment,
-    image: str,
     extra_files_need_validating: bool,
+    image: str = None,
 ) -> typing.IO[bytes]:
     """
     Create an in-memory bundle, ready to deploy.
@@ -1553,11 +1551,11 @@ def create_api_deployment_bundle(
     :param entry_point: the module/executable object for the WSGi framework.
     :param app_mode: the mode of the app being deployed.
     :param environment: environmental information.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param extra_files_need_validating: a flag indicating whether the list of extra
     files should be validated or not.  Part of validating includes qualifying each
     with the specified directory.  If you provide False here, make sure the names
     are properly qualified first. Previous default = True.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the bundle.
     """
     entry_point = validate_entry_point(entry_point, directory)
@@ -1568,7 +1566,7 @@ def create_api_deployment_bundle(
     if app_mode is None:
         app_mode = AppModes.PYTHON_API
 
-    return make_api_bundle(directory, entry_point, app_mode, environment, image, extra_files, excludes)
+    return make_api_bundle(directory, entry_point, app_mode, environment, extra_files, excludes, image)
 
 
 def create_quarto_deployment_bundle(
@@ -1578,8 +1576,8 @@ def create_quarto_deployment_bundle(
     app_mode: AppMode,
     inspect: typing.Dict[str, typing.Any],
     environment: Environment,
-    image: str,
     extra_files_need_validating: bool,
+    image: str = None,
 ) -> typing.IO[bytes]:
     """
     Create an in-memory bundle, ready to deploy.
@@ -1590,11 +1588,11 @@ def create_quarto_deployment_bundle(
     :param entry_point: the module/executable object for the WSGi framework.
     :param app_mode: the mode of the app being deployed.
     :param environment: environmental information.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param extra_files_need_validating: a flag indicating whether the list of extra
     files should be validated or not.  Part of validating includes qualifying each
     with the specified directory.  If you provide False here, make sure the names
     are properly qualified first. Previous default = True.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the bundle.
     """
     if extra_files_need_validating:
@@ -1603,7 +1601,7 @@ def create_quarto_deployment_bundle(
     if app_mode is None:
         app_mode = AppModes.STATIC_QUARTO
 
-    return make_quarto_source_bundle(directory, inspect, app_mode, image, environment, extra_files, excludes)
+    return make_quarto_source_bundle(directory, inspect, app_mode, environment, extra_files, excludes, image)
 
 
 def deploy_bundle(
@@ -1725,7 +1723,7 @@ def write_notebook_manifest_json(
         if app_mode == AppModes.UNKNOWN:
             raise api.RSConnectException('Could not determine the app mode from "%s"; please specify one.' % extension)
 
-    manifest_data = make_source_manifest(app_mode, image, environment, file_name, None)
+    manifest_data = make_source_manifest(app_mode, environment, file_name, None, image)
     manifest_add_file(manifest_data, file_name, directory)
     manifest_add_buffer(manifest_data, environment.filename, environment.contents)
 
@@ -1741,11 +1739,11 @@ def create_api_manifest_and_environment_file(
     directory: str,
     entry_point: str,
     environment: Environment,
-    image: str,
     app_mode: AppMode,
     extra_files: typing.List[str],
     excludes: typing.List[str],
     force: bool,
+    image: str = None,
 ) -> None:
     """
     Creates and writes a manifest.json file for the given Python API entry point.  If
@@ -1756,16 +1754,16 @@ def create_api_manifest_and_environment_file(
     :param entry_point: the module/executable object for the WSGi framework.
     :param environment: the Python environment to start with.  This should be what's
     returned by the inspect_environment() function.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param app_mode: the application mode to assume. Previous default = AppModes.PYTHON_API.
     :param extra_files: any extra files that should be included in the manifest. Previous default = None.
     :param excludes: a sequence of glob patterns that will exclude matched files. Previous default = None.
     :param force: if True, forces the environment file to be written. even if it
     already exists. Previous default = True.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return:
     """
     if (
-        not write_api_manifest_json(directory, entry_point, environment, image, app_mode, extra_files, excludes)
+        not write_api_manifest_json(directory, entry_point, environment, app_mode, extra_files, excludes, image)
         or force
     ):
         write_environment_file(environment, directory)
@@ -1775,10 +1773,10 @@ def write_api_manifest_json(
     directory: str,
     entry_point: str,
     environment: Environment,
-    image: str,
     app_mode: AppMode,
     extra_files: typing.List[str],
     excludes: typing.List[str],
+    image: str = None,
 ) -> bool:
     """
     Creates and writes a manifest.json file for the given entry point file.  If
@@ -1789,15 +1787,15 @@ def write_api_manifest_json(
     :param entry_point: the module/executable object for the WSGi framework.
     :param environment: the Python environment to start with.  This should be what's
     returned by the inspect_environment() function.
-    :param image: an optional docker image for off-host execution. Previous default = None.
     :param app_mode: the application mode to assume. Previous default = AppModes.PYTHON_API.
     :param extra_files: any extra files that should be included in the manifest. Previous default = None.
     :param excludes: a sequence of glob patterns that will exclude matched files. Previous default = None.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: whether or not the environment file (requirements.txt, environment.yml,
     etc.) that goes along with the manifest exists.
     """
     extra_files = validate_extra_files(directory, extra_files)
-    manifest, _ = make_api_manifest(directory, entry_point, app_mode, environment, image, extra_files, excludes)
+    manifest, _ = make_api_manifest(directory, entry_point, app_mode, environment, extra_files, excludes, image)
     manifest_path = join(directory, "manifest.json")
 
     write_manifest_json(manifest_path, manifest)

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -44,10 +44,10 @@ directories_to_ignore = [
 # noinspection SpellCheckingInspection
 def make_source_manifest(
     app_mode: AppMode,
-    image: str,
     environment: Environment,
     entrypoint: str,
     quarto_inspection: typing.Dict[str, typing.Any],
+    image: str = None,
 ) -> typing.Dict[str, typing.Any]:
 
     manifest = {
@@ -194,7 +194,7 @@ def write_manifest(
     Returns the list of filenames written.
     """
     manifest_filename = "manifest.json"
-    manifest = make_source_manifest(AppModes.JUPYTER_NOTEBOOK, image, environment, nb_name, None)
+    manifest = make_source_manifest(AppModes.JUPYTER_NOTEBOOK, environment, nb_name, None, image)
     if hide_all_input:
         if "jupyter" not in manifest:
             manifest["jupyter"] = {}
@@ -273,7 +273,7 @@ def make_notebook_source_bundle(
     base_dir = dirname(file)
     nb_name = basename(file)
 
-    manifest = make_source_manifest(AppModes.JUPYTER_NOTEBOOK, image, environment, nb_name, None)
+    manifest = make_source_manifest(AppModes.JUPYTER_NOTEBOOK, environment, nb_name, None, image)
     if hide_all_input:
         if "jupyter" not in manifest:
             manifest["jupyter"] = {}
@@ -314,10 +314,10 @@ def make_quarto_source_bundle(
     directory: str,
     inspect: typing.Dict[str, typing.Any],
     app_mode: AppMode,
-    image: str,
     environment: Environment,
     extra_files: typing.List[str],
     excludes: typing.List[str],
+    image: str = None,
 ) -> typing.IO[bytes]:
     """
     Create a bundle containing the specified Quarto content and (optional)
@@ -326,7 +326,7 @@ def make_quarto_source_bundle(
     Returns a file-like object containing the bundle tarball.
     """
     manifest, relevant_files = make_quarto_manifest(
-        directory, inspect, app_mode, image, environment, extra_files, excludes
+        directory, inspect, app_mode, environment, extra_files, excludes, image
     )
     bundle_file = tempfile.TemporaryFile(prefix="rsc_bundle")
 
@@ -346,7 +346,7 @@ def make_quarto_source_bundle(
 
 def make_html_manifest(
     filename: str,
-    image: str,
+    image: str = None,
 ) -> typing.Dict[str, typing.Any]:
     # noinspection SpellCheckingInspection
     manifest = {
@@ -569,9 +569,9 @@ def make_api_manifest(
     entry_point: str,
     app_mode: AppMode,
     environment: Environment,
-    image: str,
     extra_files: typing.List[str],
     excludes: typing.List[str],
+    image: str = None,
 ) -> typing.Tuple[typing.Dict[str, typing.Any], typing.List[str]]:
     """
     Makes a manifest for an API.
@@ -580,16 +580,16 @@ def make_api_manifest(
     :param entry_point: the main entry point for the API.
     :param app_mode: the app mode to use.
     :param environment: the Python environment information.
-    :param image: an optional docker image for off-host execution.
     :param extra_files: a sequence of any extra files to include in the bundle.
     :param excludes: a sequence of glob patterns that will exclude matched files.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the manifest and a list of the files involved.
     """
     if is_environment_dir(directory):
         excludes = list(excludes or []) + ["bin/", "lib/"]
 
     relevant_files = _create_api_file_list(directory, environment.filename, extra_files, excludes)
-    manifest = make_source_manifest(app_mode, image, environment, entry_point, None)
+    manifest = make_source_manifest(app_mode, environment, entry_point, None, image)
 
     manifest_add_buffer(manifest, environment.filename, environment.contents)
 
@@ -602,9 +602,9 @@ def make_api_manifest(
 def make_html_bundle_content(
     path: str,
     entrypoint: str,
-    image: str,
     extra_files: typing.List[str],
     excludes: typing.List[str],
+    image: str = None,
 ) -> typing.Tuple[typing.Dict[str, typing.Any], typing.List[str]]:
     """
     Makes a manifest for static html deployment.
@@ -613,6 +613,7 @@ def make_html_bundle_content(
     :param entry_point: the main entry point for the API.
     :param extra_files: a sequence of any extra files to include in the bundle.
     :param excludes: a sequence of glob patterns that will exclude matched files.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the manifest and a list of the files involved.
     """
     entrypoint = entrypoint or infer_entrypoint(path, "text/html")
@@ -692,21 +693,21 @@ def infer_entrypoint(path, mimetype):
 def make_html_bundle(
     path: str,
     entry_point: str,
-    image: str,
     extra_files: typing.List[str],
     excludes: typing.List[str],
+    image: str = None,
 ) -> typing.IO[bytes]:
     """
     Create an html bundle, given a path and a manifest.
 
     :param path: the file, or the directory containing the files to deploy.
     :param entry_point: the main entry point for the API.
-    :param image: an optional docker image for off-host execution.
     :param extra_files: a sequence of any extra files to include in the bundle.
     :param excludes: a sequence of glob patterns that will exclude matched files.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: a file-like object containing the bundle tarball.
     """
-    manifest, relevant_files = make_html_bundle_content(path, entry_point, image, extra_files, excludes)
+    manifest, relevant_files = make_html_bundle_content(path, entry_point, extra_files, excludes, image)
     bundle_file = tempfile.TemporaryFile(prefix="rsc_bundle")
 
     with tarfile.open(mode="w:gz", fileobj=bundle_file) as bundle:
@@ -726,9 +727,9 @@ def make_api_bundle(
     entry_point: str,
     app_mode: AppMode,
     environment: Environment,
-    image: str,
     extra_files: typing.List[str],
     excludes: typing.List[str],
+    image: str = None,
 ) -> typing.IO[bytes]:
     """
     Create an API bundle, given a directory path and a manifest.
@@ -737,13 +738,13 @@ def make_api_bundle(
     :param entry_point: the main entry point for the API.
     :param app_mode: the app mode to use.
     :param environment: the Python environment information.
-    :param image: an optional docker image for off-host execution.
     :param extra_files: a sequence of any extra files to include in the bundle.
     :param excludes: a sequence of glob patterns that will exclude matched files.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: a file-like object containing the bundle tarball.
     """
     manifest, relevant_files = make_api_manifest(
-        directory, entry_point, app_mode, environment, image, extra_files, excludes
+        directory, entry_point, app_mode, environment, extra_files, excludes, image
     )
     bundle_file = tempfile.TemporaryFile(prefix="rsc_bundle")
 
@@ -809,10 +810,10 @@ def make_quarto_manifest(
     directory: str,
     quarto_inspection: typing.Dict[str, typing.Any],
     app_mode: AppMode,
-    image: str,
     environment: Environment,
     extra_files: typing.List[str],
     excludes: typing.List[str],
+    image: str = None,
 ) -> typing.Tuple[typing.Dict[str, typing.Any], typing.List[str]]:
     """
     Makes a manifest for a Quarto project.
@@ -820,10 +821,10 @@ def make_quarto_manifest(
     :param directory: The directory containing the Quarto project.
     :param quarto_inspection: The parsed JSON from a 'quarto inspect' against the project.
     :param app_mode: The application mode to assume.
-    :param image: an optional docker image for off-host execution.
     :param environment: The (optional) Python environment to use.
     :param extra_files: Any extra files to include in the manifest.
     :param excludes: A sequence of glob patterns to exclude when enumerating files to bundle.
+    :param image: the optional docker image to be specified for off-host execution. Default = None.
     :return: the manifest and a list of the files involved.
     """
     if environment:
@@ -846,10 +847,10 @@ def make_quarto_manifest(
     relevant_files = _create_quarto_file_list(directory, extra_files, excludes)
     manifest = make_source_manifest(
         app_mode,
-        image,
         environment,
         None,
         quarto_inspection,
+        image,
     )
 
     for rel_path in relevant_files:

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -369,12 +369,9 @@ def make_notebook_html_bundle(
     hide_all_input: bool,
     hide_tagged_input: bool,
     image: str = None,
-    check_output: typing.Callable = subprocess.check_output,  # used to default to subprocess.check_output
+    check_output: typing.Callable = subprocess.check_output,
 ) -> typing.IO[bytes]:
     # noinspection SpellCheckingInspection
-    if check_output is None:
-        check_output = subprocess.check_output
-
     cmd = [
         python,
         "-m",

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -719,7 +719,7 @@ def deploy_notebook(
     hide_all_input,
     hide_tagged_input,
     env_vars,
-    image,
+    image: str = None,
 ):
     set_verbosity(verbose)
 
@@ -758,7 +758,7 @@ def deploy_notebook(
 
     with cli_feedback("Creating deployment bundle"):
         bundle = create_notebook_deployment_bundle(
-            file, extra_files, app_mode, python, environment, image, False, hide_all_input, hide_tagged_input
+            file, extra_files, app_mode, python, environment, False, hide_all_input, hide_tagged_input, image
         )
     _deploy_bundle(
         connect_server,
@@ -1162,7 +1162,7 @@ def generate_deploy_python(app_mode, alias, min_version):
         directory,
         extra_files,
         env_vars,
-        image,
+        image: str = None,
     ):
         _deploy_by_framework(
             name,
@@ -1488,7 +1488,7 @@ def write_manifest_quarto(
     verbose,
     directory,
     extra_files,
-    image,
+    image: str = None,
 ):
     set_verbosity(verbose)
     with cli_feedback("Checking arguments"):
@@ -1604,7 +1604,7 @@ def generate_write_manifest_python(app_mode, alias):
         verbose,
         directory,
         extra_files,
-        image,
+        image: str = None,
     ):
         _write_framework_manifest(
             overwrite,

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -602,7 +602,6 @@ def _deploy_bundle(
     :param title_is_default: a flag noting whether the title carries a defaulted value.
     :param bundle: the bundle to deploy.
     :param env_vars: list of NAME=VALUE pairs to be set as the app environment
-    :param image: an optional docker image for off-host execution.
     """
     with cli_feedback("Uploading bundle"):
         app = deploy_bundle(connect_server, app_id, name, title, title_is_default, bundle, env_vars)
@@ -693,7 +692,7 @@ def _deploy_bundle(
     "--image",
     "-I",
     help="Target image to be used during content execution (only applicable if the RStudio Connect "
-      "server is configured to use off-host execution)",
+    "server is configured to use off-host execution)",
 )
 @click.argument("file", type=click.Path(exists=True, dir_okay=False, file_okay=True))
 @click.argument(
@@ -908,7 +907,7 @@ def deploy_manifest(
     "--image",
     "-I",
     help="Target image to be used during content execution (only applicable if the RStudio Connect "
-      "server is configured to use off-host execution)",
+    "server is configured to use off-host execution)",
 )
 @click.argument("directory", type=click.Path(exists=True, dir_okay=True, file_okay=False))
 @click.argument(
@@ -977,7 +976,7 @@ def deploy_quarto(
 
     with cli_feedback("Creating deployment bundle"):
         bundle = create_quarto_deployment_bundle(
-            directory, extra_files, exclude, app_mode, inspect, environment, image, False
+            directory, extra_files, exclude, app_mode, inspect, environment, False, image
         )
 
     _deploy_bundle(
@@ -1058,7 +1057,7 @@ def deploy_html(
 
     with cli_feedback("Creating deployment bundle"):
         try:
-            bundle = make_html_bundle(path, entrypoint, "", extra_files, excludes)
+            bundle = make_html_bundle(path, entrypoint, extra_files, excludes, None)
         except IOError as error:
             msg = "Unable to include the file %s in the bundle: %s" % (
                 error.filename,
@@ -1283,7 +1282,7 @@ def _deploy_by_framework(
 
     with cli_feedback("Creating deployment bundle"):
         bundle = create_api_deployment_bundle(
-            directory, extra_files, exclude, entrypoint, app_mode, environment, image, False
+            directory, extra_files, exclude, entrypoint, app_mode, environment, False, image
         )
 
     _deploy_bundle(
@@ -1369,7 +1368,7 @@ def write_manifest():
     "--image",
     "-I",
     help="Target image to be used during content execution (only applicable if the RStudio Connect "
-      "server is configured to use off-host execution)",
+    "server is configured to use off-host execution)",
 )
 @click.argument("file", type=click.Path(exists=True, dir_okay=False, file_okay=True))
 @click.argument(
@@ -1472,7 +1471,7 @@ def write_manifest_notebook(
     "--image",
     "-I",
     help="Target image to be used during content execution (only applicable if the RStudio Connect "
-      "server is configured to use off-host execution)",
+    "server is configured to use off-host execution)",
 )
 @click.argument("directory", type=click.Path(exists=True, dir_okay=True, file_okay=False))
 @click.argument(
@@ -1682,10 +1681,10 @@ def _write_framework_manifest(
             directory,
             entrypoint,
             environment,
-            image,
             app_mode,
             extra_files,
             exclude,
+            image,
         )
 
     if environment_file_exists and not force_generate:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -218,7 +218,7 @@ class TestActions(TestCase):
         directory = get_api_path("flask")
         server = RSConnectServer("https://www.bogus.com", "bogus")
         with self.assertRaises(RSConnectException):
-            deploy_python_api(server, directory, [], [], "bogus", None, False, None, None, None, False, False, None)
+            deploy_python_api(server, directory, [], [], "bogus", False, None, None, None, False, False, None, None)
 
     def test_deploy_dash_app_docs(self):
         self.assertTrue("Dash app" in deploy_dash_app.__doc__)
@@ -250,7 +250,7 @@ class TestActions(TestCase):
         with self.assertRaises(RSConnectException):
             create_api_deployment_bundle(directory, [], [], "bogus:bogus:bogus", None, None, None, None)
         with self.assertRaises(RSConnectException):
-            create_api_deployment_bundle(directory, ["bogus"], [], "app:app", MakeEnvironment(), None, None, True)
+            create_api_deployment_bundle(directory, ["bogus"], [], "app:app", MakeEnvironment(), None, True, None)
 
     def test_inspect_environment(self):
         environment = inspect_environment(sys.executable, get_dir("pip1"))

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -225,7 +225,11 @@ class TestBundle(TestCase):
         nb_path = join(directory, "dummy.ipynb")
 
         bundle = make_notebook_html_bundle(
-            nb_path, sys.executable, hide_all_input=False, hide_tagged_input=False, image=None, check_output=None
+            nb_path,
+            sys.executable,
+            hide_all_input=False,
+            hide_tagged_input=False,
+            image=None,
         )
 
         tar = tarfile.open(mode="r:gz", fileobj=bundle)

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -291,7 +291,7 @@ class TestBundle(TestCase):
         )
 
         # include image parameter
-        manifest = make_source_manifest(AppModes.PYTHON_API, "rstudio/connect:bionic", None, None, None)
+        manifest = make_source_manifest(AppModes.PYTHON_API, None, None, None, "rstudio/connect:bionic")
         self.assertEqual(
             manifest,
             {
@@ -305,7 +305,6 @@ class TestBundle(TestCase):
         # include environment parameter
         manifest = make_source_manifest(
             AppModes.PYTHON_API,
-            None,
             Environment(
                 conda=None,
                 contents="",
@@ -317,6 +316,7 @@ class TestBundle(TestCase):
                 python="3.9.12",
                 source="file",
             ),
+            None,
             None,
             None,
         )
@@ -338,8 +338,8 @@ class TestBundle(TestCase):
         manifest = make_source_manifest(
             AppModes.PYTHON_API,
             None,
-            None,
             "main.py",
+            None,
             None,
         )
         # print(manifest)
@@ -353,12 +353,12 @@ class TestBundle(TestCase):
             AppModes.PYTHON_API,
             None,
             None,
-            None,
             {
                 "quarto": {"version": "0.9.16"},
                 "engines": ["jupyter"],
                 "config": {"project": {"title": "quarto-proj-py"}, "editor": "visual", "language": {}},
             },
+            None,
         )
         # print(manifest)
         self.assertEqual(
@@ -415,10 +415,10 @@ class TestBundle(TestCase):
                 "config": {"project": {"title": "quarto-proj-py"}, "editor": "visual", "language": {}},
             },
             AppModes.SHINY_QUARTO,
+            None,
+            None,
+            None,
             "rstudio/connect:bionic",
-            None,
-            None,
-            None,
         )
         self.assertEqual(
             manifest,
@@ -446,7 +446,6 @@ class TestBundle(TestCase):
                 "config": {"project": {"title": "quarto-proj-py"}, "editor": "visual", "language": {}},
             },
             AppModes.SHINY_QUARTO,
-            None,
             Environment(
                 conda=None,
                 contents="",
@@ -458,6 +457,7 @@ class TestBundle(TestCase):
                 python="3.9.12",
                 source="file",
             ),
+            None,
             None,
             None,
         )
@@ -495,8 +495,8 @@ class TestBundle(TestCase):
             },
             AppModes.SHINY_QUARTO,
             None,
-            None,
             ["a", "b", "c"],
+            None,
             None,
         )
         self.assertEqual(
@@ -524,9 +524,9 @@ class TestBundle(TestCase):
             },
             AppModes.SHINY_QUARTO,
             None,
-            None,
             ["a", "b", "c"],
             ["requirements.txt"],
+            None,
         )
         self.assertEqual(
             manifest,


### PR DESCRIPTION
# NOTE: This PR has Bincheng's branch merged in, so that I could holistically search and refactor all image parameter usages.

# Description

To maintain compatibility at the public api layer of rsconnect-python, we have made the decision to make the `image` parameter be optional and default to `None`.

This impacts the following CLI commands which support the image parameter (`--image` or `-I`).
- `rsconnect write-manifest api`: 
- `rsconnect write-manifest bokeh`: 
- `rsconnect write-manifest dash`:
- `rsconnect write-manifest fastapi`:
- `rsconnect write-manifest notebook`:
- `rsconnect write-manifest quarto`:
- `rsconnect write-manifest streamlit`:

- `rsconnect deploy api`
- `rsconnect deploy bokeh`
- `rsconnect deploy dash`
- `rsconnect deploy fastapi` 
- `rsconnect deploy notebook` 
- `rsconnect deploy quarto`  
- `rsconnect deploy streamlit`  

Not impacted (but related) and unaffected (do not accept the --image parameter)
- `rsconnect deploy manifest`
- `rsconnect deploy other-content`
- `rsconnect deploy html`

# Implementation Notes

RSConnect-Python's public API library, uses functions which are not prefixed with an underscore (`_`) to indicate internal functions. These functions will use fixed arguments to leverage tooling as much as possible and therefore are not effected by this change.

# Testing Notes / Validation Steps

Validation follows the approach outlined within https://github.com/rstudio/rsconnect-python/pull/245, where image support was first introduced. These steps should give a good validation for direct usage of the rsconnect-python CLI. It does not include, however, integration testing between `rsconnect-python` and `rsconnect-jupyter` (which builds upon the `rsconnect-python` codebase). That will need to be validated in a separate way.

## Approach taken
By using a kubernetes configuration for Connect, which utilizes two duplicate images, we are able to verify the functionality of which image is used by the server when the image flag is specified and when it is not.

Verification for each of the impacted commands is grouped by target, allowing us to focus on a target at a time, but executing fairly similar steps for each target:

### Validate write-manifest <target>
- Validate the help output contains the image option
- Update the reference manifest.json to be reflective of the active version of python, save this off.
- Use `rsconnect write-manifest -image rstudio/dev-connect-duplicate <target>` to update the manifest.json to include the `environment.image` setting
- Diff the manifest.json files (with and without image) to confirm there are no other significant differences
- 

### Validate deploy manifest for the manifest.json with the image setting
- Use `rsconnect deploy manifest <manifest file>` to confirm proper deployment

### Validate deploy <target> with and without image
- Validate the help output contains image
- Use `rsconnect deploy <target>` to validate that target is able to be deployed to server and that the server selects the content image target by using the built-in algorithm (will select `rstudio/dev-connect`).
- Use `rsconnect deploy <target> --image rstudio/dev-connect-duplicate` to validate that target is able to be deployed to server and that the server uses the image option to determine the target image (will be `rstudio/dev-connect-duplicate`).


## Testing details

Need to be setup specifically with Python 3.8.x to work with the test data / content outlined below.

```bash
brew install python@3.8
#Updated my path to have `/usr/local/opt/python@3.8/bin` ahead of `/usr/local/bin` in ~/.zshenv 
source ~/.zshenv
```

Setup virtual environment to use branch rsconnect within the base directory of rsconnect-python repo:

```bash
# Setup a virtual python environment w/ 3.8.x
rm -rd .venv
python3 --version        
# confirm version listed above is 3.8.x
python3 -m venv .venv
# Activate the virtual environment
source .venv/bin/activate
python3 --version        
# confirm version listed above is 3.8.x
# install our requirements into the virtual environment
pip install -r requirements.txt
# install rsconnect-python with a symbolic link to the locations repository, 
# meaning any changes to code in there will automatically be reflected
pip install -e ./
# clear out path to executables
hash -r
```

For Connect, I recommend using the new `dev-connect` docker file workflow, which will be available from `main` before this PR goes to testing, as will David's supporting server branch which implements the image logic needed on the server.

To start the server, you'll need to:

1. Build the codebase, from the root of the rstudio/connect project:
    - `just ui/dashboard/clean`
    - `just bootstrap build`
2. Update `yeti/docker/built-in/connect-shared-files/rsc-launcher-runtime.yml` to have the following two additional image specifications, to be placed at top of image list (on line 3, after the line `images:`). This should move all of the other image entries down in the file / list.

```
  - 
    name: rstudio/dev-connect
    python:
      installations:
        - path: /opt/python/3.8.12/bin/python3.8
          version: 3.8.12
    r:
      installations:
        - path: /opt/R/3.6.3/bin/R
          version: 3.6.3
    quarto:
      installations:
        - path: /opt/rstudio-connect/ext/quarto/bin/quarto
          version: 0.9.16
  - 
    name: rstudio/dev-connect-duplicate
    python:
      installations:
        - path: /opt/python/3.8.12/bin/python3.8
          version: 3.8.12
    r:
      installations:
        - path: /opt/R/3.6.3/bin/R
          version: 3.6.3
    quarto:
      installations:
        - path: /opt/rstudio-connect/ext/quarto/bin/quarto
          version: 0.9.16
  -
```

3. Create a custom template and add an `imagePullPolicy=Never` to the pods volume definition.
    - Copy `packaging/launcher/connect-k8s-templates/job.tpl` to `config/launcher/k8s-custom-templates`
    - Edit `config/launcher/k8s-custom-templates/job.tpl` and add the following line after line 83 (`image: {{ toYaml .Job.container.image }}`) - should be indented same level as the image line.

```
          imagePullPolicy: Never
```

    - Save the file with your changes.
4. Temporarily update the main justfile to have (updating area around 234 of `justfile`):

```
    # Always build the docker images
    docker build . -t rstudio/dev-connect -f docker/devconnect/Dockerfile
    if [[ "${USE_KUBERNETES}" == "yes" ]]; then
        docker build . -t rstudio/dev-connect-duplicate -f docker/devconnect/Dockerfile
    fi
```

5. Reset the dev-connect data volume:
    - `docker volume rm dev-connect-volume`
6. Reset your kubernetes cluster:
    - `kubectl -n rsc-dev delete jobs --all`
    - `kubectl -n rsc-dev delete svc --all`
7. Start the server:
    - `USE_KUBERNETES=yes just start-dev-connect`

## Validate changes for target: API

### Verify write-manifest api

WITH the venv active.. cd into your rstudio/connect-content repo.
From:  rstudio/connect-content
1. cd bundles/python-flaskapi
2. execute:

```bash
# baseline the manifest w/ your virtual environment basics
rsconnect write-manifest api . --overwrite
mv manifest.json manifest-original.json
rsconnect write-manifest api --image rstudio/dev-connect-duplicate .
diff manifest.json manifest-original.json
```

confirm that you see the environment/image path added in the new manifest. This will look something like:

```
16,18d15
<   "environment": {
<     "image": "rstudio/dev-connect-duplicate"
<   },
26,28d22
<     "manifest-original.json": {
<       "checksum": "f5dcb185f388ab9694ac4e6e3ce9f8e0"
<     },
```

where the first section is the important verification (and the second is just an artifact that we added a file).

### Verify deploy manifest

```bash
rsconnect deploy manifest -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new ./manifest.json
```

Verify output is similar to:

```
Deployment log:
Building Python API...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

### Verify deploy api

WITH your terminal working directory same as previously (bundles/python-flaskapi)

1. execute:

```bash
rsconnect deploy api -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new .
```

Confirm that the automatic image was selected, by verifying the output is similar to:

```
Deployment log:
Building Python API...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect which has version 3.8.8
```

2. execute:

```bash
rsconnect deploy api -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --image rstudio/dev-connect-duplicate --new .
```

Verify the output is similar to the following:

```
Deployment log:
Building Python API...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

## Validate changes for target: BOKEH

### Verify write-manifest bokeh

WITH the venv active.. cd into your rstudio/connect-content repo.
From:  rstudio/connect-content:

```bash
cd bundles/python-bokeh
# baseline the manifest w/ your virtual environment basics
rsconnect write-manifest bokeh . --overwrite
mv manifest.json manifest-original.json
rsconnect write-manifest bokeh --image rstudio/dev-connect-duplicate .
diff manifest.json manifest-original.json
```

Confirm that you see the environment/image path added in the new manifest. This will look something like the following

```
16,18d15
<   "environment": {
<     "image": "rstudio/dev-connect-duplicate"
<   },
26,28d22
<     "manifest-original.json": {
<       "checksum": "f5dcb185f388ab9694ac4e6e3ce9f8e0"
<     },
```
Where the first section is the important verification (and the second is just an artifact that we added a file).

### Verify deploy manifest

```bash
rsconnect deploy manifest -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new  ./manifest.json
```

Verify output is similar to:

```
Deployment log:
Building Bokeh application...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

### Verify deploy bokeh

WITH your terminal working directory same as previously (bundles/python-bokeh)
1. execute:

```bash
rsconnect deploy bokeh -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new .
```

Confirm that the automatic image was selected, by verifying the output is similar to:

```
Deployment log:
Building Bokeh application...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect which has version 3.8.8
```

2. execute:

```bash
rsconnect deploy bokeh -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --image rstudio/dev-connect-duplicate --new .
```

Verify the output is similar to the following:

```
Deployment log:
Building Bokeh application...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

## Validate changes for target: DASH

### Verify write-manifest dash

WITH the venv active.. cd into your rstudio/connect-content repo.
From:  rstudio/connect-content:

1. Execute:

```bash
cd bundles/python-dash
# baseline the manifest w/ your virtual environment basics
rsconnect write-manifest dash . --overwrite
mv manifest.json manifest-original.json
rsconnect write-manifest dash --image rstudio/dev-connect-duplicate .
diff manifest.json manifest-original.json
```

Confirm that you see the environment/image path added in the new manifest. This will look something like the following
```
16,18d15
<   "environment": {
<     "image": "rstudio/dev-connect-duplicate"
<   },
26,28d22
<     "manifest-original.json": {
<       "checksum": "f5dcb185f388ab9694ac4e6e3ce9f8e0"
<     },
```
Where the first section is the important verification (and the second is just an artifact that we added a file).

### Verify deploy manifest

```bash
rsconnect deploy manifest -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new  ./manifest.json
```

Verify output is similar to:

```
Deployment log:
Building Dash application...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

### Verify deploy dash

WITH your terminal working directory same as previously (bundles/python-dash)

1. Execute:

```bash
rsconnect deploy dash -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new .
```

Confirm that the automatic image was selected, by verifying the output is similar to:

```
Deployment log:
Building Dash application...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect which has version 3.8.8
```

2. execute:

```bash
rsconnect deploy dash -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --image rstudio/dev-connect-duplicate --new .
```

Verify the output is similar to the following:

```
Deployment log:
Building Dash application...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

## Validate changes for target: FASTAPI

### Verify write-manifest fastapi

WITH the venv active.. cd into your rstudio/connect-content repo.
From:  rstudio/connect-content:

1. Execute:
 
```bash
cd bundles/fastapi-simple
# baseline the manifest w/ your virtual environment basics
rsconnect write-manifest fastapi . --overwrite
mv manifest.json manifest-original.json
rsconnect write-manifest fastapi --image rstudio/dev-connect-duplicate .
diff manifest.json manifest-original.json
```

Confirm that you see the environment/image path added in the new manifest. This will look something like the following

```
16,18d15
<   "environment": {
<     "image": "rstudio/dev-connect-duplicate"
<   },
26,28d22
<     "manifest-original.json": {
<       "checksum": "f5dcb185f388ab9694ac4e6e3ce9f8e0"
<     },
```

Where the first section is the important verification (and the second is just an artifact that we added a file).

### Verify deploy manifest

```bash
rsconnect deploy manifest -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new  ./manifest.json
```

Verify output is similar to:

```
Deployment log:
Building FastAPI application...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

### Verify deploy fastapi

WITH your terminal working directory same as previously (bundles/fastapi-simple)

1. Confirm that the help output contains the image option:

```bash
rsconnect deploy fastapi -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new .
```

Confirm that the automatic image was selected, by verifying the output is similar to:

```
Deployment log:
Building FastAPI application...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect which has version 3.8.8
```

2. execute:

```bash
rsconnect deploy fastapi -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --image rstudio/dev-connect-duplicate --new .
```

Verify the output is similar to the following:

```
Deployment log:
Building FastAPI application...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

## Validate changes for target: NOTEBOOK

### Verify write-manifest notebook

WITH the venv active.. cd into your rstudio/connect-content repo.
From:  rstudio/connect-content:

1. Execute:

```bash
cd bundles/stock-report-jupyter
# baseline the manifest w/ your virtual environment basics
rsconnect write-manifest notebook --overwrite stock-report-jupyter.ipynb quandl-wiki-tsla.json.gz thumbnail.jpg
mv manifest.json manifest-original.json
rsconnect write-manifest notebook --image rstudio/dev-connect-duplicate stock-report-jupyter.ipynb quandl-wiki-tsla.json.gz thumbnail.jpg
diff manifest.json manifest-original.json
```

Confirm that you see the environment/image path added in the new manifest. This will look something like the following

```
16,18d15
<   "environment": {
<     "image": "rstudio/dev-connect-duplicate"
<   },
```
Where the first section is the important verification (and the second is just an artifact that we added a file).

### Verify deploy manifest

```bash
rsconnect deploy manifest -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new  ./manifest.json
```

Verify output is similar to:

```
Deployment log:
Building Jupyter notebook...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

### Verify deploy notebook

WITH your terminal working directory same as previously (bundles/stock-report-jupyter)

1. Confirm that the help output contains the image option:

```bash
rsconnect deploy notebook -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new stock-report-jupyter.ipynb quandl-wiki-tsla.json.gz thumbnail.jpg
```

Confirm that the automatic image was selected, by verifying the output is similar to:

```
Deployment log:
Building Jupyter notebook...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect which has version 3.8.8
```

2. execute:

```bash
rsconnect deploy notebook -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --image rstudio/dev-connect-duplicate --new stock-report-jupyter.ipynb quandl-wiki-tsla.json.gz thumbnail.jpg
```

Verify the output is similar to the following:

```
Deployment log:
Building Jupyter notebook...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

## Validate changes for target: QUARTO

### Verify write-manifest quarto

WITH the venv active.. cd into your rstudio/connect-content repo.
From:  rstudio/connect-content:

1. Execute:

```bash
cd bundles/quarto-proj-py
# baseline the manifest w/ your virtual environment basics
rsconnect write-manifest quarto . --overwrite
mv manifest.json manifest-original.json
rsconnect write-manifest quarto --image rstudio/dev-connect-duplicate .
diff manifest.json manifest-original.json
```

Confirm that you see the environment/image path added in the new manifest. This will look something like the following

```
16,18d15
<   "environment": {
<     "image": "rstudio/dev-connect-duplicate"
<   },
26,28d22
<     "manifest-original.json": {
<       "checksum": "f5dcb185f388ab9694ac4e6e3ce9f8e0"
<     },
```
Where the first section is the important verification (and the second is just an artifact that we added a file).

### Verify deploy manifest

```bash
rsconnect deploy manifest -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new  ./manifest.json
```

Verify output is similar to:

```
Deployment log:
Building Quarto document...
Bundle created with Python version 3.8.13 and Quarto version 0.9.16 is compatible with environment Kubernetes::rstudio/dev-connect with Python version 3.8.12 from /opt/python/3.8.12/bin/python3.8 and Quarto version 0.9.16 from /opt/rstudio-connect/ext/quarto/bin/quarto 
Bundle requested Python version 3.8.13; using /opt/python/3.8.12/bin/python3.8 from Kubernetes::rstudio/dev-connect which has version 3.8.12
```

### Verify deploy quarto

WITH your terminal working directory same as previously (bundles/quarto-project-py)

1. Execute:

```bash
rsconnect deploy quarto -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new .
```

Confirm that the automatic image was selected, by verifying the output is similar to:

```
Deployment log:
Building Quarto document...
Bundle created with Python version 3.8.13 and Quarto version 0.9.16 is compatible with environment Kubernetes::rstudio/dev-connect with Python version 3.8.12 from /opt/python/3.8.12/bin/python3.8 and Quarto version 0.9.16 from /opt/rstudio-connect/ext/quarto/bin/quarto 
Bundle requested Python version 3.8.13; using /opt/python/3.8.12/bin/python3.8 from Kubernetes::rstudio/dev-connect which has version 3.8.12
```

2. execute:

```bash
rsconnect deploy quarto -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --image rstudio/dev-connect-duplicate --new .
```

Verify the output is similar to the following:

```
Deployment log:
Building Quarto document...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 and Quarto version 0.9.16 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.12 from /opt/python/3.8.12/bin/python3.8 and Quarto version 0.9.16 from /opt/rstudio-connect/ext/quarto/bin/quarto 
Bundle requested Python version 3.8.13; using /opt/python/3.8.12/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.12
```

## Validate changes for target: STREAMLIT

### Verify write-manifest streamlit

WITH the venv active.. cd into your rstudio/connect-content repo.
From:  rstudio/connect-content:

1. Execute:

```bash
cd bundles/python-streamlit
# baseline the manifest w/ your virtual environment basics
rsconnect write-manifest streamlit --overwrite .
mv manifest.json manifest-original.json
rsconnect write-manifest streamlit --image rstudio/dev-connect-duplicate .
diff manifest.json manifest-original.json
```

Confirm that you see the environment/image path added in the new manifest. This will look something like the following

```
16,18d15
<   "environment": {
<     "image": "rstudio/dev-connect-duplicate"
<   },
```
Where the first section is the important verification (and the second is just an artifact that we added a file).

### Verify deploy manifest

```bash
rsconnect deploy manifest -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new  ./manifest.json
```

Verify output is similar to:

```
Deployment log:
Building Streamlit application...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

### Verify deploy streamlit

WITH your terminal working directory same as previously (bundles/python-streamlit)

1. Confirm that the help output contains the image option:

```bash
rsconnect deploy streamlit -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --new .
```

Confirm that the automatic image was selected, by verifying the output is similar to:

```
Deployment log:
Building Streamlit application...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect with Python version 3.8.12 from /opt/python/3.8.12/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.12/bin/python3.8 from Kubernetes::rstudio/dev-connect which has version 3.8.12
```

2. execute:

```bash
rsconnect deploy streamlit -s http://localhost:3939 -k c7achTdggWVGtr851azThcyYDwH5JRgf --image rstudio/dev-connect-duplicate --new .
```

Verify the output is similar to the following:

```
Deployment log:
Building Streamlit application...
A target image was specified: rstudio/dev-connect-duplicate, checking if it is compatible...
Bundle created with Python version 3.8.13 is compatible with environment Kubernetes::rstudio/dev-connect-duplicate with Python version 3.8.8 from /opt/python/3.8.8/bin/python3.8 
Bundle requested Python version 3.8.13; using /opt/python/3.8.8/bin/python3.8 from Kubernetes::rstudio/dev-connect-duplicate which has version 3.8.8
```

