### PR TITLE
implement publishing static outputs for cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+### Added
+- `deploy html` and `deploy manifest` now support deployment to Posit Cloud.
+
+### Changed
+- Cloud deployments accept the content id instead of application id in the --app-id field.
+- The `app_id` field in application store files also stores the content id instead of the application id.
+- Application store files include a `version` field, set to 1 for this release.
+
+## Unreleased
+
 ### Fixed
 - getdefaultlocale deprecated
 

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -224,8 +224,7 @@ def test_server(connect_server):
 def test_rstudio_server(server: api.PositServer):
     with api.PositClient(server) as client:
         try:
-            result = client.get_current_user()
-            server.handle_bad_response(result)
+            client.get_current_user()
         except RSConnectException as exc:
             raise RSConnectException("Failed to verify with {} ({}).".format(server.remote_name, exc))
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1422,14 +1422,9 @@ def get_app_info(connect_server, app_id):
 
 
 def get_rstudio_app_info(server, app_id):
-    cloud_resource_identity = CloudResourceIdentity(app_id)
     with PositClient(server) as client:
-        if cloud_resource_identity.content_id:
-            response = client.get_content(cloud_resource_identity.content_id)
-            return response["source"]
-        else:
-            return client.get_application(app_id)
-
+        response = client.get_content(app_id)
+        return response["source"]
 
 def get_app_config(connect_server, app_id):
     """

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1330,9 +1330,12 @@ class CloudService:
                 content_id = application.get("content_id") or application.get("output_id")
                 app_id_int = application["id"]
 
+                output = self._rstudio_client.get_content(content_id)
+
             if application_type == "static":
                 revision = self._rstudio_client.create_revision(content_id)
                 app_id_int = revision["application_id"]
+
 
         app_url = output["url"]
         output_id = output["id"]

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1336,7 +1336,6 @@ class CloudService:
                 revision = self._rstudio_client.create_revision(content_id)
                 app_id_int = revision["application_id"]
 
-
         app_url = output["url"]
         output_id = output["id"]
 
@@ -1428,6 +1427,7 @@ def get_rstudio_app_info(server, app_id):
     with PositClient(server) as client:
         response = client.get_content(app_id)
         return response["source"]
+
 
 def get_app_config(connect_server, app_id):
     """

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -25,7 +25,7 @@ from .certificates import read_certificate_file
 from .http_support import HTTPResponse, HTTPServer, append_to_path, CookieJar
 from .log import logger, connect_logger, cls_logged, console_logger
 from .models import AppMode, AppModes
-from .metadata import ServerStore, AppStore, CURRENT_APP_STORE_VERSION
+from .metadata import ServerStore, AppStore
 from .exception import RSConnectException
 from .bundle import _default_title, fake_module_file_from_directory
 from .timeouts import get_timeout
@@ -848,7 +848,6 @@ class RSConnectExecutor:
             raise RSConnectException("Specify either a new deploy or an app ID but not both.")
 
         existing_app_mode = None
-        app_store_version = CURRENT_APP_STORE_VERSION
         if not new:
             if app_id is None:
                 # Possible redeployment - check for saved metadata.

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -744,7 +744,7 @@ class RSConnectExecutor:
                 self.upload_rstudio_bundle(prepare_deploy_result, bundle_size, contents)
                 shinyapps_service.do_deploy(prepare_deploy_result.bundle_id, prepare_deploy_result.app_id)
             else:
