### PR TITLE
Environment variable support for JWT bootstrap secret keys

### DIFF
--- a/rsconnect/json_web_token.py
+++ b/rsconnect/json_web_token.py
@@ -27,7 +27,7 @@ def read_secret_key(keypath) -> bytes:
     """
     Reads a secret key as bytes given a path to a file containing a base64-encoded key.
 
-    The secret key can optionally be overridden by an environment variable.
+    The secret key can optionally be set with an environment variable.
     """
 
     env_raw_data = os.getenv(SECRET_KEY_ENV)

--- a/rsconnect/json_web_token.py
+++ b/rsconnect/json_web_token.py
@@ -20,7 +20,7 @@ DEFAULT_AUDIENCE = "rsconnect"
 BOOTSTRAP_SCOPE = "bootstrap"
 BOOTSTRAP_EXP = timedelta(minutes=15)
 
-SECRET_KEY_ENV = "CONNECT_BOOTSTRAP_SECRET_KEY"
+SECRET_KEY_ENV = "CONNECT_BOOTSTRAP_SECRETKEY"
 
 
 def read_secret_key(keypath) -> bytes:

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -317,7 +317,6 @@ def _test_rstudio_creds(server: api.RStudioServer):
 @click.option(
     "--jwt-keypath",
     "-j",
-    required=True,
     help="The path to the file containing the private key used to sign the JWT.",
 )
 @click.option("--raw", "-r", is_flag=True, help="Return the API key as raw output rather than a JSON object")

