### PR TITLE
Adds a check to Python executable validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `--cacert` option now supports certificate files encoded in the Distinguished Encoding Rules (DER) binary format. Certificate files with DER encoding must end in a `.cer` or `.der` suffix.
+- The `--python` option now provides additional user guidance when an invalid path is provided.
 
 ### Changed
 

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1075,19 +1075,24 @@ def are_apis_supported_on_server(connect_details):
     return connect_details["python"]["api_enabled"]
 
 
-def which_python(python, env=os.environ):
-    """Determine which python binary should be used.
+def which_python(python: typing.Optional[str] = None):
+    """Determines which Python executable to use.
 
-    In priority order:
-    * --python specified on the command line
-    * the python binary running this script
+    If the :param python: is provided, then validation is performed to check if the path is an executable file. If
+    None, the invoking system Python executable location is returned.
+
+    :param python: (Optional) path to a python executable.
+    :return: :param python: or `sys.executable`.
     """
-    if python:
-        if not (exists(python) and os.access(python, os.X_OK)):
-            raise RSConnectException('The file, "%s", does not exist or is not executable.' % python)
-        return python
-
-    return sys.executable
+    if python is None:
+        return sys.executable
+    if not exists(python):
+        raise RSConnectException(f"The path '{python}' does not exist. Expected a Python executable.")
+    if isdir(python):
+        raise RSConnectException(f"The path '{python}' is a directory. Expected a Python executable.")
+    if not os.access(python, os.X_OK):
+        raise RSConnectException(f"The path '{python}' is not executable. Expected a Python executable")
+    return python
 
 
 def inspect_environment(

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -646,13 +646,6 @@ class TestBundle(TestCase):
         finally:
             shutil.rmtree(directory)
 
-    def test_which_python(self):
-        with self.assertRaises(RSConnectException):
-            which_python("fake.file")
-
-        self.assertEqual(which_python(sys.executable), sys.executable)
-        self.assertEqual(which_python(None), sys.executable)
-
     def test_default_title(self):
         self.assertEqual(_default_title("testing.txt"), "testing")
         self.assertEqual(_default_title("this.is.a.test.ext"), "this.is.a.test")
@@ -781,3 +774,30 @@ def test_get_python_env_info(
 
         assert python == expected_python
         assert environment == expected_environment
+
+
+class WhichPythonTestCase(TestCase):
+    def test_default(self):
+        self.assertEqual(which_python(), sys.executable)
+
+    def test_none(self):
+        self.assertEqual(which_python(None), sys.executable)
+
+    def test_sys(self):
+        self.assertEqual(which_python(sys.executable), sys.executable)
+
+    def test_does_not_exist(self):
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            name = tmpfile.name
+        with self.assertRaises(RSConnectException):
+            which_python(name)
+
+    def test_is_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(RSConnectException):
+                which_python(tmpdir)
+
+    def test_is_not_executable(self):
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            with self.assertRaises(RSConnectException):
+                which_python(tmpfile.name)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description
<!--- Please describe the problem you are addressing and your proposed changes. -->

Adds a check to determine if the provided path is an file or a
directory. If the path is directory, an RSConnectException is thrown.

In addition:

- The error message for each existing validation is updated to inform
  the user that a Python executable is expected.
- Refactors the which_python method, eliminating an unused parameter,
  and providing additional None safety.

## Motivation and Context
<!--- Even small changes deserve a little attention to detail. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Example: "Addresses Issue # 1" -->

When a user provides the `-p` argument with a directory, an error is presented that does not include useful diagnostic information. This change provides the user with a course of action in this scenario.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Automation should be used to verify that a change remains in place. -->
<!--- Automated tests should be included in this pull request. -->

Automated tests validate each code path. For manual validation, execute the following command:

`rsconnect deploy fastapi -v --server https://alwayssecure.rsc:3443/ --api-key $CONNECT_API_KEY --insecure -p ./an/existing/path .`

<!--- If applicable, enumerate the steps that someone can take to exercise this change manually. -->
<!--- Please include details of your testing environment. -->
<!--- Detail is important! -->

### Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.