### PR TITLE
RStudio to Posit cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,7 +964,7 @@ xargs printf -- '-g %s\n' < guids.txt | xargs rsconnect content build add
 ```
 ## Programmatic Provisioning
 
-RStudio Connect supports the programmatic bootstrapping of an admininistrator API key 
+Posit Connect supports the programmatic bootstrapping of an admininistrator API key 
 for scripted provisioning tasks. This process is supported by the `rsconnect bootstrap` command,
 which uses a JSON Web Token to request an initial API key from a fresh Connect instance. 
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -847,8 +847,8 @@ def deploy_notebook(
 # noinspection SpellCheckingInspection,DuplicatedCode
 @deploy.command(
     name="voila",
-    short_help="Deploy Jupyter notebook in Voila mode to RStudio Connect [v2023.03.0+].",
-    help=("Deploy a Jupyter notebook in Voila mode to RStudio Connect."),
+    short_help="Deploy Jupyter notebook in Voila mode to Posit Connect [v2023.03.0+].",
+    help=("Deploy a Jupyter notebook in Voila mode to Posit Connect."),
     no_args_is_help=True,
 )
 @server_args


### PR DESCRIPTION
- Noticed that the help text for Voila deployment says "RStudio Connect" 
- Ran a Search for places we're using "RStudio Connect" where we should be using "Posit Connect" 

<img width="531" alt="Screen Shot 2023-03-14 at 2 36 04 PM" src="https://user-images.githubusercontent.com/4359210/225144341-675bc3cd-6f66-49b3-a936-fdeb55f5551a.png">

## Description
- Changed one instance in the Readme
- Changed two instances (short_help and help) in main.py

## Motivation and Context

## How Has This Been Tested?
I did not test this change

### Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
