### PR TITLE
Remove python 3.5 and 3.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # TODO: work on windows-latest compatibility?
         os: [ubuntu-latest]
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
         - os: macos-latest
           python-version: '3.9'
@@ -28,10 +28,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: pip install -r requirements.txt
     - run: pip freeze
-    - if: matrix.python-version > '3.5'
-      run: make fmt
-    - if: matrix.python-version >= '3.6'
-      run: make lint
+    - run: make fmt
+    - run: make lint
     - run: python setup.py --version
     - run: make test-${{ matrix.python-version }}
   prerelease-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # TODO: work on windows-latest compatibility?
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
         - os: macos-latest
           python-version: '3.9'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ tooling](https://packaging.python.org/guides/tool-recommendations/).
 
 To get started, you'll want to:
 - clone the repo into a project directory
-- setup a virtual 3.5+ python environment in the project directory
+- setup a virtual 3.7+ python environment in the project directory
 - activate that virtual environment
 - install the dependencies
 - validate your build environment with some sample commands

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ SOURCE_DATE_EPOCH := $(shell date +%s)
 export SOURCE_DATE_EPOCH
 
 .PHONY: all-tests
-all-tests: all-images test-3.5 test-3.6 test-3.7 test-3.8 test-3.9 test-3.10
+all-tests: all-images test-3.7 test-3.8 test-3.9 test-3.10
 
 .PHONY: all-images
-all-images: image-3.5 image-3.6 image-3.7 image-3.8 image-3.9 image-3.10
+all-images: image-3.7 image-3.8 image-3.9 image-3.10
 
 image-%:
 	docker build -t rsconnect-python:$* --build-arg BASE_IMAGE=python:$*-slim .
@@ -62,9 +62,6 @@ mock-test-%: clean-stores
 fmt-%:
 	$(RUNNER) 'black .'
 
-.PHONY: fmt-3.5
-fmt-3.5: .fmt-unsupported
-
 .PHONY: .fmt-unsupported
 .fmt-unsupported:
 	@echo ERROR: This python version cannot run the fmting tools
@@ -82,9 +79,6 @@ lint-%:
 	$(RUNNER) 'flake8 rsconnect/'
 	$(RUNNER) 'flake8 tests/'
 	$(RUNNER) 'mypy -p rsconnect'
-
-.PHONY: lint-3.5
-lint-3.5: .lint-unsupported
 
 .PHONY: .lint-unsupported
 .lint-unsupported:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 !!! warning
 
-    As of version 1.7.0, rsconnect-python requires Python version 3.5 or higher. Please see the
-    [official announcement](https://www.rstudio.com/blog/rstudio-connect-2021-08-python-updates/)
-    for details about this decision.
+    As of version 1.14.0, rsconnect-python requires Python version 3.7 or higher.
 
 This package provides a CLI (command-line interface) for interacting
 with and deploying to Posit Connect. This is also used by the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==22.3.0; python_version >= '3.6'
+black==22.3.0
 click>=7.0.0
 coverage
 flake8
@@ -8,13 +8,12 @@ importlib-metadata
 ipykernel
 ipython
 jupyter_client
-mypy; python_version >= '3.6'
+mypy
 nbconvert
-pyjwt>=2.4.0; python_version >= '3.6'
-pyjwt; python_version < '3.6'
+pyjwt>=2.4.0
 pytest
 pytest-cov
-pytest-mypy; python_version >= '3.5'
+pytest-mypy
 semver>=2.0.0,<3.0.0
 setuptools_scm
 six>=1.14.0

--- a/rsconnect/json_web_token.py
+++ b/rsconnect/json_web_token.py
@@ -5,7 +5,6 @@ Json Web Token (JWT) utilities
 import base64
 from datetime import datetime, timedelta, timezone
 import os
-import sys
 
 import binascii
 import jwt
@@ -62,14 +61,6 @@ def read_secret_key(keypath) -> bytes:
 def validate_hs256_secret_key(key: bytes):
     if len(key) < 32:
         raise RSConnectException("Secret key expected to be at least 32 bytes in length")
-
-
-def is_jwt_compatible_python_version() -> bool:
-    """
-    JWT library is incompatible with Python 3.5
-    """
-
-    return not sys.version_info < (3, 6)
 
 
 def parse_client_response(response):

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -71,7 +71,6 @@ from .models import (
 from .json_web_token import (
     read_secret_key,
     validate_hs256_secret_key,
-    is_jwt_compatible_python_version,
     TokenGenerator,
     produce_bootstrap_output,
     parse_client_response,
@@ -333,11 +332,6 @@ def bootstrap(
     verbose,
 ):
     set_verbosity(verbose)
-    if not is_jwt_compatible_python_version():
-        raise RSConnectException(
-            "Python version > 3.5 required for JWT generation. Please upgrade your Python installation."
-        )
-
     if not server.startswith("http"):
         raise RSConnectException("Server URL expected to begin with transfer protocol (ex. http/https).")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,15 +20,14 @@ install_requires =
     click>=7.0.0
     pip>=10.0.0
     semver>=2.0.0,<3.0.0
-    pyjwt>=2.4.0; python_version >= '3.6'
-    pyjwt; python_version < '3.6'
+    pyjwt>=2.4.0
 setup_requires =
     setuptools
     setuptools_scm>=3.4
     toml
     wheel
 packages = rsconnect
-python_requires = >=3.5
+python_requires = >=3.7
 zip_safe = true
 
 [options.entry_points]

--- a/tests/test_json_web_token.py
+++ b/tests/test_json_web_token.py
@@ -18,7 +18,6 @@ from rsconnect.json_web_token import (
     SECRET_KEY_ENV,
     read_secret_key,
     produce_bootstrap_output,
-    is_jwt_compatible_python_version,
     parse_client_response,
     TokenGenerator,
     JWTEncoder,
@@ -43,9 +42,6 @@ def are_unix_timestamps_approx_equal(a, b):
 
 class TestJsonWebToken(TestCase):
     def setUp(self):
-        if not is_jwt_compatible_python_version():
-            self.skipTest("JWTs not supported in Python < 3.6")
-
         # decoded copy of the base64-encoded key in testdata/jwt/secret.key
         self.secret_key = b"12345678901234567890123456789012345"
         self.secret_key_b64 = b"MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU="
@@ -185,13 +181,6 @@ class TestJsonWebToken(TestCase):
 
         with pytest.raises(RSConnectException):
             parse_client_response(None)
-
-    def test_is_jwt_compatible_python_version(self):
-        """
-        With setUp() skipping invalid versions, this test should always return True
-        regardless of the particular python env we're running the tests in
-        """
-        self.assertTrue(is_jwt_compatible_python_version())
 
     def test_jwt_encoder_constructor(self):
         encoder = JWTEncoder("issuer", "audience", self.secret_key)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ import httpretty
 import pytest
 from click.testing import CliRunner
 
-from rsconnect.json_web_token import SECRET_KEY_ENV, is_jwt_compatible_python_version
+from rsconnect.json_web_token import SECRET_KEY_ENV
 
 from .utils import (
     apply_common_args,
@@ -561,9 +561,6 @@ class TestMain:
 
 class TestBootstrap(TestCase):
     def setUp(self):
-        if not is_jwt_compatible_python_version():
-            self.skipTest("JWTs not supported in Python < 3.6")
-
         self.mock_server = "http://localhost:8080"
         self.mock_uri = "http://localhost:8080/__api__/v1/experimental/bootstrap"
         self.jwt_keypath = "tests/testdata/jwt/secret.key"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,6 @@
 from unittest import TestCase
 from datetime import timedelta
 
-from rsconnect.json_web_token import is_jwt_compatible_python_version
-
 from rsconnect.json_web_token import JWTEncoder
 
 from tests.utils import (
@@ -12,10 +10,6 @@ from tests.utils import (
 
 
 class TestJwtUtils(TestCase):
-    def setUp(self):
-        if not is_jwt_compatible_python_version():
-            self.skipTest("JWTs not supported in Python < 3.6")
-
     def test_jwt_decoder(self):
 
         secret = b"12345678912345678912345678912345"


### PR DESCRIPTION
### Description

This PR removes support and testing for Python 3.5 and 3.6 since they are well past end of support, and Connect is planning to drop support in the January 2023 release. 

Also, CI is failing with this error:
```
Run actions/setup-python@v2
  with:
    python-version: 3.6
    token: ***
Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```