-                cloud_service = CloudService(self.client, self.remote_server)
+                cloud_service = CloudService(self.client, self.remote_server, os.getenv("LUCID_APPLICATION_ID"))
                 app_store_version = self.get("app_store_version")
                 prepare_deploy_result = cloud_service.prepare_deploy(
                     app_id, deployment_name, bundle_size, bundle_hash, app_mode, app_store_version
@@ -1282,7 +1282,7 @@ class CloudService:
     Encapsulates operations involving multiple API calls to Posit Cloud.
     """
 
-    def __init__(self, cloud_client: PositClient, server: CloudServer, project_application_id: typing.Optional[str] = os.getenv("LUCID_APPLICATION_ID")):
+    def __init__(self, cloud_client: PositClient, server: CloudServer, project_application_id: typing.Optional[str]):
         self._rstudio_client = cloud_client
         self._server = server
         self._project_application_id = project_application_id

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -145,12 +145,12 @@ def server_args(func):
     return wrapper
 
 
-def rstudio_args(func):
+def cloud_shinyapps_args(func):
     @click.option(
         "--account",
         "-A",
         envvar=["SHINYAPPS_ACCOUNT"],
-        help="The shinyapps.io account name.",
+        help="The shinyapps.io/Posit Cloud account name.",
     )
     @click.option(
         "--token",
@@ -412,7 +412,7 @@ def bootstrap(
     help="The path to trusted TLS CA certificates.",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Print detailed messages.")
-@rstudio_args
+@cloud_shinyapps_args
 @click.pass_context
 def add(ctx, name, server, api_key, insecure, cacert, account, token, secret, verbose):
 
@@ -961,7 +961,7 @@ def deploy_voila(
 )
 @server_args
 @content_args
-@rstudio_args
+@cloud_shinyapps_args
 @click.argument("file", type=click.Path(exists=True, dir_okay=True, file_okay=True))
 @cli_exception_handler
 def deploy_manifest(
@@ -1133,12 +1133,13 @@ def deploy_quarto(
 # noinspection SpellCheckingInspection,DuplicatedCode
 @deploy.command(
     name="html",
-    short_help="Deploy html content to Posit Connect.",
-    help=("Deploy an html file, or directory of html files with entrypoint, to Posit Connect."),
+    short_help="Deploy html content to Posit Connect or Posit Cloud.",
+    help=("Deploy an html file, or directory of html files with entrypoint, to Posit Connect or Posit Cloud."),
     no_args_is_help=True,
 )
 @server_args
 @content_args
+@cloud_shinyapps_args
 @click.option(
     "--entrypoint",
     "-e",
@@ -1177,6 +1178,9 @@ def deploy_html(
     api_key: str = None,
     insecure: bool = False,
     cacert: typing.IO = None,
+    account: str = None,
+    token: str = None,
+    secret: str = None,
 ):
     kwargs = locals()
     ce = None
@@ -1218,7 +1222,7 @@ def generate_deploy_python(app_mode, alias, min_version):
     )
     @server_args
     @content_args
-    @rstudio_args
+    @cloud_shinyapps_args
     @click.option(
         "--entrypoint",
         "-e",

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -406,12 +406,13 @@ class AppStore(DataStore):
     are made.
     """
 
-    def __init__(self, app_file):
+    def __init__(self, app_file, version=1):
         base_name = str(basename(app_file).rsplit(".", 1)[0]) + ".json"
         super(AppStore, self).__init__(
             join(dirname(app_file), "rsconnect-python", base_name),
             join(config_dirname(), "applications", sha1(abspath(app_file)) + ".json"),
         )
+        self.version = version
 
     def get(self, server_url):
         """
@@ -449,7 +450,7 @@ class AppStore(DataStore):
                 app_guid=app_guid,
                 title=title,
                 app_mode=app_mode.name() if isinstance(app_mode, AppMode) else app_mode,
-                app_store_version=self.current_app_store_version,
+                app_store_version=self.version,
             ),
         )
 
@@ -457,7 +458,7 @@ class AppStore(DataStore):
         metadata = self.get(server)
         if metadata is None:
             logger.debug("No previous deployment to this server was found; this will be a new deployment.")
-            return app_id, app_mode, self.current_app_store_version
+            return app_id, app_mode, self.version
 
         logger.debug("Found previous deployment data in %s" % self.get_path())
 
@@ -470,10 +471,6 @@ class AppStore(DataStore):
 
         app_store_version = metadata.get("app_store_version")
         return app_id, app_mode, app_store_version
-
-    @property
-    def current_app_store_version(self):
-        return 1
 
 
 DEFAULT_BUILD_DIR = join(os.getcwd(), "rsconnect-build")

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -380,9 +380,6 @@ def sha1(s):
     return base64.urlsafe_b64encode(m.digest()).decode("utf-8").rstrip("=")
 
 
-CURRENT_APP_STORE_VERSION = 1
-
-
 class AppStore(DataStore):
     """
     Defines a metadata store for information about where the app has been
@@ -409,13 +406,12 @@ class AppStore(DataStore):
     are made.
     """
 
-    def __init__(self, app_file, app_store_version=CURRENT_APP_STORE_VERSION):
+    def __init__(self, app_file):
         base_name = str(basename(app_file).rsplit(".", 1)[0]) + ".json"
         super(AppStore, self).__init__(
             join(dirname(app_file), "rsconnect-python", base_name),
             join(config_dirname(), "applications", sha1(abspath(app_file)) + ".json"),
         )
-        self.app_store_version = app_store_version
 
     def get(self, server_url):
         """
@@ -453,7 +449,7 @@ class AppStore(DataStore):
                 app_guid=app_guid,
                 title=title,
                 app_mode=app_mode.name() if isinstance(app_mode, AppMode) else app_mode,
-                app_store_version=self.app_store_version,
+                app_store_version=self.current_app_store_version,
             ),
         )
 
