### PR TITLE
limit code checks to the rsconnect directory

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -27,4 +27,4 @@ jobs:
         uses: snyk/actions/python@master
         with:
           command: code test
-          args: --project-name=${{ env.SNYK_PROJECT }} --org=${{ env.SNYK_ORG }}
+          args: --project-name=${{ env.SNYK_PROJECT }} --org=${{ env.SNYK_ORG }} rsconnect/


### PR DESCRIPTION
### Description

The Snyk report is currently checking all code including the mock_connect test fixture. This PR limits the checks to the `rsconnect` directory.


### Testing Notes / Validation Steps

Snyk checks should only report vulnerabilities in the rsconnect package code.

Note that the Snyk check will exit nonzero, failing the Action run, if there are any vulnerabilities reported. This is expected (for now).