### PR TITLE
Posit Cloud rebrand

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -225,8 +225,8 @@ def test_server(connect_server):
     raise RSConnectException("\n".join(failures))
 
 
-def test_rstudio_server(server: api.RStudioServer):
-    with api.RStudioClient(server) as client:
+def test_rstudio_server(server: api.PositServer):
+    with api.PositClient(server) as client:
         try:
             result = client.get_current_user()
             server.handle_bad_response(result)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -152,13 +152,13 @@ def rstudio_args(func):
         "--token",
         "-T",
         envvar=["SHINYAPPS_TOKEN", "RSCLOUD_TOKEN"],
-        help="The shinyapps.io/RStudio Cloud token.",
+        help="The shinyapps.io/Posit Cloud token.",
     )
     @click.option(
         "--secret",
         "-S",
         envvar=["SHINYAPPS_SECRET", "RSCLOUD_SECRET"],
-        help="The shinyapps.io/RStudio Cloud token secret.",
+        help="The shinyapps.io/Posit Cloud token secret.",
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -245,8 +245,8 @@ def cli(future):
     certificate file to use for TLS.  The last two items are only relevant if the
     URL specifies the "https" protocol.
 
-    For RStudio Cloud and shinyapps.io, the information needed to connect includes
-    the account, auth token, auth secret, and server ('rstudio.cloud' or 'shinyapps.io').
+    For Posit Cloud and shinyapps.io, the information needed to connect includes
+    the account, auth token, auth secret, and server ('posit.cloud' or 'shinyapps.io').
     """
     global future_enabled
     future_enabled = future
@@ -284,7 +284,7 @@ def _test_server_and_api(server, api_key, insecure, ca_cert):
     return real_server, me
 
 
-def _test_rstudio_creds(server: api.RStudioServer):
+def _test_rstudio_creds(server: api.PositServer):
     with cli_feedback("Checking {} credential".format(server.remote_name)):
         test_rstudio_server(server)
 
@@ -433,7 +433,7 @@ def add(ctx, name, server, api_key, insecure, cacert, account, token, secret, ve
     old_server = server_store.get_by_name(name)
 
     if token:
-        if server and "rstudio.cloud" in server:
+        if server and ("rstudio.cloud" in server or "posit.cloud" in server):
             real_server = api.CloudServer(server, account, token, secret)
         else:
             real_server = api.ShinyappsServer(server, account, token, secret)

--- a/rsconnect/validation.py
+++ b/rsconnect/validation.py
@@ -35,15 +35,15 @@ def validate_connection_options(url, api_key, insecure, cacert, account_name, to
 
     if present_connect_options and present_shinyapps_options:
         raise RSConnectException(
-            "Connect options ({}) may not be passed alongside shinyapps.io or RStudio Cloud options ({}).".format(
+            "Connect options ({}) may not be passed alongside shinyapps.io or Posit Cloud options ({}).".format(
                 ", ".join(present_connect_options), ", ".join(present_shinyapps_options)
             )
         )
 
-    if url and 'rstudio.cloud' in url:
+    if url and ('posit.cloud' in url or 'rstudio.cloud' in url):
         if len(present_cloud_options) != len(cloud_options):
             raise RSConnectException(
-                "-T/--token and -S/--secret must be provided for RStudio Cloud."
+                "-T/--token and -S/--secret must be provided for Posit Cloud."
             )
     elif present_shinyapps_options:
         if len(present_shinyapps_options) != len(shinyapps_options):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -270,13 +270,13 @@ class TestMain:
 
         httpretty.register_uri(
             httpretty.GET,
-            "https://api.rstudio.cloud/v1/users/me",
+            "https://api.posit.cloud/v1/users/me",
             body=open("tests/testdata/rstudio-responses/get-user.json", "r").read(),
             status=200,
         )
         httpretty.register_uri(
             httpretty.GET,
-            "https://api.rstudio.cloud/v1/applications"
+            "https://api.posit.cloud/v1/applications"
             "?filter=name:like:shinyapp&offset=0&count=100&use_advanced_filters=true",
             body=open("tests/testdata/rstudio-responses/get-applications.json", "r").read(),
             adding_headers={"Content-Type": "application/json"},
@@ -284,7 +284,7 @@ class TestMain:
         )
         httpretty.register_uri(
             httpretty.GET,
-            "https://api.rstudio.cloud/v1/accounts/",
+            "https://api.posit.cloud/v1/accounts/",
             body=open("tests/testdata/rstudio-responses/get-accounts.json", "r").read(),
             adding_headers={"Content-Type": "application/json"},
             status=200,
@@ -293,21 +293,21 @@ class TestMain:
         if project_application_id:
             httpretty.register_uri(
                 httpretty.GET,
-                "https://api.rstudio.cloud/v1/applications/444",
+                "https://api.posit.cloud/v1/applications/444",
                 body=open("tests/testdata/rstudio-responses/get-project-application.json", "r").read(),
                 adding_headers={"Content-Type": "application/json"},
                 status=200,
             )
             httpretty.register_uri(
                 httpretty.GET,
-                "https://api.rstudio.cloud/v1/content/555",
+                "https://api.posit.cloud/v1/content/555",
                 body=open("tests/testdata/rstudio-responses/get-content.json", "r").read(),
                 adding_headers={"Content-Type": "application/json"},
                 status=200,
             )
             httpretty.register_uri(
                 httpretty.GET,
-                "https://api.rstudio.cloud/v1/content/1",
+                "https://api.posit.cloud/v1/content/1",
                 body=open("tests/testdata/rstudio-responses/create-output.json", "r").read(),
                 adding_headers={"Content-Type": "application/json"},
                 status=200,
@@ -328,7 +328,7 @@ class TestMain:
 
         httpretty.register_uri(
             httpretty.GET,
-            "https://api.rstudio.cloud/v1/applications/8442",
+            "https://api.posit.cloud/v1/applications/8442",
             body=open("tests/testdata/rstudio-responses/get-output-application.json", "r").read(),
             adding_headers={"Content-Type": "application/json"},
             status=200,
@@ -336,7 +336,7 @@ class TestMain:
 
         httpretty.register_uri(
             httpretty.POST,
-            "https://api.rstudio.cloud/v1/outputs/",
+            "https://api.posit.cloud/v1/outputs/",
             body=post_output_callback,
         )
 
@@ -359,7 +359,7 @@ class TestMain:
 
         httpretty.register_uri(
             httpretty.POST,
-            "https://api.rstudio.cloud/v1/bundles",
+            "https://api.posit.cloud/v1/bundles",
             body=post_bundle_callback,
         )
 
@@ -382,17 +382,17 @@ class TestMain:
                 assert parsed_request == {"status": "ready"}
             except AssertionError as e:
                 return _error_to_response(e)
-            return [303, {"Location": "https://api.rstudio.cloud/v1/bundles/12640"}, ""]
+            return [303, {"Location": "https://api.posit.cloud/v1/bundles/12640"}, ""]
 
         httpretty.register_uri(
             httpretty.POST,
-            "https://api.rstudio.cloud/v1/bundles/12640/status",
+            "https://api.posit.cloud/v1/bundles/12640/status",
             body=post_bundle_status_callback,
         )
 
         httpretty.register_uri(
             httpretty.GET,
-            "https://api.rstudio.cloud/v1/bundles/12640",
+            "https://api.posit.cloud/v1/bundles/12640",
             body=open("tests/testdata/rstudio-responses/get-accounts.json", "r").read(),
             adding_headers={"Content-Type": "application/json"},
             status=200,
@@ -406,19 +406,19 @@ class TestMain:
                 return _error_to_response(e)
             return [
                 303,
-                {"Location": "https://api.rstudio.cloud/v1/tasks/333"},
+                {"Location": "https://api.posit.cloud/v1/tasks/333"},
                 open("tests/testdata/rstudio-responses/post-deploy.json", "r").read(),
             ]
 
         httpretty.register_uri(
             httpretty.POST,
-            "https://api.rstudio.cloud/v1/applications/8442/deploy",
+            "https://api.posit.cloud/v1/applications/8442/deploy",
             body=post_deploy_callback,
         )
 
         httpretty.register_uri(
             httpretty.GET,
-            "https://api.rstudio.cloud/v1/tasks/333",
+            "https://api.posit.cloud/v1/tasks/333",
             body=open("tests/testdata/rstudio-responses/get-task.json", "r").read(),
             adding_headers={"Content-Type": "application/json"},
             status=200,
@@ -505,7 +505,7 @@ class TestMain:
         original_server_value = os.environ.pop("CONNECT_SERVER", None)
         try:
             httpretty.register_uri(
-                httpretty.GET, "https://api.rstudio.cloud/v1/users/me", body='{"id": 1000}', status=200
+                httpretty.GET, "https://api.posit.cloud/v1/users/me", body='{"id": 1000}', status=200
             )
 
             runner = CliRunner()
@@ -524,7 +524,7 @@ class TestMain:
                 ],
             )
             assert result.exit_code == 0, result.output
-            assert "RStudio Cloud credential" in result.output
+            assert "Posit Cloud credential" in result.output
 
         finally:
             if original_api_key_value:


### PR DESCRIPTION
### Description

Rebrand from RStudio Cloud to Posit Cloud. Passing --server `rstudio.cloud` and `posit.cloud` now have the same effect.

Resolves https://github.com/rstudio/rsconnect-python/issues/315.

### Testing Notes / Validation Steps

`rsconnect add` and `rsconnect deploy` should work under both `--server` options.