@@ -461,7 +457,7 @@ class AppStore(DataStore):
         metadata = self.get(server)
         if metadata is None:
             logger.debug("No previous deployment to this server was found; this will be a new deployment.")
-            return app_id, app_mode, CURRENT_APP_STORE_VERSION
+            return app_id, app_mode, self.current_app_store_version
 
         logger.debug("Found previous deployment data in %s" % self.get_path())
 
@@ -474,6 +470,10 @@ class AppStore(DataStore):
 
         app_store_version = metadata.get("app_store_version")
         return app_id, app_mode, app_store_version
+
+    @property
+    def current_app_store_version(self):
+        return 1
 
 
 DEFAULT_BUILD_DIR = join(os.getcwd(), "rsconnect-build")

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -380,6 +380,9 @@ def sha1(s):
     return base64.urlsafe_b64encode(m.digest()).decode("utf-8").rstrip("=")
 
 
+CURRENT_APP_STORE_VERSION = 1
+
+
 class AppStore(DataStore):
     """
     Defines a metadata store for information about where the app has been
@@ -396,20 +399,23 @@ class AppStore(DataStore):
     * App GUID
     * Title
     * App mode
+    * App store file version
 
     The metadata file for an app is written in the same directory as the app's
     entry point file, if that directory is writable.  Otherwise, it is stored
     in the user's config directory under `applications/{hash}.json` where the
-    hash is derived from the entry point file name.
+    hash is derived from the entry point file name. The file contains a version
+    field, which is incremented when backwards-incompatible file format changes
+    are made.
     """
 
-    def __init__(self, app_file, appstore_version=1):
+    def __init__(self, app_file, app_store_version=CURRENT_APP_STORE_VERSION):
         base_name = str(basename(app_file).rsplit(".", 1)[0]) + ".json"
         super(AppStore, self).__init__(
             join(dirname(app_file), "rsconnect-python", base_name),
             join(config_dirname(), "applications", sha1(abspath(app_file)) + ".json"),
         )
