### PR TITLE
Authenticate to avoid `just` repo rate limiting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,6 +183,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Containers
         run: |
             just integration-testing/build


### PR DESCRIPTION
Small change to use authenticated requests when extracting `just` from github repo.  This should allow us to avoid the rate-limiting issue we've seen.
