### PR TITLE
remove capability check

### DIFF
--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -272,19 +272,6 @@ def gather_server_details(connect_server):
     }
 
 
-def are_apis_supported_on_server(connect_details):
-    """
-    Returns whether or not the Connect server has Python itself enabled and its license allows
-    for API usage.  This controls whether APIs may be deployed..
-
-    :param connect_details: details about a Connect server as returned by gather_server_details()
-    :return: boolean True if the Connect server supports Python APIs or not or False if not.
-    :error: The Posit Connect server does not allow for Python APIs.
-    """
-    warn("This method has been moved and will be deprecated.", DeprecationWarning, stacklevel=2)
-    return connect_details["python"]["api_enabled"]
-
-
 def is_conda_supported_on_server(connect_details):
     """
     Returns whether or not conda is supported on a Connect server.
@@ -294,34 +281,6 @@ def is_conda_supported_on_server(connect_details):
     :error: Conda is not supported on the target server.  Try deploying without requesting Conda.
     """
     return connect_details.get("conda", {}).get("supported", False)
-
-
-def check_server_capabilities(connect_server, capability_functions, details_source=gather_server_details):
-    """
-    Uses a sequence of functions that check for capabilities in a Connect server.  The
-    server settings data is retrieved by the gather_server_details() function.
-
-    Each function provided must accept one dictionary argument which will be the server
-    settings data returned by the gather_server_details() function.  That function must
-    return a boolean value.  It must also contain a docstring which itself must contain
-    an ":error:" tag as the last thing in the docstring.  If the function returns False,
-    an exception is raised with the function's ":error:" text as its message.
-
-    :param connect_server: the information needed to interact with the Connect server.
-    :param capability_functions: a sequence of functions that will be called.
-    :param details_source: the source for obtaining server details, gather_server_details(),
-    by default.
-    """
-    details = details_source(connect_server)
-
-    for function in capability_functions:
-        if not function(details):
-            index = function.__doc__.find(":error:") if function.__doc__ else -1
-            if index >= 0:
-                message = function.__doc__[index + 7 :].strip()
-            else:
-                message = "The server does not satisfy the %s capability check." % function.__name__
-            raise RSConnectException(message)
 
 
 def _make_deployment_name(remote_server: api.TargetableServer, title: str, force_unique: bool) -> str:
