### PR TITLE
Ensure posix paths in manifest

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -355,7 +355,8 @@ def manifest_add_file(manifest, rel_path, base_dir):
     path = join(base_dir, rel_path) if os.path.isdir(base_dir) else rel_path
     if "files" not in manifest:
         manifest["files"] = {}
-    manifest["files"][rel_path] = {"checksum": file_checksum(path)}
+    manifestPath = Path(rel_path).as_posix()
+    manifest["files"][manifestPath] = {"checksum": file_checksum(path)}
 
 
 def manifest_add_buffer(manifest, filename, buf):

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -173,7 +173,8 @@ class Manifest:
         self.data["metadata"]["primary_html"] = value
 
     def add_file(self, path):
-        self.data["files"][path] = {"checksum": file_checksum(path)}
+        manifestPath = Path(path).as_posix()
+        self.data["files"][manifestPath] = {"checksum": file_checksum(path)}
         return self
 
     def discard_file(self, path):
@@ -296,7 +297,6 @@ def make_source_manifest(
     quarto_inspection: typing.Dict[str, typing.Any],
     image: str = None,
 ) -> typing.Dict[str, typing.Any]:
-
     manifest = {
         "version": 1,
     }  # type: typing.Dict[str, typing.Any]
@@ -543,7 +543,6 @@ def make_notebook_source_bundle(
 
     bundle_file = tempfile.TemporaryFile(prefix="rsc_bundle")
     with tarfile.open(mode="w:gz", fileobj=bundle_file) as bundle:
-
         # add the manifest first in case we want to partially untar the bundle for inspection
         bundle_add_buffer(bundle, "manifest.json", json.dumps(manifest, indent=2))
         bundle_add_buffer(bundle, environment.filename, environment.contents)

--- a/tests/test_Manifest.py
+++ b/tests/test_Manifest.py
@@ -1,4 +1,3 @@
-import sys
 import json
 import os
 
@@ -11,7 +10,6 @@ cur_dir = os.path.dirname(__file__)
 html_manifest_json_file = os.path.join(cur_dir, "testdata", "Manifest", "html_manifest.json")
 
 
-@pytest.mark.skipif(sys.platform in ("win32", "win64"), reason="Backslash vs forward slash")
 def test_Manifest_from_json():
     html_manifest_dict = {
         "version": 1,
@@ -27,23 +25,6 @@ def test_Manifest_from_json():
     assert m.json == manifest_json_str
 
 
-@pytest.mark.skipif(sys.platform not in ("win32", "win64"), reason="Backslash vs forward slash")
-def test_Manifest_from_json_Windows():
-    html_manifest_dict = {
-        "version": 1,
-        "metadata": {"appmode": "static", "primary_html": "index.html", "entrypoint": "index.html"},
-        "files": {
-            "index.html": {"checksum": "c14bd63e50295f94b761ffe9d41e3742"},
-            "test1.txt": {"checksum": "3e7705498e8be60520841409ebc69bc1"},
-            "test_folder1\\testfoldertext1.txt": {"checksum": "0a576fd324b6985bac6aa934131d2f5c"},
-        },
-    }
-    manifest_json_str = json.dumps(html_manifest_dict, indent=2)
-    m = Manifest.from_json(manifest_json_str)
-    assert m.json == manifest_json_str
-
-
-@pytest.mark.skipif(sys.platform in ("win32", "win64"), reason="Backslash vs forward slash")
 def test_Manifest_from_json_file():
     m = Manifest.from_json_file(html_manifest_json_file)
     with open(html_manifest_json_file) as json_file:
@@ -51,7 +32,6 @@ def test_Manifest_from_json_file():
         assert m.json == json.dumps(json_dict, indent=2)
 
 
-@pytest.mark.skipif(sys.platform in ("win32", "win64"), reason="Backslash vs forward slash")
 def test_Manifest_properties():
     html_manifest_dict = {
         "version": 1,
@@ -71,27 +51,6 @@ def test_Manifest_properties():
     assert list(m.data["files"].keys()) == ["index.html", "test1.txt"]
 
 
-@pytest.mark.skipif(sys.platform not in ("win32", "win64"), reason="Backslash vs forward slash")
-def test_Manifest_properties_Windows():
-    html_manifest_dict = {
-        "version": 1,
-        "metadata": {"appmode": "static", "primary_html": "index.html", "entrypoint": "index.html"},
-        "files": {
-            "index.html": {"checksum": "c14bd63e50295f94b761ffe9d41e3742"},
-            "test1.txt": {"checksum": "3e7705498e8be60520841409ebc69bc1"},
-            "test_folder1\\testfoldertext1.txt": {"checksum": "0a576fd324b6985bac6aa934131d2f5c"},
-        },
-    }
-    manifest_json_str = json.dumps(html_manifest_dict, indent=2)
-    m = Manifest.from_json(manifest_json_str)
-    assert m.primary_html == html_manifest_dict["metadata"]["primary_html"]
-    assert m.entrypoint == html_manifest_dict["metadata"]["entrypoint"]
-
-    m.discard_file("test_folder1\\testfoldertext1.txt")
-    assert list(m.data["files"].keys()) == ["index.html", "test1.txt"]
-
-
-@pytest.mark.skipif(sys.platform in ("win32", "win64"), reason="Backslash vs forward slash")
 def test_Manifest_flattened_copy():
     start = {
         "version": 1,
@@ -120,44 +79,6 @@ def test_Manifest_flattened_copy():
             "index.html": {"checksum": "c14bd63e50295f94b761ffe9d41e3742"},
             "test1.txt": {"checksum": "3e7705498e8be60520841409ebc69bc1"},
             "test_folder1/testfoldertext1.txt": {"checksum": "0a576fd324b6985bac6aa934131d2f5c"},
-        },
-    }
-    assert m.flattened_copy.data == html_manifest_dict
-
-
-@pytest.mark.skipif(sys.platform not in ("win32", "win64"), reason="Backslash vs forward slash")
-def test_Manifest_flattened_copy_Windows():
-    start = {
-        "version": 1,
-        "metadata": {
-            "appmode": "static",
-            "primary_html": "tests\\testdata\\html_tests\\single_file_index\\index.html",
-            "entrypoint": "tests\\testdata\\html_tests\\single_file_index\\index.html",
-        },
-        "files": {
-            "tests\\testdata\\html_tests\\single_file_index\\index.html": {
-                "checksum": "c14bd63e50295f94b761ffe9d41e3742"
-            },
-            "tests\\testdata\\html_tests\\single_file_index\\test1.txt": {
-                "checksum": "3e7705498e8be60520841409ebc69bc1"
-            },
-            "tests\\testdata\\html_tests\\single_file_index\\test_folder1\\testfoldertext1.txt": {
-                "checksum": "0a576fd324b6985bac6aa934131d2f5c"
-            },
-        },
-    }
-    start_json_str = json.dumps(start, indent=2)
-    m = Manifest.from_json(start_json_str)
-    assert m.data == start
-    m.entrypoint = "tests\\testdata\\html_tests\\single_file_index\\index.html"
-    m.deploy_dir = "tests\\testdata\\html_tests\\single_file_index"
-    html_manifest_dict = {
-        "version": 1,
-        "metadata": {"appmode": "static", "primary_html": "index.html", "entrypoint": "index.html"},
-        "files": {
-            "index.html": {"checksum": "c14bd63e50295f94b761ffe9d41e3742"},
-            "test1.txt": {"checksum": "3e7705498e8be60520841409ebc69bc1"},
-            "test_folder1\\testfoldertext1.txt": {"checksum": "0a576fd324b6985bac6aa934131d2f5c"},
         },
     }
     assert m.flattened_copy.data == html_manifest_dict


### PR DESCRIPTION
This PR ensures that manifest file lists always contain posix paths, and not Windows paths (containing `\`). shinyapps.io does not accept Windows paths in the manifest.json.

## Intent

Fixes #373

## Type of Change

- [X] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
Using `pathlib.Path.as_posix()` to convert to Posix paths.

## Automated Tests
I removed all of the special case unit tests for Windows, and make all of the tests run on all platforms.

## Directions for Reviewers

Will need to test deployments on posix and Windows clients, deploying to Connect and to shinyapps.io.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
