### PR TITLE
remove RETICULATE_PYTHON detection

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1117,9 +1117,6 @@ def which_python(python, env=os.environ):
             raise RSConnectException('The file, "%s", does not exist or is not executable.' % python)
         return python
 
-    if "RETICULATE_PYTHON" in env:
-        return os.path.expanduser(env["RETICULATE_PYTHON"])
-
     return sys.executable
 
 


### PR DESCRIPTION
### Description

Detection of `RETICULATE_PYTHON` leads to surprising behaviors in environment detection in workbench. As per slack discussion, this was initially set in expectation of the CLI being used to deploy content from the RStudio IDE, but this functionality was never realized.