### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ a server with only Python 3.8 installed will fail to match content deployed with
 Python 3.7. Your administrator may also enable exact Python version matching which
 will be stricter and require matching major, minor, and patch versions. For more
 information see the [Posit Connect Admin Guide chapter titled Python Version
-Matching](https://docs.rstudio.com/connect/admin/python.html#python-version-matching).
+Matching](https://docs.posit.co/connect/admin/python.html#python-version-matching).
 
 ### Installation
 
@@ -722,7 +722,7 @@ of the available search flags.
 > **Note:** The `rsconnect content build` subcommand requires Posit Connect >= 2021.11.1
 
 Posit Connect caches R and Python packages in the configured
-[`Server.DataDir`](https://docs.rstudio.com/connect/admin/appendix/configuration/#Server.DataDir).
+[`Server.DataDir`](https://docs.posit.co/connect/admin/appendix/configuration/#Server.DataDir).
 Under certain circumstances (examples below), these package caches can become stale
 and need to be rebuilt. This refresh automatically occurs when a Posit Connect
 user visits the content. You may wish to refresh some content before it is visited
@@ -741,7 +741,7 @@ The following are some common scenarios where performing a content build might b
 > **Note:** The `content build` command is non-destructive, meaning that it does nothing to purge
 > existing packrat/python package caches before a build. If you have an
 > existing cache, it should be cleared prior to starting a content build.
-> See the [migration documentation](https://docs.rstudio.com/connect/admin/appendix/cli/#migration) for details.
+> See the [migration documentation](https://docs.posit.co/connect/admin/appendix/cli/#migration) for details.
 
 > **Note:** You may use the [`rsconnect content search`](#content-search) subcommand to help
 > identify high priority content items to build.
@@ -977,4 +977,4 @@ $ rsconnect bootstrap --server https://connect.example.org:3939 --jwt-keypath /p
 ```
 
 A full description on how to use `rsconnect bootstrap` in a provisioning workflow is provided in the Connect administrator guide's 
-[programmatic provisioning](https://docs.rstudio.com/connect/admin/programmatic-provisioning) documentation.
+[programmatic provisioning](https://docs.posit.co/connect/admin/programmatic-provisioning) documentation.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ a server with only Python 3.8 installed will fail to match content deployed with
 Python 3.7. Your administrator may also enable exact Python version matching which
 will be stricter and require matching major, minor, and patch versions. For more
 information see the [Posit Connect Admin Guide chapter titled Python Version
-Matching](https://docs.posit.co/connect/admin/python.html#python-version-matching).
+Matching](https://docs.posit.co/connect/admin/python/#python-version-matching).
 
 ### Installation
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,14 @@
 site_name: 'Posit Connect: rsconnect-python'
 copyright: Posit Software, PBC. All Rights Reserved
 
+# We activate GA only when hosted on our public docs site
+# and not when installed.
+#
+# See overrides/partials/integrations/analytics.html
+google_analytics:
+  - 'GTM-KHBDBW7'
+  - 'auto'
+
 markdown_extensions:
   - toc:
       permalink: "#"

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -81,7 +81,7 @@
     <div class="md-flex__cell md-flex__cell--shrink left-nav">
       <ul class="md-tabs__list">
         <li class="md-tabs__item"><a href="{{ base_url }}/../news/" title="Release Notes" class="md-tabs__link md-source">Release Notes</a></li>
-        <li class="md-tabs__item"><a href="https://support.rstudio.com/hc/en-us" title="Posit Support" class="md-tabs__link md-source">Help</a></li>
+        <li class="md-tabs__item"><a href="https://support.posit.co/hc/en-us" title="Posit Support" class="md-tabs__link md-source">Help</a></li>
         <li class="md-tabs__item"><a href="https://www.posit.co/" title="Posit" class="md-tabs__link md-source logo"></a></li>
       </ul>
     </div>

--- a/docs/overrides/partials/integrations/analytics.html
+++ b/docs/overrides/partials/integrations/analytics.html
@@ -1,0 +1,41 @@
+{% set property = config.google_analytics %}
+<!-- Google Analytics 4 (G-XXXXXXXXXX) -->
+<script>
+    /* Use GA when hosted by our public docs site, not when installed. */
+    if (location.href.indexOf("docs.posit.co") >= 0) {
+        window.dataLayer = window.dataLayer || []
+        function gtag() { dataLayer.push(arguments) }
+        /* Set up integration and send page view */
+        gtag("js", new Date())
+        gtag("config", "{{ property[0] }}")
+
+        /* Register virtual event handlers */
+        document.addEventListener("DOMContentLoaded", function () {
+            if (document.forms.search) {
+                var query = document.forms.search.query
+                query.addEventListener("blur", function () {
+                    if (this.value) {
+                        gtag("event", "search", { search_term: this.value })
+                    }
+                })
+            }
+
+            /* Send page view on location change */
+            if (typeof location$ !== "undefined")
+                location$.subscribe(function (url) {
+                    gtag("config", "{{ property[0] }}", {
+                        page_path: url.pathname
+                    })
+                })
+        })
+        /* Create script tag */
+        var script = document.createElement("script")
+        script.async = true
+        script.src = "https://www.googletagmanager.com/gtag/js?id={{ property[0] }}"
+
+        /* Inject script tag */
+        var container = document.getElementsByTagName("head")[0]
+        var firstChild = container.firstChild
+        container.insertBefore(script, firstChild)
+    }
+</script>

--- a/integration-testing/content/notebook/README.md
+++ b/integration-testing/content/notebook/README.md
@@ -9,8 +9,8 @@ This stock report is generated using Python and Jupyter Notebook. Stock prices a
 
 * [Jupyter Homepage](https://jupyter.org/)
 * [Jupyter Documentation](https://jupyter.org/documentation)
-* [Using Jupyter Notebooks in {systemDisplayName}](https://docs.rstudio.com/connect/user/jupyter-notebook/)
-* [User Guide for rsconnect_jupyter](https://docs.rstudio.com/rsconnect-jupyter/)
+* [Using Jupyter Notebooks in {systemDisplayName}](https://docs.posit.co/connect/user/jupyter-notebook/)
+* [User Guide for rsconnect_jupyter](https://docs.posit.co/rsconnect-jupyter/)
 
 ## Requirements
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ long_description_content_type = text/markdown
 name = rsconnect_python
 url = http://github.com/rstudio/rsconnect-python
 project_urls =
-    Documentation = https://docs.rstudio.com/rsconnect-python
+    Documentation = https://docs.posit.co/rsconnect-python
 
 [options]
 packages = rsconnect


### PR DESCRIPTION
## Description

Adds Google analytics tracking to the docs -- conditional, only active when hosted on docs.posit.co. Also updates some docs URLs while we're in here.

Connected to #366 

## Testing Notes / Validation Steps

Check to make sure that tracking is only loaded when on a docs.posit.co site (not on a local install), and that the tracking code is changed to the GTM-KHBDBW7

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have added tests to cover my changes.
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
