### PR TITLE
fix jupyter module execution

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -386,7 +386,7 @@ def make_notebook_html_bundle(
     cmd = [
         python,
         "-m",
-        "jupyter",
+        "jupyter_core",
         "nbconvert",
         "--execute",
         "--stdout",

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -386,7 +386,6 @@ def make_notebook_html_bundle(
     cmd = [
         python,
         "-m",
-        "jupyter_core",
         "nbconvert",
         "--execute",
         "--stdout",


### PR DESCRIPTION
Version 4.11.0 of jupyter-core (released today) made a change that broke executing `python -m jupyter`. Instead of using `jupyter nbconnect`, we can execute `nbconnect` directly.

I'm not certain whether this is an actual regression in jupyter-core or just a change to undocumented and unsupported behavior, but I think this should be fine.