### PR TITLE
fix unable to read cacert error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- cacert read error when adding/updating a server.
+
 ## [1.16.0] - 2023-03-27
 
 ### Added

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -274,7 +274,9 @@ def _test_server_and_api(server, api_key, insecure, ca_cert):
     :return: a tuple containing an appropriate ConnectServer object and the username
     of the user the API key represents (or None, if no key was provided).
     """
-    ca_data = ca_cert and ca_cert.read()
+    ca_data = None
+    if ca_cert:
+        ca_data = read_certificate_file(ca_cert)
     me = None
 
     with cli_feedback("Checking %s" % server):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
fixes #403

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
Adding a new server should now work when specified with --cacert

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
