### PR TITLE
Redeploy to Posit Cloud from a project associates the content with project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Failed deploys to shinyapps.io will now output build logs. Posit Cloud application deploys will also output build logs once supported server-side.
+- Redeploy to Posit Cloud from a project now correctly associates the content with that project.
 
 ## [1.19.0] - 2023-07-12
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1336,10 +1336,10 @@ class CloudService:
     ) -> PrepareDeployOutputResult:
         application_type = "static" if app_mode == AppModes.STATIC else "connect"
 
+        project_id = self._get_current_project_id()
+
         if app_id is None:
             # this is a deployment of a new output
-            # associate the current Posit Cloud project and space (if any) to the new output
-            project_id = self._get_current_project_id()
             if project_id is not None:
                 project = self._rstudio_client.get_content(project_id)
                 space_id = project["space_id"]
@@ -1347,6 +1347,7 @@ class CloudService:
                 project_id = None
                 space_id = None
 
+            # create the new output and associate it with the current Posit Cloud project and space
             output = self._rstudio_client.create_output(
                 name=app_name, application_type=application_type, project_id=project_id, space_id=space_id
             )
@@ -1371,7 +1372,6 @@ class CloudService:
                 app_id_int = revision["application_id"]
 
             # associate the output with the current Posit Cloud project (if any)
-            project_id = self._get_current_project_id()
             if project_id is not None:
                 self._rstudio_client.update_output(output["id"], {"project": project_id})
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1319,6 +1319,12 @@ class CloudService:
         self._server = server
         self._project_application_id = project_application_id
 
+    def _get_current_project_id(self):
+        if self._project_application_id is not None:
+            project_application = self._rstudio_client.get_application(self._project_application_id)
+            return project_application["content_id"]
+        return None
+
     def prepare_deploy(
         self,
         app_id: typing.Optional[typing.Union[str, int]],
@@ -1331,11 +1337,10 @@ class CloudService:
         application_type = "static" if app_mode == AppModes.STATIC else "connect"
 
         if app_id is None:
-            # this is a new deployment.
-            # get the Posit Cloud project so that we can associate the deployment with it
-            if self._project_application_id is not None:
-                project_application = self._rstudio_client.get_application(self._project_application_id)
-                project_id = project_application["content_id"]
+            # this is a deployment of a new output
+            # associate the current Posit Cloud project and space (if any) to the new output
+            project_id = self._get_current_project_id()
+            if project_id is not None:
                 project = self._rstudio_client.get_content(project_id)
                 space_id = project["space_id"]
             else:
@@ -1347,7 +1352,7 @@ class CloudService:
             )
             app_id_int = output["source_id"]
         else:
-            # this is a redeployment
+            # this is a redeployment of an existing output
             if app_store_version is not None:
                 # versioned app store files store content id in app_id
                 output = self._rstudio_client.get_content(app_id)
@@ -1359,12 +1364,16 @@ class CloudService:
                 # content_id will appear on static applications as output_id
                 content_id = application.get("content_id") or application.get("output_id")
                 app_id_int = application["id"]
-
                 output = self._rstudio_client.get_content(content_id)
 
             if application_type == "static":
                 revision = self._rstudio_client.create_revision(content_id)
                 app_id_int = revision["application_id"]
+
+            # associate the output with the current Posit Cloud project (if any)
+            project_id = self._get_current_project_id()
+            if project_id is not None:
+                self._rstudio_client.update_output(output["id"], {"project": project_id})
 
         app_url = output["url"]
         output_id = output["id"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -349,7 +349,7 @@ class CloudServiceTestCase(TestCase):
         )
         self.cloud_client.get_content.assert_called_with(1)
         self.cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
-        cloud_client.update_output.assert_called_with(1, {"project": 200})
+        self.cloud_client.update_output.assert_called_with(1, {"project": 200})
 
         assert prepare_deploy_result.app_id == 1
         assert prepare_deploy_result.application_id == 10
@@ -387,7 +387,7 @@ class CloudServiceTestCase(TestCase):
         self.cloud_client.get_content.assert_called_with(1)
         self.cloud_client.create_revision.assert_called_with(1)
         self.cloud_client.create_bundle.assert_called_with(11, "application/x-tar", bundle_size, bundle_hash)
-        cloud_client.update_output.assert_called_with(1, {"project": 200})
+        self.cloud_client.update_output.assert_called_with(1, {"project": 200})
 
         assert prepare_deploy_result.app_id == 1
         assert prepare_deploy_result.application_id == 11
@@ -423,7 +423,7 @@ class CloudServiceTestCase(TestCase):
             app_store_version=None,
         )
         # first call is to get the current project id, second call is to get the application
-        self.cloud_client.get_application.assert_has_calls([call(project_application_id), call(app_id)])
+        self.cloud_client.get_application.assert_has_calls([call(self.project_application_id), call(app_id)])
         self.cloud_client.get_content.assert_called_with(1)
         self.cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
         self.cloud_client.update_output.assert_called_with(1, {"project": 1})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, call
 import json
 
 import httpretty
