### PR TITLE
Add support for deploying quarto files/projects to posit.cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `CONNECT_TASK_TIMEOUT` environment variable, which configures the timeout for [task based operations](https://docs.posit.co/connect/api/#get-/v1/tasks/-id-). This value translates into seconds (e.g., `CONNECT_TASK_TIMEOUT=60` is equivalent to 60 seconds.) By default, this value is set to 86,400 seconds (e.g., 24 hours).
-- Deploys for Posit Cloud now support quarto source files or projects with `markdown` or `jupyter` engines.
+- Deploys for Posit Cloud now support Quarto source files or projects with `markdown` or `jupyter` engines.
 
 
 ## [1.18.0] - 2023-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `CONNECT_TASK_TIMEOUT` environment variable, which configures the timeout for [task based operations](https://docs.posit.co/connect/api/#get-/v1/tasks/-id-). This value translates into seconds (e.g., `CONNECT_TASK_TIMEOUT=60` is equivalent to 60 seconds.) By default, this value is set to 86,400 seconds (e.g., 24 hours).
+- Deploys for Posit Cloud now support quarto source files or projects with `markdown` or `jupyter` engines.
+
 
 ## [1.18.0] - 2023-06-27
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -965,7 +965,7 @@ def deploy_voila(
     name="manifest",
     short_help="Deploy content to Posit Connect, Posit Cloud, or shinyapps.io by manifest.",
     help=(
-        "Deploy content to Posit Connect using an existing manifest.json "
+        "Deploy content to Posit Connect, Posit Cloud, or shinyapps.io using an existing manifest.json "
         'file.  The specified file must either be named "manifest.json" or '
         'refer to a directory that contains a file named "manifest.json".'
     ),
@@ -1018,13 +1018,13 @@ def deploy_manifest(
 # noinspection SpellCheckingInspection,DuplicatedCode
 @deploy.command(
     name="quarto",
-    short_help="Deploy Quarto content to Posit Connect [v2021.08.0+].",
+    short_help="Deploy Quarto content to Posit Connect [v2021.08.0+] or Posit Cloud.",
     help=(
-        "Deploy a Quarto document or project to Posit Connect. Should the content use the Quarto Jupyter engine, "
-        'an environment file ("requirements.txt") is created and included in the deployment if one does '
-        "not already exist. Requires Posit Connect 2021.08.0 or later."
-        "\n\n"
-        "FILE_OR_DIRECTORY is the path to a single-file Quarto document or the directory containing a Quarto project."
+        'Deploy a Quarto document or project to Posit Connect or Posit Cloud. Should the content use the Quarto '
+        'Jupyter engine, an environment file ("requirements.txt") is created and included in the deployment if one '
+        'does not already exist. Requires Posit Connect 2021.08.0 or later.'
+        '\n\n'
+        'FILE_OR_DIRECTORY is the path to a single-file Quarto document or the directory containing a Quarto project.'
     ),
     no_args_is_help=True,
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -354,7 +354,7 @@ class CloudServiceTestCase(TestCase):
             "presigned_checksum": "the_checksum",
         }
 
-        prepare_deploy_result = cloud_service.prepare_deploy(
+        cloud_service.prepare_deploy(
             app_id=app_id,
             app_name=app_name,
             bundle_size=bundle_size,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -268,7 +268,6 @@ class ShinyappsServiceTestCase(TestCase):
 
 
 class CloudServiceTestCase(TestCase):
-
     def setUp(self):
         self.cloud_client = Mock(spec=PositClient)
         self.server = CloudServer("https://api.posit.cloud", "the_account", "the_token", "the_secret")
@@ -277,7 +276,7 @@ class CloudServiceTestCase(TestCase):
             cloud_client=self.cloud_client, server=self.server, project_application_id=self.project_application_id
         )
 
-    def test_prepare_new_deploy(self):
+    def test_prepare_new_deploy_python_shiny(self):
         app_id = None
         app_name = "my app"
         bundle_size = 5000
@@ -313,7 +312,7 @@ class CloudServiceTestCase(TestCase):
         self.cloud_client.get_application.assert_called_with(self.project_application_id)
         self.cloud_client.get_content.assert_called_with(2)
         self.cloud_client.create_output.assert_called_with(
-            name=app_name, application_type="connect", project_id=2, space_id=1000
+            name=app_name, application_type="connect", project_id=2, space_id=1000, render_by=None
         )
         self.cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
 
@@ -323,6 +322,52 @@ class CloudServiceTestCase(TestCase):
         assert prepare_deploy_result.bundle_id == 100
         assert prepare_deploy_result.presigned_url == "https://presigned.url"
         assert prepare_deploy_result.presigned_checksum == "the_checksum"
+
+    def test_prepare_new_deploy_static_quarto(self):
+        cloud_client = Mock(spec=PositClient)
+        server = CloudServer("https://api.posit.cloud", "the_account", "the_token", "the_secret")
+        project_application_id = "20"
+        cloud_service = CloudService(
+            cloud_client=cloud_client, server=server, project_application_id=project_application_id
+        )
+
+        app_id = None
+        app_name = "my app"
+        bundle_size = 5000
+        bundle_hash = "the_hash"
+        app_mode = AppModes.STATIC_QUARTO
+
+        cloud_client.get_application.return_value = {
+            "content_id": 2,
+        }
+        cloud_client.get_content.return_value = {
+            "space_id": 1000,
+        }
+        cloud_client.create_output.return_value = {
+            "id": 1,
+            "source_id": 10,
+            "url": "https://posit.cloud/content/1",
+        }
+        cloud_client.create_bundle.return_value = {
+            "id": 100,
+            "presigned_url": "https://presigned.url",
+            "presigned_checksum": "the_checksum",
+        }
+
+        prepare_deploy_result = cloud_service.prepare_deploy(
+            app_id=app_id,
+            app_name=app_name,
+            bundle_size=bundle_size,
+            bundle_hash=bundle_hash,
+            app_mode=app_mode,
+            app_store_version=1,
+        )
+
+        cloud_client.get_application.assert_called_with(project_application_id)
+        cloud_client.get_content.assert_called_with(2)
+        cloud_client.create_output.assert_called_with(
+            name=app_name, application_type="static", project_id=2, space_id=1000, render_by='server'
+        )
 
     def test_prepare_redeploy(self):
         app_id = 1

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -273,7 +273,7 @@ class TestBundle(TestCase):
                 manifest,
                 {
                     "version": 1,
-                    "locale": "en_US.UTF-8",
+                    "locale": mock.ANY,
                     "metadata": {
                         "appmode": "quarto-static"
                     },


### PR DESCRIPTION
This change is to enable publishing of `quarto` files or projects to `posit.cloud` in anticipation of the publishing release in the beginning of August.

## Intent
With this change, one can use `rsconnect-python` to publish `quarto` files or projects to `posit.cloud` using:
```
rsconnect deploy quarto <path_to_quarto_file>
rsconnect deploy quarto <path_to_quarto_project>
```
similarly to publishing to `Posit Connect`.  The supported `engine` values are `markdown` and `jupyter`.

Resolves #436 

## Type of Change
- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
We have previously added support for publishing quarto outputs to `posit.cloud` as Connect applications.  With the support of quarto publishing in `posit.cloud` as static, server-rendered output, this change modifies the output creation API call to pass an additional `render_by=server` parameter and set `application_type=static`.

## Automated Tests
Added/updated tests in the following areas:
* API calls
* Bundling for quarto files and projects 

## Directions for Reviewers
The following deployment of quarto is now supported:
```
rsconnect deploy quarto \
          --account $YOUR_ACCOUNT \
          --token $YOUR_TOKEN \
          --secret $YOUR_SECRET \
          --server 'https://api.staging.posit.cloud' \
          'some_file.qmd'
```
where `some_file.qmd` is a quarto doc with `markdown` or `jupyter` engine.  Similarly, a quarto project could be supplied instead of a file. 

## Checklist
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
