### PR TITLE
add CLI command for git repo deployment

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -189,6 +189,29 @@ class RSConnectClient(HTTPServer):
         self._server.handle_bad_response(response)
         return response
 
+
+    def deploy_git(self, app_name, repository, branch, subdirectory):
+        app = self.app_create(app_name)
+        self._server.handle_bad_response(app)
+
+        self.post(
+            "applications/%s/repo" % app["guid"],
+            body={
+                "repository": repository, "branch": branch , "subdirectory": subdirectory
+            }
+        )
+
+        task = self.post("applications/%s/deploy" % app["guid"], body=dict())
+        self._server.handle_bad_response(task)
+
+        return {
+            "task_id": task["id"],
+            "app_id": app["id"],
+            "app_guid": app["guid"],
+            "app_url": app["url"],
+            "title": app["title"],
+        }
+
     def deploy(self, app_id, app_name, app_title, title_is_default, tarball, env_vars=None):
         if app_id is None:
             # create an app if id is not provided

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1139,6 +1139,56 @@ def deploy_help():
     click.echo()
 
 
+@deploy.command(
+    name="git",
+    short_help="Deploy git repository with exisiting manifest file",
+    help="Deploy git repository with exisiting manifest file"
+)
+@click.option("--name", "-n", help="The nickname of the RStudio Connect server to deploy to.")
+@click.option(
+    "--server", "-s", envvar="CONNECT_SERVER", help="The URL for the RStudio Connect server to deploy to.",
+)
+@click.option(
+    "--api-key", "-k", envvar="CONNECT_API_KEY", help="The API key to use to authenticate with RStudio Connect.",
+)
+@click.option(
+    "--insecure", "-i", envvar="CONNECT_INSECURE", is_flag=True, help="Disable TLS certification/host validation.",
+)
+@click.option(
+    "--cacert",
+    "-c",
+    envvar="CONNECT_CA_CERTIFICATE",
+    type=click.File(),
+    help="The path to trusted TLS CA certificates.",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Print detailed messages.")
+@click.option('--app_name', '-a')
+@click.option('--repository', "-r")
+@click.option('--branch', "-b")
+@click.option('--subdirectory', "-d")
+def deploy_git(name, server, api_key, insecure, cacert, verbose, app_name, repository, branch, subdirectory):
+    set_verbosity(verbose)
+
+    with cli_feedback("Checking arguments"):
+        connect_server = _validate_deploy_to_args(name, server, api_key, insecure, cacert)
+
+    connect_client = api.RSConnect(connect_server)
+
+    with cli_feedback("Deploying git repository"):
+        app = connect_client.deploy_git(app_name, repository, branch, subdirectory)
+
+    with cli_feedback(""):
+        click.secho("\nDeployment log:", fg="bright_white")
+        app_url, _ = spool_deployment_log(connect_server, app, click.echo)
+        click.secho("Deployment completed successfully.", fg="bright_white")
+        click.secho("    Dashboard content URL: %s" % app_url, fg="bright_white")
+        click.secho("    Direct content URL: %s" % app["app_url"], fg="bright_white")
+
+
+    click.secho("Git deployment completed successfully.", fg="bright_white")
+    click.secho("App available as %s" % app_name, fg="bright_white")
+
+
 @cli.group(
     name="write-manifest",
     no_args_is_help=True,
@@ -1151,7 +1201,6 @@ def deploy_help():
 )
 def write_manifest():
     pass
-
 
 @write_manifest.command(
     name="notebook",


### PR DESCRIPTION
### Description

Add options to deploy a git repository to Connect. Some caveats:

- We should evaluate this UX to decide if we want a related mechanism for "telling a piece of content to fetch new git commits"
- Need to add testing and ensure all of the appropriate bits are copied over
- It has been a while since I wrote this. I may be missing things
- There are internal API endpoints in use here
- The interface can be evaluated. IIRC it is currently `rsconnect deploy git`
- This was written before the "great refactor" and may need to be tweaked as a result

Connected to #

### Testing Notes / Validation Steps


