### PR TITLE
Switch docs from AWS id/secret to a role

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,8 +125,7 @@ jobs:
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.DOCS_AWS_ID }}
-        aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: us-east-1
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       run: make promote-docs-in-s3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-to-assume: ${{ secrets.DOCS_AWS_ROLE }}
         aws-region: us-east-1
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       run: make promote-docs-in-s3


### PR DESCRIPTION
### Description

Switch the docs upload from using an AWS ID and secret (both repo secrets) to using an assumed role (also a repo secret).

### Testing Notes / Validation Steps

This will be exercised when we tag the beta of the next release.
