### PR TITLE
Add repo name to Snyk project name

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -20,10 +20,10 @@ jobs:
         uses: snyk/actions/python@master
         with:
           command: monitor
-          args: --file=setup.py --package-manager=pip --project-name=setup.py --org=${{ env.SNYK_ORG }}
+          args: --file=setup.py --package-manager=pip --project-name=rsconnect-python --org=${{ env.SNYK_ORG }}
 
       - name: Run Snyk (requirements.txt)
         uses: snyk/actions/python@master
         with:
           command: monitor
-          args: --file=requirements.txt --package-manager=pip --project-name=requirements.txt --org=${{ env.SNYK_ORG }}
+          args: --file=requirements.txt --package-manager=pip --project-name=rsconnect-python --org=${{ env.SNYK_ORG }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

The Snyk reports include projects named things like "requirements.txt" and "Pipfile" with no indication of which git repo they originate from.

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Update project name in snyk.yml.

## Automated Tests

No tests since this is a GHA configuration change.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
