### PR TITLE
1.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.8.1] - 2022-05-31
+
+### Changed
+
+Corrected changelog heading.
+
+## [1.8.0] - 2022-05-31
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,9 @@ All version and release management is done via [annotated git tags](https://git-
 repo metadata used by the [`setuptools_scm`](https://github.com/pypa/setuptools_scm) package to generate the version
 string provided as `rsconnect:VERSION` and output by `rsconnect version`.
 
+Before releasing, replace the `Unreleased` heading in the changelog
+with the version number and date.
+
 To create a new release, create and push an annotated git tag:
 
 ```bash


### PR DESCRIPTION
Fixes the changelog heading for 1.8.0, and adds a note to future self that the `Unreleased` changelog heading needs to be filled out before release.
