### PR TITLE
Adds Human Friendly Error Message For Task Timeouts

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -28,7 +28,7 @@ from .models import AppMode, AppModes
 from .metadata import ServerStore, AppStore
 from .exception import RSConnectException
 from .bundle import _default_title, fake_module_file_from_directory
-from .timeouts import get_task_timeout
+from .timeouts import get_task_timeout, get_task_timeout_help_message
 
 
 class AbstractRemoteServer:
@@ -313,7 +313,7 @@ class RSConnectClient(HTTPServer):
         time_slept = 0
         while True:
             if (time.time() - start_time) > timeout:
-                raise RSConnectException("Task timed out after %d seconds" % timeout)
+                raise RSConnectException(get_task_timeout_help_message(timeout))
             elif abort_func():
                 raise RSConnectException("Task aborted.")
 
@@ -1195,7 +1195,7 @@ class PositClient(HTTPServer):
             time.sleep(2)
 
         if not finished:
-            raise RSConnectException("Application deployment timed out.")
+            raise RSConnectException(get_task_timeout_help_message(timeout))
 
         if status != "success":
             raise RSConnectException("Application deployment failed with error: {}".format(error))

--- a/rsconnect/timeouts.py
+++ b/rsconnect/timeouts.py
@@ -1,4 +1,6 @@
 import os
+import textwrap
+
 from typing import Union
 
 from rsconnect.exception import RSConnectException
@@ -70,3 +72,18 @@ def get_task_timeout() -> int:
         raise RSConnectException(f"'CONNECT_TASK_TIMEOUT' is set to '{timeout}'. The value must be a positive integer.")
 
     return timeout
+
+
+def get_task_timeout_help_message(timeout=get_task_timeout()) -> str:
+    """Gets a human friendly help message for adjusting the task timeout value."""
+
+    return f"The task timed out after {timeout} seconds." + textwrap.dedent(
+        f"""
+
+        You may try increasing the task timeout value using the {_CONNECT_TASK_TIMEOUT_KEY} environment variable. The default value is {_CONNECT_TASK_TIMEOUT_DEFAULT_VALUE} seconds. The current value is {get_task_timeout()} seconds.
+
+        Example:
+
+            CONNECT_TASK_TIMEOUT={_CONNECT_TASK_TIMEOUT_DEFAULT_VALUE} rsconnect deploy api --server <your-server> --api-key <your-api-key> ./
+        """  # noqa: E501
+    )

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from rsconnect.exception import RSConnectException
-from rsconnect.timeouts import get_request_timeout, get_task_timeout
+from rsconnect.timeouts import get_request_timeout, get_task_timeout, get_task_timeout_help_message
 
 
 class GetRequestTimeoutTestCase(TestCase):
@@ -56,3 +56,11 @@ class GetTaskTimeoutTestCase(TestCase):
         with patch.dict(os.environ, {"CONNECT_TASK_TIMEOUT": "-24"}):
             with self.assertRaises(RSConnectException):
                 get_task_timeout()
+
+class GetTaskTimeoutHelpMessageTestCase(TestCase):
+    def test_get_task_timeout_help_message(self):
+        res = get_task_timeout_help_message(1)
+        self.assertTrue("The task timed out after 1 seconds." in res)
+        self.assertTrue("You may try increasing the task timeout value using the CONNECT_TASK_TIMEOUT environment variable." in res)  # noqa: E501
+        self.assertTrue("The default value is 86400 seconds." in res)
+        self.assertTrue("The current value is 86400 seconds." in res)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

The existing error message does not provide any valuable feedback for users. This change adds detailed information so that the user has the opportunity to resolve the issue themselves.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

This change may be viewed by setting the CONNECT_TASK_TIMEOUT to 1 and executing a deployment.

For example,

```
CONNECT_TASK_TIMEOUT=1 rsconnect deploy api --server https://rsc.radixu.com/ --api-key <your-api-key> ./
```

An error should be thrown with the following message:

> Error: The task timed out after 1 seconds.
> 
> You may try increasing the task timeout value using the CONNECT_TASK_TIMEOUT environment variable. The default value is 86400 seconds. The value is currently set to 1 seconds.
> 
> Example:
> 
>     CONNECT_TASK_TIMEOUT=86400 rsconnect deploy api --server <your-server> --api-key <your-api-key> ./
> 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