-        self.appstore_version = appstore_version
+        self.app_store_version = app_store_version
 
     def get(self, server_url):
         """
@@ -447,7 +453,7 @@ class AppStore(DataStore):
                 app_guid=app_guid,
                 title=title,
                 app_mode=app_mode.name() if isinstance(app_mode, AppMode) else app_mode,
-                appstore_version=self.appstore_version,
+                app_store_version=self.app_store_version,
             ),
         )
 
@@ -455,7 +461,7 @@ class AppStore(DataStore):
         metadata = self.get(server)
         if metadata is None:
             logger.debug("No previous deployment to this server was found; this will be a new deployment.")
-            return app_id, app_mode
+            return app_id, app_mode, CURRENT_APP_STORE_VERSION
 
         logger.debug("Found previous deployment data in %s" % self.get_path())
 
@@ -465,7 +471,9 @@ class AppStore(DataStore):
 
         # app mode cannot be changed on redeployment
         app_mode = AppModes.get_by_name(metadata.get("app_mode"))
-        return app_id, app_mode
+
+        app_store_version = metadata.get("app_store_version")
+        return app_id, app_mode, app_store_version
 
 
 DEFAULT_BUILD_DIR = join(os.getcwd(), "rsconnect-build")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,11 +6,21 @@ import httpretty
 import sys
 import io
 from rsconnect.exception import RSConnectException
+from rsconnect.metadata import CURRENT_APP_STORE_VERSION
+from rsconnect.models import AppModes
 from .utils import (
     require_api_key,
     require_connect,
 )
-from rsconnect.api import RSConnectClient, RSConnectExecutor, RSConnectServer, _to_server_check_list
+from rsconnect.api import (
+    RSConnectClient,
+    RSConnectExecutor,
+    RSConnectServer,
+    _to_server_check_list,
+    CloudService,
+    PositClient,
+    CloudServer,
+)
 
 
 class TestAPI(TestCase):
@@ -207,3 +217,185 @@ class RSConnectClientTestCase(TestCase):
             app_id = Mock()
             with self.assertRaises(RSConnectException):
                 client.deploy(app_id, app_name=None, app_title=None, title_is_default=None, tarball=None)
+
+
+class CloudServiceTestCase(TestCase):
+    def test_prepare_new_deploy(self):
+        cloud_client = Mock(spec=PositClient)
+        server = CloudServer("https://api.posit.cloud", "the_account", "the_token", "the_secret")
+        project_application_id = "20"
+        cloud_service = CloudService(
+            cloud_client=cloud_client, server=server, project_application_id=project_application_id
+        )
+
+        app_id = None
+        app_name = "my app"
+        bundle_size = 5000
+        bundle_hash = "the_hash"
+        app_mode = AppModes.PYTHON_SHINY
+
+        cloud_client.get_application.return_value = {
+            "content_id": 2,
+        }
+        cloud_client.get_content.return_value = {
+            "space_id": 1000,
+        }
+        cloud_client.create_output.return_value = {
+            "id": 1,
+            "source_id": 10,
+            "url": "https://posit.cloud/content/1",
+        }
+        cloud_client.create_bundle.return_value = {
+            "id": 100,
+            "presigned_url": "https://presigned.url",
+            "presigned_checksum": "the_checksum",
+        }
+
+        prepare_deploy_result = cloud_service.prepare_deploy(
+            app_id=app_id,
+            app_name=app_name,
+            bundle_size=bundle_size,
+            bundle_hash=bundle_hash,
+            app_mode=app_mode,
+            app_store_version=CURRENT_APP_STORE_VERSION,
+        )
+
+        cloud_client.get_application.assert_called_with(project_application_id)
+        cloud_client.get_content.assert_called_with(2)
+        cloud_client.create_output.assert_called_with(
+            name=app_name, application_type="connect", project_id=2, space_id=1000
+        )
+        cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
+
+        assert prepare_deploy_result.app_id == 1
+        assert prepare_deploy_result.application_id == 10
+        assert prepare_deploy_result.app_url == "https://posit.cloud/content/1"
+        assert prepare_deploy_result.bundle_id == 100
+        assert prepare_deploy_result.presigned_url == "https://presigned.url"
+        assert prepare_deploy_result.presigned_checksum == "the_checksum"
+
+    def test_prepare_redeploy(self):
+        cloud_client = Mock(spec=PositClient)
+        server = CloudServer("https://api.posit.cloud", "the_account", "the_token", "the_secret")
+        project_application_id = "20"
+        cloud_service = CloudService(
+            cloud_client=cloud_client, server=server, project_application_id=project_application_id
+        )
+
+        app_id = 1
+        app_name = "my app"
+        bundle_size = 5000
+        bundle_hash = "the_hash"
+        app_mode = AppModes.PYTHON_SHINY
+
+        cloud_client.get_content.return_value = {"id": 1, "source_id": 10, "url": "https://posit.cloud/content/1"}
+        cloud_client.create_bundle.return_value = {
+            "id": 100,
+            "presigned_url": "https://presigned.url",
+            "presigned_checksum": "the_checksum",
+        }
+
+        prepare_deploy_result = cloud_service.prepare_deploy(
+            app_id=app_id,
+            app_name=app_name,
+            bundle_size=bundle_size,
+            bundle_hash=bundle_hash,
+            app_mode=app_mode,
+            app_store_version=CURRENT_APP_STORE_VERSION,
+        )
+        cloud_client.get_content.assert_called_with(1)
+        cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
+
+        assert prepare_deploy_result.app_id == 1
+        assert prepare_deploy_result.application_id == 10
+        assert prepare_deploy_result.app_url == "https://posit.cloud/content/1"
+        assert prepare_deploy_result.bundle_id == 100
+        assert prepare_deploy_result.presigned_url == "https://presigned.url"
+        assert prepare_deploy_result.presigned_checksum == "the_checksum"
+
+    def test_prepare_redeploy_static(self):
+        cloud_client = Mock(spec=PositClient)
+        server = CloudServer("https://api.posit.cloud", "the_account", "the_token", "the_secret")
+        project_application_id = "20"
+        cloud_service = CloudService(
+            cloud_client=cloud_client, server=server, project_application_id=project_application_id
+        )
+
+        app_id = 1
+        app_name = "my app"
+        bundle_size = 5000
+        bundle_hash = "the_hash"
+        app_mode = AppModes.STATIC
+
+        cloud_client.get_content.return_value = {"id": 1, "source_id": 10, "url": "https://posit.cloud/content/1"}
+        cloud_client.create_revision.return_value = {
+            "application_id": 11,
+        }
+        cloud_client.create_bundle.return_value = {
+            "id": 100,
+            "presigned_url": "https://presigned.url",
+            "presigned_checksum": "the_checksum",
+        }
+
+        prepare_deploy_result = cloud_service.prepare_deploy(
+            app_id=app_id,
+            app_name=app_name,
+            bundle_size=bundle_size,
+            bundle_hash=bundle_hash,
+            app_mode=app_mode,
+            app_store_version=CURRENT_APP_STORE_VERSION,
+        )
+        cloud_client.get_content.assert_called_with(1)
+        cloud_client.create_revision.assert_called_with(1)
+        cloud_client.create_bundle.assert_called_with(11, "application/x-tar", bundle_size, bundle_hash)
+
+        assert prepare_deploy_result.app_id == 1
+        assert prepare_deploy_result.application_id == 11
+        assert prepare_deploy_result.app_url == "https://posit.cloud/content/1"
+        assert prepare_deploy_result.bundle_id == 100
+        assert prepare_deploy_result.presigned_url == "https://presigned.url"
+        assert prepare_deploy_result.presigned_checksum == "the_checksum"
+
+    def test_prepare_redeploy_preversioned_app_store(self):
+        cloud_client = Mock(spec=PositClient)
+        server = CloudServer("https://api.posit.cloud", "the_account", "the_token", "the_secret")
+        project_application_id = "20"
+        cloud_service = CloudService(
+            cloud_client=cloud_client, server=server, project_application_id=project_application_id
+        )
+
+        app_id = 10
+        app_name = "my app"
+        bundle_size = 5000
+        bundle_hash = "the_hash"
+        app_mode = AppModes.PYTHON_SHINY
+
+        cloud_client.get_application.return_value = {
+            "id": 10,
+            "content_id": 1,
+        }
+        cloud_client.get_content.return_value = {"id": 1, "source_id": 10, "url": "https://posit.cloud/content/1"}
+        cloud_client.create_bundle.return_value = {
+            "id": 100,
+            "presigned_url": "https://presigned.url",
+            "presigned_checksum": "the_checksum",
+        }
+
+        prepare_deploy_result = cloud_service.prepare_deploy(
+            app_id=app_id,
+            app_name=app_name,
+            bundle_size=bundle_size,
+            bundle_hash=bundle_hash,
+            app_mode=app_mode,
+            app_store_version=None,
+        )
+        cloud_client.get_application.assert_called_with(10)
+        cloud_client.get_content.assert_called_with(1)
+        cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
+
+        assert prepare_deploy_result.app_id == 1
+        assert prepare_deploy_result.application_id == 10
+        assert prepare_deploy_result.app_url == "https://posit.cloud/content/1"
+        assert prepare_deploy_result.bundle_id == 100
+        assert prepare_deploy_result.presigned_url == "https://presigned.url"
+        assert prepare_deploy_result.presigned_checksum == "the_checksum"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,6 @@ import httpretty
 import sys
 import io
 from rsconnect.exception import RSConnectException
-from rsconnect.metadata import CURRENT_APP_STORE_VERSION
 from rsconnect.models import AppModes
 from .utils import (
     require_api_key,
@@ -257,7 +256,7 @@ class CloudServiceTestCase(TestCase):
             bundle_size=bundle_size,
             bundle_hash=bundle_hash,
             app_mode=app_mode,
-            app_store_version=CURRENT_APP_STORE_VERSION,
+            app_store_version=1,
         )
 
         cloud_client.get_application.assert_called_with(project_application_id)
@@ -301,7 +300,7 @@ class CloudServiceTestCase(TestCase):
             bundle_size=bundle_size,
             bundle_hash=bundle_hash,
             app_mode=app_mode,
-            app_store_version=CURRENT_APP_STORE_VERSION,
+            app_store_version=1,
         )
         cloud_client.get_content.assert_called_with(1)
         cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
@@ -343,7 +342,7 @@ class CloudServiceTestCase(TestCase):
             bundle_size=bundle_size,
             bundle_hash=bundle_hash,
             app_mode=app_mode,
-            app_store_version=CURRENT_APP_STORE_VERSION,
+            app_store_version=1,
         )
         cloud_client.get_content.assert_called_with(1)
         cloud_client.create_revision.assert_called_with(1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -442,7 +442,8 @@ class TestMain:
 
     @httpretty.activate(verbose=True, allow_net_connect=False)
     @pytest.mark.parametrize(
-        "command_and_arg",
+        "command,arg",
+
         [
             [
                 "manifest",
@@ -455,10 +456,12 @@ class TestMain:
         ],
         ids=["using manifest", "using html"],
     )
-    def test_deploy_static_cloud(self, command_and_arg):
+    def test_deploy_static_cloud(self, command, arg):
         """
         Verify that an app with app_mode as static can deploy to cloud.
         """
+        shutil.rmtree(os.path.join(arg, 'rsconnect-python'), ignore_errors=True)
+
         original_api_key_value = os.environ.pop("CONNECT_API_KEY", None)
         original_server_value = os.environ.pop("CONNECT_SERVER", None)
 
@@ -583,7 +586,8 @@ class TestMain:
         runner = CliRunner()
         args = [
             "deploy",
-            *command_and_arg,
+            command,
+            arg,
             "--server",
             "rstudio.cloud",
             "--account",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,7 +31,7 @@ def _error_to_response(error):
     HTTPretty is unable to show errors resulting from callbacks, so this method attempts to raise failure visibility by
     passing the return back through HTTP.
     """
