### PR TITLE
remove RETICULATE_PYTHON detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- `rsconnect-python` no longer considers the `RETICULATE_PYTHON` environment variable.
+  In environments where `RETICULATE_PYTHON` is set outside a project context (e.g. by a Posit Workbench administrator),
+  attempting to deploy content or write manifests in projects using virtual environments required explicitly setting `--python /path/to/virtualenv/python`.
+  Removing `RETICULATE_PYTHON` detection should simplify the use of the CLI in this case.
+
 ## [1.13.0] - 2022-12-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -220,8 +220,7 @@ specified package list.
 
 If there is no `requirements.txt` file or the `--force-generate` option is specified,
 the package dependencies will be determined from the current Python environment, or
-from an alternative Python executable specified via the `--python` option or via the
-`RETICULATE_PYTHON` environment variable:
+from an alternative Python executable specified via the `--python` option:
 
 ```bash
 rsconnect deploy notebook --python /path/to/python my-notebook.ipynb

--- a/README.md
+++ b/README.md
@@ -254,8 +254,7 @@ in a later deployment. Use the `write-manifest` command to do this.
 The `write-manifest` command will also create a `requirements.txt` file, if it does
 not already exist or the `--force-generate` option is specified. It will contain the
 package dependencies from the current Python environment, or from an alternative
-Python executable specified in the `--python` option or via the `RETICULATE_PYTHON`
-environment variable.
+Python executable specified in the `--python` option.
 
 Here is an example of the `write-manifest` command:
 
@@ -348,8 +347,7 @@ the specified package list.
 
 If there is no `requirements.txt` file or the `--force-generate` option is specified,
 the package dependencies will be determined from the current Python environment, or
-from an alternative Python executable specified via the `--python` option or via the
-`RETICULATE_PYTHON` environment variable:
+from an alternative Python executable specified via the `--python` option:
 
 ```bash
 rsconnect deploy api --python /path/to/python my-api/
@@ -370,8 +368,7 @@ manifest in a later deployment. Use the `write-manifest` command to do this.
 The `write-manifest` command will also create a `requirements.txt` file, if it does
 not already exist or the `--force-generate` option is specified. It will contain
 the package dependencies from the current Python environment, or from an alternative
-Python executable specified in the `--python` option or via the `RETICULATE_PYTHON`
-environment variable.
+Python executable specified in the `--python` option.
 
 Here is an example of the `write-manifest` command:
 

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -113,7 +113,6 @@ def which_python(python, env=os.environ):
 
     In priority order:
     * --python specified on the command line
-    * RETICULATE_PYTHON defined in the environment
     * the python binary running this script
     """
     warn("This method has been moved and will be deprecated.", DeprecationWarning, stacklevel=2)
@@ -121,9 +120,6 @@ def which_python(python, env=os.environ):
         if not (exists(python) and os.access(python, os.X_OK)):
             raise RSConnectException('The file, "%s", does not exist or is not executable.' % python)
         return python
-
-    if "RETICULATE_PYTHON" in env:
-        return os.path.expanduser(env["RETICULATE_PYTHON"])
 
     return sys.executable
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1080,7 +1080,6 @@ def which_python(python, env=os.environ):
 
     In priority order:
     * --python specified on the command line
-    * RETICULATE_PYTHON defined in the environment
     * the python binary running this script
     """
     if python:

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1117,9 +1117,6 @@ def which_python(python, env=os.environ):
             raise RSConnectException('The file, "%s", does not exist or is not executable.' % python)
         return python
 
-    if "RETICULATE_PYTHON" in env:
-        return os.path.expanduser(env["RETICULATE_PYTHON"])
-
     return sys.executable
 
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -652,7 +652,6 @@ class TestBundle(TestCase):
 
         self.assertEqual(which_python(sys.executable), sys.executable)
         self.assertEqual(which_python(None), sys.executable)
-        self.assertEqual(which_python(None, {"RETICULATE_PYTHON": "fake-python"}), "fake-python")
 
     def test_default_title(self):
         self.assertEqual(_default_title("testing.txt"), "testing")


### PR DESCRIPTION
### Description

Detection of RETICULATE_PYTHON leads to surprising behaviors in environment detection in workbench. As per slack discussion, this was initially set in expectation of the CLI being used to deploy content from the RStudio IDE, but this functionality was never realized.

supersedes #326 
