### PR TITLE
Use directory in `get_python_env_info`

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -1632,7 +1632,7 @@ def get_python_env_info(file_name, python, conda_mode=False, force_generate=Fals
     """
     python = which_python(python)
     logger.debug("Python: %s" % python)
-    environment = inspect_environment(python, dirname(file_name), conda_mode=conda_mode, force_generate=force_generate)
+    environment = inspect_environment(python, file_name, conda_mode=conda_mode, force_generate=force_generate)
     if environment.error:
         raise RSConnectException(environment.error)
     logger.debug("Python: %s" % python)


### PR DESCRIPTION
### Description

> Include a brief description of the problem being solved and why this
> approach was chosen. Mention risks or shortcomings with this solution.
> Provide relevant background information such as the associated issue, links
> to design documents, screenshots, and performance measurements.
>
> Even small changes deserve a little attention to detail. Put your change in
> context.

Connected to #269 

`actions._deploy_by_python_framework` ingests a directory, and the directory is passed into `actions.get_python_env_info` in the `filename` argument. t is assumed to be , causing `actions.get_python_env_info` to look one step too high in the directory structure.

This manifests itself when users pass in a `requirements.txt` file when deploying different python frameworks. Because `actions.get_python_env_info` is looking too high in the directory, it does not recognize the user's requirements file in the working directory and will overwrite it with one generated by rsconnect-python.

### Testing Notes / Validation Steps

> Explain how this change has been tested and what cases/conditions are
> covered. Enumerate the steps someone might take to manually exercise this
> change. Detail is important!
>
> You can recommend one-time manual testing when someone validates your
> changes. Rely on automation when trying to verify that a change remains in
> place. Automated tests should be included in this PR.

Tried this on my local Connect, and it allows for me to pass in custom `requirements.txt`. Trying it out on the CI to make sure its not breaking other things 😄 