-    return [500, {}, str(error)]
+    return [555, {}, str(error)]
 
 
 def _load_json(data):
@@ -274,22 +274,6 @@ class TestMain:
             body=open("tests/testdata/rstudio-responses/get-user.json", "r").read(),
             status=200,
         )
-        httpretty.register_uri(
-            httpretty.GET,
-            "https://api.posit.cloud/v1/applications"
-            "?filter=name:like:shinyapp&offset=0&count=100&use_advanced_filters=true",
-            body=open("tests/testdata/rstudio-responses/get-applications.json", "r").read(),
-            adding_headers={"Content-Type": "application/json"},
-            status=200,
-        )
-        httpretty.register_uri(
-            httpretty.GET,
-            "https://api.posit.cloud/v1/accounts/",
-            body=open("tests/testdata/rstudio-responses/get-accounts.json", "r").read(),
-            adding_headers={"Content-Type": "application/json"},
-            status=200,
-        )
-
         if project_application_id:
             httpretty.register_uri(
                 httpretty.GET,
@@ -317,7 +301,12 @@ class TestMain:
             space_id = 917733 if project_application_id else None
             parsed_request = _load_json(request.body)
             try:
-                assert parsed_request == {"name": "myapp", "space": space_id, "project": project_id}
+                assert parsed_request == {
+                    "name": "myapp",
+                    "space": space_id,
+                    "project": project_id,
+                    "application_type": "connect",
+                }
             except AssertionError as e:
                 return _error_to_response(e)
             return [
@@ -450,6 +439,170 @@ class TestMain:
                 os.environ["CONNECT_SERVER"] = original_server_value
             if project_application_id:
                 del os.environ["LUCID_APPLICATION_ID"]
+
+    @httpretty.activate(verbose=True, allow_net_connect=False)
+    @pytest.mark.parametrize(
+        "command_and_arg",
+        [
+            [
+                "manifest",
+                get_manifest_path("static", parent="py3"),
+            ],
+            [
+                "html",
+                join(os.path.dirname(__file__), "testdata", "py3", "static"),
+            ],
+        ],
+        ids=["using manifest", "using html"],
+    )
+    def test_deploy_static_cloud(self, command_and_arg):
+        """
+        Verify that an app with app_mode as static can deploy to cloud.
+        """
+        original_api_key_value = os.environ.pop("CONNECT_API_KEY", None)
+        original_server_value = os.environ.pop("CONNECT_SERVER", None)
+
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://api.posit.cloud/v1/users/me",
+            body=open("tests/testdata/rstudio-responses/get-user.json", "r").read(),
+            status=200,
+        )
+
+        def post_output_callback(request, uri, response_headers):
+            parsed_request = _load_json(request.body)
+            try:
+                assert parsed_request == {"name": "myapp", "space": None, "project": None, "application_type": "static"}
+            except AssertionError as e:
+                return _error_to_response(e)
+            return [
+                201,
+                {"Content-Type": "application/json"},
+                open("tests/testdata/rstudio-responses/create-output.json", "r").read(),
+            ]
+
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://api.posit.cloud/v1/applications/8442",
+            body=open("tests/testdata/rstudio-responses/get-output-application.json", "r").read(),
+            adding_headers={"Content-Type": "application/json"},
+            status=200,
+        )
+
+        if True:
+            httpretty.register_uri(
+                httpretty.POST,
+                "https://api.posit.cloud/v1/outputs/",
+                body=post_output_callback,
+            )
+
+        def post_bundle_callback(request, uri, response_headers):
+            parsed_request = _load_json(request.body)
+            del parsed_request["checksum"]
+            del parsed_request["content_length"]
+            try:
+                assert parsed_request == {
+                    "application": 8442,
+                    "content_type": "application/x-tar",
+                }
+            except AssertionError as e:
+                return _error_to_response(e)
+            return [
+                201,
+                {"Content-Type": "application/json"},
+                open("tests/testdata/rstudio-responses/create-bundle.json", "r").read(),
+            ]
+
+        httpretty.register_uri(
+            httpretty.POST,
+            "https://api.posit.cloud/v1/bundles",
+            body=post_bundle_callback,
+        )
+
+        httpretty.register_uri(
+            httpretty.PUT,
+            "https://lucid-uploads-staging.s3.amazonaws.com/bundles/application-8442/"
+            "6c9ed0d91ee9426687d9ac231d47dc83.tar.gz"
+            "?AWSAccessKeyId=theAccessKeyId"
+            "&Signature=dGhlU2lnbmF0dXJlCg%3D%3D"
+            "&content-md5=D1blMI4qTiI3tgeUOYXwkg%3D%3D"
+            "&content-type=application%2Fx-tar"
+            "&x-amz-security-token=dGhlVG9rZW4K"
+            "&Expires=1656715153",
+            body="",
+        )
+
+        def post_bundle_status_callback(request, uri, response_headers):
+            parsed_request = _load_json(request.body)
+            try:
+                assert parsed_request == {"status": "ready"}
+            except AssertionError as e:
+                return _error_to_response(e)
+            return [303, {"Location": "https://api.posit.cloud/v1/bundles/12640"}, ""]
+
+        httpretty.register_uri(
+            httpretty.POST,
+            "https://api.posit.cloud/v1/bundles/12640/status",
+            body=post_bundle_status_callback,
+        )
+
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://api.posit.cloud/v1/bundles/12640",
+            body=open("tests/testdata/rstudio-responses/get-accounts.json", "r").read(),
+            adding_headers={"Content-Type": "application/json"},
+            status=200,
+        )
+
+        def post_deploy_callback(request, uri, response_headers):
+            parsed_request = _load_json(request.body)
+            try:
+                assert parsed_request == {"bundle": 12640, "rebuild": False}
+            except AssertionError as e:
+                return _error_to_response(e)
+            return [
+                303,
+                {"Location": "https://api.posit.cloud/v1/tasks/333"},
+                open("tests/testdata/rstudio-responses/post-deploy.json", "r").read(),
+            ]
+
+        httpretty.register_uri(
+            httpretty.POST,
+            "https://api.posit.cloud/v1/applications/8442/deploy",
+            body=post_deploy_callback,
+        )
+
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://api.posit.cloud/v1/tasks/333",
+            body=open("tests/testdata/rstudio-responses/get-task.json", "r").read(),
+            adding_headers={"Content-Type": "application/json"},
+            status=200,
+        )
+
+        runner = CliRunner()
+        args = [
+            "deploy",
+            *command_and_arg,
+            "--server",
+            "rstudio.cloud",
+            "--account",
+            "some-account",
+            "--token",
+            "someToken",
+            "--secret",
+            "c29tZVNlY3JldAo=",
+            "--title",
+            "myApp",
+        ]
+        try:
+            result = runner.invoke(cli, args)
+            assert result.exit_code == 0, result.output
+        finally:
+            if original_api_key_value:
+                os.environ["CONNECT_API_KEY"] = original_api_key_value
+            if original_server_value:
+                os.environ["CONNECT_SERVER"] = original_server_value
 
     def test_deploy_api(self):
         target = optional_target(get_api_path("flask"))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -199,7 +199,7 @@ class TestAppMetadata(TestCase):
                 title="Important Title",
                 app_mode="static",
                 filename="/path/to/file",