@@ -332,6 +332,7 @@ class CloudServiceTestCase(TestCase):
         app_mode = AppModes.PYTHON_SHINY
 
         self.cloud_client.get_content.return_value = {"id": 1, "source_id": 10, "url": "https://posit.cloud/content/1"}
+        self.cloud_client.get_application.return_value = {"id": 10, "content_id": 200}
         self.cloud_client.create_bundle.return_value = {
             "id": 100,
             "presigned_url": "https://presigned.url",
@@ -348,6 +349,7 @@ class CloudServiceTestCase(TestCase):
         )
         self.cloud_client.get_content.assert_called_with(1)
         self.cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
+        cloud_client.update_output.assert_called_with(1, {"project": 200})
 
         assert prepare_deploy_result.app_id == 1
         assert prepare_deploy_result.application_id == 10
@@ -364,6 +366,7 @@ class CloudServiceTestCase(TestCase):
         app_mode = AppModes.STATIC
 
         self.cloud_client.get_content.return_value = {"id": 1, "source_id": 10, "url": "https://posit.cloud/content/1"}
+        self.cloud_client.get_application.return_value = {"id": 10, "content_id": 200}
         self.cloud_client.create_revision.return_value = {
             "application_id": 11,
         }
@@ -384,6 +387,7 @@ class CloudServiceTestCase(TestCase):
         self.cloud_client.get_content.assert_called_with(1)
         self.cloud_client.create_revision.assert_called_with(1)
         self.cloud_client.create_bundle.assert_called_with(11, "application/x-tar", bundle_size, bundle_hash)
+        cloud_client.update_output.assert_called_with(1, {"project": 200})
 
         assert prepare_deploy_result.app_id == 1
         assert prepare_deploy_result.application_id == 11
@@ -418,9 +422,10 @@ class CloudServiceTestCase(TestCase):
             app_mode=app_mode,
             app_store_version=None,
         )
-        self.cloud_client.get_application.assert_called_with(10)
+        self.cloud_client.get_application.assert_has_calls([call(app_id), call(project_application_id)])
         self.cloud_client.get_content.assert_called_with(1)
         self.cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
+        cloud_client.update_output.assert_called_with(1, {"project": 1})
 
         assert prepare_deploy_result.app_id == 1
         assert prepare_deploy_result.application_id == 10

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -422,10 +422,11 @@ class CloudServiceTestCase(TestCase):
             app_mode=app_mode,
             app_store_version=None,
         )
-        self.cloud_client.get_application.assert_has_calls([call(app_id), call(project_application_id)])
+        # first call is to get the current project id, second call is to get the application
+        self.cloud_client.get_application.assert_has_calls([call(project_application_id), call(app_id)])
         self.cloud_client.get_content.assert_called_with(1)
         self.cloud_client.create_bundle.assert_called_with(10, "application/x-tar", bundle_size, bundle_hash)
-        cloud_client.update_output.assert_called_with(1, {"project": 1})
+        self.cloud_client.update_output.assert_called_with(1, {"project": 1})
 
         assert prepare_deploy_result.app_id == 1
         assert prepare_deploy_result.application_id == 10

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -350,6 +350,13 @@ class TestMain:
             body=post_output_callback,
         )
 
+        httpretty.register_uri(
+            httpretty.PATCH,
+            "https://api.posit.cloud/v1/outputs/1",
+            body=open("tests/testdata/rstudio-responses/create-output.json", "r").read(),
+            status=200,
+        )
+
         def post_bundle_callback(request, uri, response_headers):
             parsed_request = _load_json(request.body)
             del parsed_request["checksum"]


### PR DESCRIPTION
## Intent
Redeploy to Posit Cloud from a project now correctly associates the content with that project.  Previously, this was done on new deploys only.  This affects Posit Cloud only.

Resolves #409 

## Type of Change
- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
The code to fetch the Posit Cloud project associated with the content (in the case of the initial deployment) was extracted as a function and re-used in the case of re-deployments.  In the case of re-deployment, the existing content in Posit Cloud is updated so that it is associated with the current project.

## Automated Tests
The automated tests assert the API calls made to Posit Cloud to 1) retrieve the id of the current project, and 2) update the content being redeployed with that project id.

## Directions for Reviewers
Minimal steps to verify:
1. create a new project (A) in Posit Cloud
2. install `rsconnect`
3. create an Rmd file and render it to html
4. deploy the rendered html to Posit Cloud using `rsconnect deploy html my_output --name posit.cloud`
5. verify the content is deployed correctly and that it is associated with project A 
6. record the id of the content in the content URL (e.g., https://posit.cloud/spaces/1425143/content/**1942409**)
7. create a new project (B) in Posit Cloud 
8. install `rsconnect`
9. create an Rmd file and render it to html 
10. deploy the rendered html to Posit Cloud using `rsconnect deploy html my_other_output --app-id <id_from_step_6> --name posit.cloud`
11. verify the content is deployed correctly to the URL as step 6 and that it is associated with project B 

## Checklist
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
