### PR TITLE
Sets the CONNECT_TASK_TIMEOUT default to 86,400 (24 hours).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The `CONNECT_TASK_TIMEOUT` environment variable, which configures the timeout for [task based operations](https://docs.posit.co/connect/api/#get-/v1/tasks/-id-). This value translates into seconds (e.g., `CONNECT_TASK_TIMEOUT=60` is equivalent to 60 seconds.) By default, this value is set to [`sys.maxsize`](https://docs.python.org/3/library/sys.html#sys.maxsize).
+- The `CONNECT_TASK_TIMEOUT` environment variable, which configures the timeout for [task based operations](https://docs.posit.co/connect/api/#get-/v1/tasks/-id-). This value translates into seconds (e.g., `CONNECT_TASK_TIMEOUT=60` is equivalent to 60 seconds.) By default, this value is set to 86,400 seconds (e.g., 24 hours).
 
 ## [1.18.0] - 2023-06-27
 

--- a/rsconnect/timeouts.py
+++ b/rsconnect/timeouts.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from typing import Union
 
 from rsconnect.exception import RSConnectException
@@ -8,7 +7,7 @@ _CONNECT_REQUEST_TIMEOUT_KEY: str = "CONNECT_REQUEST_TIMEOUT"
 _CONNECT_REQUEST_TIMEOUT_DEFAULT_VALUE: str = "300"
 
 _CONNECT_TASK_TIMEOUT_KEY: str = "CONNECT_TASK_TIMEOUT"
-_CONNECT_TASK_TIMEOUT_DEFAULT_VALUE: str = str(sys.maxsize)
+_CONNECT_TASK_TIMEOUT_DEFAULT_VALUE: str = "86400"
 
 
 def get_request_timeout() -> int:
@@ -50,7 +49,7 @@ def get_task_timeout() -> int:
 
     The timeout value is intended to be interpreted in seconds. A value of 60 is equal to sixty seconds, or one minute.
 
-    If CONNECT_TASK_TIMEOUT is unset, a default value of sys.maxsize is used.
+    If CONNECT_TASK_TIMEOUT is unset, a default value of 86,400 (1 day) is used.
 
     If CONNECT_TASK_TIMEOUT is set to a value less or equal to 0, an `RSConnectException` is raised.
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from unittest import TestCase
 from unittest.mock import patch
@@ -36,7 +35,7 @@ class GetRequestTimeoutTestCase(TestCase):
 class GetTaskTimeoutTestCase(TestCase):
     def test_get_default_timeout(self):
         timeout = get_task_timeout()
-        self.assertEqual(sys.maxsize, timeout)
+        self.assertEqual(24 * 60 * 60, timeout)
 
     def test_get_valid_timeout_from_environment(self):
         with patch.dict(os.environ, {"CONNECT_TASK_TIMEOUT": "24"}):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Changes the CONNECT_TASK_TIMEOUT to a reasonable default of 86,400 seconds (24 hours).

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Automated tests have been updated to validate the timeout value.

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
