### PR TITLE
Add Snyk scanning to CI

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,30 @@
+name: snyk
+on:
+  schedule:
+    - cron: "0 10 * * 1" # Monday @ 10am UTC
+  workflow_dispatch:
+
+env:
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+  SNYK_ORG: rstudio-connect
+  SNYK_PROJECT: rsconnect-python
+
+jobs:
+  python-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk on dependencies
+        uses: snyk/actions/python@master
+        with:
+          command: monitor
+          args: --file=setup.py --print-deps --project-name=${{ env.SNYK_PROJECT }} --org=${{ env.SNYK_ORG }}
+  python-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk static analysis
+        uses: snyk/actions/python@master
+        with:
+          command: code test
+          args: --project-name=${{ env.SNYK_PROJECT }} --org=${{ env.SNYK_ORG }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,17 +15,6 @@ project_urls =
     Documentation = https://docs.rstudio.com/rsconnect-python
 
 [options]
-install_requires =
-    six>=1.14.0
-    click>=8.0.0
-    pip>=10.0.0
-    semver>=2.0.0,<3.0.0
-    pyjwt>=2.4.0
-setup_requires =
-    setuptools
-    setuptools_scm>=3.4
-    toml
-    wheel
 packages = rsconnect
 python_requires = >=3.7
 zip_safe = true

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,19 @@
 from setuptools import setup
 
-setup()
+# Dependencies here so Snyk can see them
+# https://github.com/snyk/snyk-python-plugin/issues/147
+setup(
+    install_requires=[
+        "six>=1.14.0",
+        "click>=7.0.0",
+        "pip>=10.0.0",
+        "semver>=2.0.0,<3.0.0",
+        "pyjwt>=2.4.0",
+    ],
+    setup_requires=[
+        "setuptools",
+        "setuptools_scm>=3.4",
+        "toml",
+        "wheel",
+    ],
+)


### PR DESCRIPTION
### Description

Set up Snyk scanning in CI to check:
* Dependencies of `rsconnect-python`
* Static code check for the `rsconnect/` source


### Testing Notes / Validation Steps

Run CI. Verify that Snyk console shows vulnerabilities (only) from dependencies declared in `setup.py` and code in the the `rsconnect/` directory.