--- a/tests/test_json_web_token.py
+++ b/tests/test_json_web_token.py
@@ -15,6 +15,7 @@ from rsconnect.json_web_token import (
     BOOTSTRAP_SCOPE,
     DEFAULT_ISSUER,
     DEFAULT_AUDIENCE,
+    SECRET_KEY_ENV,
     read_secret_key,
     produce_bootstrap_output,
     is_jwt_compatible_python_version,
@@ -48,6 +49,8 @@ class TestJsonWebToken(TestCase):
         # decoded copy of the base64-encoded key in testdata/jwt/secret.key
         self.secret_key = b"12345678901234567890123456789012345"
         self.secret_key_b64 = b"MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU="
+        # the environment variable version of the secret key will be stored as a string
+        self.secret_key_b64_env = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU="
 
     def assert_bootstrap_jwt_is_valid(self, payload, current_datetime):
         """
@@ -84,11 +87,37 @@ class TestJsonWebToken(TestCase):
         empty = read_secret_key("tests/testdata/jwt/empty_secret.key")
         self.assertEqual(empty, b"")
 
+        # might pass 'None' if we're using an environment variable
+        with pytest.raises(RSConnectException):
+            read_secret_key(None)
+
         with pytest.raises(RSConnectException):
             read_secret_key("invalid/path.key")
 
         with pytest.raises(RSConnectException):
             read_secret_key("tests/testdata/jwt/invalid_secret.key")
+
+        # environment variable overrides the file
+        os.environ[SECRET_KEY_ENV] = self.secret_key_b64_env
+
+        valid_env = read_secret_key(None)
+        self.assertEqual(valid_env, self.secret_key)
+
+        # with env variable set, can't also attempt to read from file
+        with pytest.raises(RSConnectException):
+            read_secret_key("tests/testdata/jwt/secret.key")
+
+        with pytest.raises(RSConnectException):
+            read_secret_key("tests/testdata/jwt/empty_secret.key")
+
+        os.environ[SECRET_KEY_ENV] = "this_is_not_base64"
+
+        # env variable must also be a base64-encoded secret
+        with pytest.raises(RSConnectException):
+            read_secret_key(None)
+
+        # cleanup
+        del os.environ[SECRET_KEY_ENV]
 
     def test_validate_hs256_secret_key(self):
 

--- a/tests/test_json_web_token.py
+++ b/tests/test_json_web_token.py
@@ -97,7 +97,7 @@ class TestJsonWebToken(TestCase):
         with pytest.raises(RSConnectException):
             read_secret_key("tests/testdata/jwt/invalid_secret.key")
 
-        # environment variable overrides the file
+        # environment variable replaces the need for a filepath
         os.environ[SECRET_KEY_ENV] = self.secret_key_b64_env
 
         valid_env = read_secret_key(None)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -819,7 +819,7 @@ class TestBootstrap(TestCase):
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertEqual(
             result.output,
-            "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRET_KEY\n",
+            "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRETKEY\n",
         )
 
         del os.environ[SECRET_KEY_ENV]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -777,11 +777,6 @@ class TestBootstrap(TestCase):
             result.output, "Error: Server URL expected to begin with transfer protocol (ex. http/https).\n"
         )
 
-    def test_bootstrap_missing_server_option(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["bootstrap"])
-        self.assertEqual(result.exit_code, 2, result.output)
-
     def test_boostrap_missing_jwt_option(self):
         """
         If jwt keyfile is not specified, it needs to be set using an environment variable
@@ -819,7 +814,7 @@ class TestBootstrap(TestCase):
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertEqual(
             result.output,
-            "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRETKEY\n",
+            "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRET_KEY\n",
         )
 
         del os.environ[SECRET_KEY_ENV]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ import httpretty
 import pytest
 from click.testing import CliRunner
 
-from rsconnect.json_web_token import is_jwt_compatible_python_version
+from rsconnect.json_web_token import SECRET_KEY_ENV, is_jwt_compatible_python_version
 
 from .utils import (
     apply_common_args,
@@ -569,6 +569,7 @@ class TestBootstrap(TestCase):
         self.mock_server = "http://localhost:8080"
         self.mock_uri = "http://localhost:8080/__api__/v1/experimental/bootstrap"
         self.jwt_keypath = "tests/testdata/jwt/secret.key"
+        self.jwt_env_secret = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU="
 
         self.default_cli_args = [
             "bootstrap",
@@ -618,6 +619,39 @@ class TestBootstrap(TestCase):
         json_output = json.loads(result.output)
         expected_output = json.loads(open("tests/testdata/initial-admin-responses/success.json", "r").read())
         self.assertEqual(json_output, expected_output)
+
+    @httpretty.activate(verbose=True, allow_net_connect=False)
+    def test_bootstrap_env_var(self):
+        """
+        Normal initial-admin operation if secret key is configured using an environment variable
+        """
+        cli_args = [
+            "bootstrap",
+            "--server",
+            self.mock_server,
+            "--insecure",
+        ]
+
+        callback = self.create_bootstrap_mock_callback(200, {"api_key": "testapikey123"})
+
+        httpretty.register_uri(
+            httpretty.POST,
+            self.mock_uri,
+            body=callback,
+        )
+
+        os.environ[SECRET_KEY_ENV] = self.jwt_env_secret
+
+        runner = CliRunner()
+        result = runner.invoke(cli, cli_args)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+
+        json_output = json.loads(result.output)
+        expected_output = json.loads(open("tests/testdata/initial-admin-responses/success.json", "r").read())
+        self.assertEqual(json_output, expected_output)
+
+        del os.environ[SECRET_KEY_ENV]
 
     @httpretty.activate(verbose=True, allow_net_connect=False)
     def test_bootstrap_misc_error(self):
@@ -749,9 +783,46 @@ class TestBootstrap(TestCase):
         self.assertEqual(result.exit_code, 2, result.output)
 
     def test_boostrap_missing_jwt_option(self):
+        """
+        If jwt keyfile is not specified, it needs to be set using an environment variable
+        """
         runner = CliRunner()
         result = runner.invoke(cli, ["bootstrap", "--server", "http://a_server"])
-        self.assertEqual(result.exit_code, 2, result.output)
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertEqual(
+            result.output, "Error: Must specify secret key using either a keyfile or environment variable.\n"
+        )
+
+    def test_bootstrap_conflicting_jwt_option(self):
+        """
+        If jwt keyfile is specified, it cannot also be set using an environment variable
+        """
+
+        os.environ[SECRET_KEY_ENV] = "a_value"
+        runner = CliRunner()
+        result = runner.invoke(cli, self.default_cli_args)
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertEqual(
+            result.output, "Error: Cannot specify secret key using both a keyfile and environment variable.\n"
+        )
+
+        del os.environ[SECRET_KEY_ENV]
+
+    def test_bootstrap_invalid_env_secret_key(self):
+        """
+        If jwt env variable is specified, it needs to be a valid base64-encoded value
+        """
+
+        os.environ[SECRET_KEY_ENV] = "a_value"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["bootstrap", "--server", "http://a_server"])
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertEqual(
+            result.output,
+            "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRET_KEY\n",
+        )
+
+        del os.environ[SECRET_KEY_ENV]
 
     @httpretty.activate(verbose=True, allow_net_connect=False)
     def test_bootstrap_raw_output(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -814,7 +814,7 @@ class TestBootstrap(TestCase):
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertEqual(
             result.output,
-            "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRET_KEY\n",
+            "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRETKEY\n",
         )
 
         del os.environ[SECRET_KEY_ENV]


### PR DESCRIPTION
### Description

Adds the capability of setting the JWT secret key for bootstrapping using an environment variable (`CONNECT_BOOTSTRAP_SECRETKEY`)

Connected to #22276

### Testing Notes / Validation Steps

- [x] Setting the environment variable `CONNECT_BOOTSTRAP_SECRETEY` with the base64-encoded JWT secret should allow the bootstrap command to succeed without passing the secret key file as a command line parameter 

```bash
export CONNECT_BOOTSTRAP_SECRETKEY=<your_secret>
./rsconnect bootstrap -s <server>
```
- [x] Normal bootstrap workflow should work with a secret in a key file, passed as a command-line parameter
```bash
./rsconnect bootstrap -s <server> -j <path_to_secret_keyfile>
```
- [x] Both setting an environment variable and passing a command-line parameter for the keyfile should fail
```bash
Error: Cannot specify secret key using both a keyfile and environment variable.
```
- [x] Neither setting an environment variable nor passing a command-line parameter for the keyfile should fail with:
```bash
Error: Must specify secret key using either a keyfile or environment variable.
```

- [x] Setting an environment variable which is not a base64-encoded secret key should fail with:
```bash
Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRETKEY
```