@@ -830,7 +789,6 @@ def deploy_app(
     (
         ce.validate_server()
         .validate_app_mode(app_mode=app_mode)
-        .check_server_capabilities([are_apis_supported_on_server])
         .make_bundle(
             make_api_bundle,
             directory,

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -294,7 +294,6 @@ class RSConnectClient(HTTPServer):
     def wait_for_task(
         self, task_id, log_callback, abort_func=lambda: False, timeout=get_timeout(), poll_wait=0.5, raise_on_error=True
     ):
-
         last_status = None
         ending = time.time() + timeout if timeout else 999999999999
 
@@ -653,36 +652,6 @@ class RSConnectExecutor:
 
         d["bundle"] = bundle
 
-        return self
-
-    def check_server_capabilities(self, capability_functions):
-        """
-        Uses a sequence of functions that check for capabilities in a Connect server.  The
-        server settings data is retrieved by the gather_server_details() function.
-
-        Each function provided must accept one dictionary argument which will be the server
-        settings data returned by the gather_server_details() function.  That function must
-        return a boolean value.  It must also contain a docstring which itself must contain
-        an ":error:" tag as the last thing in the docstring.  If the function returns False,
-        an exception is raised with the function's ":error:" text as its message.
-
-        :param capability_functions: a sequence of functions that will be called.
-        :param details_source: the source for obtaining server details, gather_server_details(),
-        by default.
-        """
-        if isinstance(self.remote_server, PositServer):
-            return self
-
-        details = self.server_details
-
-        for function in capability_functions:
-            if not function(details):
-                index = function.__doc__.find(":error:") if function.__doc__ else -1
-                if index >= 0:
-                    message = function.__doc__[index + 7 :].strip()
-                else:
-                    message = "The server does not satisfy the %s capability check." % function.__name__
-                raise RSConnectException(message)
         return self
 
     def upload_rstudio_bundle(self, prepare_deploy_result, bundle_size: int, contents):

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1431,27 +1431,6 @@ def fake_module_file_from_directory(directory: str):
     return join(directory, app_name + ".py")
 
 
-def is_python_enabled_on_server(connect_details):
-    """
-    Returns whether or not the Connect server has Python itself enabled.
-
-    :error: The Posit Connect server does not have Python enabled.
-    """
-    return any(connect_details.get("python", {}).get("versions", []))
-
-
-def are_apis_supported_on_server(connect_details):
-    """
-    Returns whether or not the Connect server has Python itself enabled and its license allows
-    for API usage.  This controls whether APIs may be deployed..
-
-    :param connect_details: details about a Connect server as returned by gather_server_details()
-    :return: boolean True if the Connect server supports Python APIs or not or False if not.
-    :error: The Posit Connect server does not allow for Python APIs.
-    """
-    return connect_details["python"]["api_enabled"]
-
-
 def which_python(python: typing.Optional[str] = None):
     """Determines which Python executable to use.
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -40,8 +40,6 @@ from .actions_content import (
 from . import api, VERSION, validation
 from .api import RSConnectExecutor, RSConnectServer, RSConnectClient, filter_out_server_info
 from .bundle import (
-    is_python_enabled_on_server,
-    are_apis_supported_on_server,
     create_python_environment,
     default_title_from_manifest,
     is_environment_dir,
@@ -1312,7 +1310,6 @@ def generate_deploy_python(app_mode, alias, min_version):
         (
             ce.validate_server()
             .validate_app_mode(app_mode=app_mode)
-            .check_server_capabilities([is_python_enabled_on_server, are_apis_supported_on_server])
             .make_bundle(
                 make_api_bundle,
                 directory,

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -10,15 +10,12 @@ from unittest import TestCase
 
 from rsconnect.actions import (
     _verify_server,
-    are_apis_supported_on_server,
-    check_server_capabilities,
     create_api_deployment_bundle,
     create_notebook_deployment_bundle,
     deploy_dash_app,
     deploy_python_api,
     deploy_streamlit_app,
     deploy_bokeh_app,
-    is_conda_supported_on_server,
 )
 from rsconnect.api import RSConnectServer
 from rsconnect.environment import MakeEnvironment
@@ -36,39 +33,6 @@ class TestActions(TestCase):
         with self.assertRaises(RSConnectException):
             _verify_server(RSConnectServer("fake-url", None))
 
-    def test_check_server_capabilities(self):
-        no_api_support = {"python": {"api_enabled": False}}
-        api_support = {"python": {"api_enabled": True}}
-
-        with self.assertRaises(RSConnectException) as context:
-            check_server_capabilities(None, (are_apis_supported_on_server,), lambda x: no_api_support)
-        self.assertEqual(
-            str(context.exception),
-            "The Posit Connect server does not allow for Python APIs.",
-        )
-
-        check_server_capabilities(None, (are_apis_supported_on_server,), lambda x: api_support)
-
-        no_conda = api_support
-        conda_not_supported = {"conda": {"supported": False}}
-        conda_supported = {"conda": {"supported": True}}
-
-        with self.assertRaises(RSConnectException) as context:
-            check_server_capabilities(None, (is_conda_supported_on_server,), lambda x: no_conda)
-        self.assertEqual(
-            str(context.exception),
-            "Conda is not supported on the target server.  " + "Try deploying without requesting Conda.",
-        )
-
-        with self.assertRaises(RSConnectException) as context:
-            check_server_capabilities(None, (is_conda_supported_on_server,), lambda x: conda_not_supported)
-        self.assertEqual(
-            str(context.exception),
-            "Conda is not supported on the target server.  " + "Try deploying without requesting Conda.",
-        )
-
-        check_server_capabilities(None, (is_conda_supported_on_server,), lambda x: conda_supported)
-
         # noinspection PyUnusedLocal
         def fake_cap(details):
             return False
@@ -77,20 +41,6 @@ class TestActions(TestCase):
         def fake_cap_with_doc(details):
             """A docstring."""
             return False
-
-        with self.assertRaises(RSConnectException) as context:
-            check_server_capabilities(None, (fake_cap,), lambda x: None)
-        self.assertEqual(
-            str(context.exception),
-            "The server does not satisfy the fake_cap capability check.",
-        )
-
-        with self.assertRaises(RSConnectException) as context:
-            check_server_capabilities(None, (fake_cap_with_doc,), lambda x: None)
-        self.assertEqual(
-            str(context.exception),
-            "The server does not satisfy the fake_cap_with_doc capability check.",
-        )
 
     def test_deploy_python_api_validates(self):
         directory = get_api_path("flask")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR removes the server capability check in order to allow Python for Shiny to be deployed with a base Connect license.

The other reason for the functionality removal is that the functionality it is redundant. Connect itself will return the corresponding error messages if the server does not have APIs enabled or if Python is not enabled. Maintaining this check client side check is not only redundant, but actively obstructs server features from being functional without a client side change.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