-                appstore_version=1,
+                app_store_version=1,
             ),
         )
 
@@ -213,7 +213,7 @@ class TestAppMetadata(TestCase):
                 title="Untitled",
                 app_mode="jupyter-static",
                 filename="/path/to/file",
-                appstore_version=1,
+                app_store_version=1,
             ),
         )
 

--- a/tests/testdata/py3/static/index.html
+++ b/tests/testdata/py3/static/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Very basic HTML page</h1>
+<p>There's not much here.</p>
+
+</body>
+</html>

--- a/tests/testdata/py3/static/manifest.json
+++ b/tests/testdata/py3/static/manifest.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "appmode": "static",
+    "primary_rmd": null,
+    "primary_html": "index.html",
+    "content_category": null,
+    "has_parameters": false
+  },
+  "packages": null,
+  "files": {
+    "index.html": {
+      "checksum": "b7fffcb24c6883ea12b6e80c129daceb"
+    }
+  },
+  "users": null
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Adds support for `deploy html` and `deploy manifest` to deploy to Posit Cloud.

Resolves https://github.com/rstudio/rsconnect-python/issues/420.

This includes the changes from https://github.com/mslynch/rsconnect-python/pull/1, plus versioned app store files and more tests.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

Allows for static content to be deployed to Posit Cloud.

This PR also introduces file versioning to the app store files with an initial version of 1. For cloud deployments, `app_id` will now store the content id (as in `https://posit.cloud/content/{content_id}` (as opposed to the previous approach of storing the application id).

Also contains a refactor to Cloud's HTTP client to handle errors within the client and return the parsed response body from its calls.

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Added a test with `rsconnect deploy manifest` using a manifest for a `static`-appmode application. Also added several unit tests for `CloudService.prepare_deploy` to test deploy/redeploy/pre-versioned app store files.

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

To test this manually, you can use:
```shell
rsconnect deploy html \
          --account $YOUR_ACCOUNT \
          --token $YOUR_TOKEN \
          --secret $YOUR_SECRET \
          --server 'https://api.staging.posit.cloud' \
          'some_file.html'
```

To test compatibility with pre-versioned app store files,
- do a deploy on the current version:
  ```shell
  rsconnect deploy shiny \
            --account $YOUR_ACCOUNT \
            --token $YOUR_TOKEN \
            --secret $YOUR_SECRET \
            --server 'https://api.staging.posit.cloud' \
            'my-shiny-app'
  ```
- then check out main, reinstall, and run the command again.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
