### PR TITLE
shinyapps/posit cloud build logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Failed deploys to shinyapps.io will now output build logs. Posit Cloud application deploys will also output build logs once supported server-side.
+
 ## [1.19.0] - 2023-07-12
 
 ### Added

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -26,7 +26,7 @@ from .http_support import HTTPResponse, HTTPServer, append_to_path, CookieJar
 from .log import logger, connect_logger, cls_logged, console_logger
 from .models import AppMode, AppModes
 from .metadata import ServerStore, AppStore
-from .exception import RSConnectException
+from .exception import RSConnectException, DeploymentFailedException
 from .bundle import _default_title, fake_module_file_from_directory
 from .timeouts import get_task_timeout, get_task_timeout_help_message
 
@@ -1172,6 +1172,11 @@ class PositClient(HTTPServer):
         self._server.handle_bad_response(response)
         return response
 
+    def get_task_logs(self, task_id):
+        response = self.get("/v1/tasks/{}/logs".format(task_id))
+        self._server.handle_bad_response(response)
+        return response
+
     def get_current_user(self):
         response = self.get("/v1/users/me")
         self._server.handle_bad_response(response)
@@ -1198,7 +1203,7 @@ class PositClient(HTTPServer):
             raise RSConnectException(get_task_timeout_help_message(timeout))
 
         if status != "success":
-            raise RSConnectException("Application deployment failed with error: {}".format(error))
+            raise DeploymentFailedException("Application deployment failed with error: {}".format(error))
 
         print("Task done: {}".format(description))
 
@@ -1281,7 +1286,12 @@ class ShinyappsService:
     def do_deploy(self, bundle_id, app_id):
         self._rstudio_client.set_bundle_status(bundle_id, "ready")
         deploy_task = self._rstudio_client.deploy_application(bundle_id, app_id)
-        self._rstudio_client.wait_until_task_is_successful(deploy_task["id"])
+        try:
+            self._rstudio_client.wait_until_task_is_successful(deploy_task["id"])
+        except DeploymentFailedException as e:
+            logs = self._rstudio_client.get_task_logs(deploy_task["id"])
+            logger.error("Build logs:\n{}".format(logs))
+            raise e
 
 
 class CloudService:
@@ -1358,7 +1368,13 @@ class CloudService:
     def do_deploy(self, bundle_id, app_id):
         self._rstudio_client.set_bundle_status(bundle_id, "ready")
         deploy_task = self._rstudio_client.deploy_application(bundle_id, app_id)
-        self._rstudio_client.wait_until_task_is_successful(deploy_task["id"])
+        try:
+            self._rstudio_client.wait_until_task_is_successful(deploy_task["id"])
+        except DeploymentFailedException as e:
+            logs = self._rstudio_client.get_task_logs(deploy_task["id"])
+            if len(logs) > 0:
+                logger.error("Build logs:\n{}".format(logs))
+            raise e
 
 
 def verify_server(connect_server):

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1172,13 +1172,16 @@ class PositClient(HTTPServer):
         self._server.handle_bad_response(response)
         return response
 
-    # /tasks?filter=parent_id:eq:1318096033&filter=action:eq:image-build'
     def get_shinyapps_build_task(self, parent_task_id):
-        response = self.get("/v1/tasks",
-                            query_params={"filter": [
-                                "parent_id:eq:{}".format(parent_task_id),
-                                "action:eq:image-build",
-                            ]})
+        response = self.get(
+            "/v1/tasks",
+            query_params={
+                "filter": [
+                    "parent_id:eq:{}".format(parent_task_id),
+                    "action:eq:image-build",
+                ]
+            },
+        )
         self._server.handle_bad_response(response)
         return response
 
@@ -1299,8 +1302,8 @@ class ShinyappsService:
         try:
             self._rstudio_client.wait_until_task_is_successful(deploy_task["id"])
         except DeploymentFailedException as e:
-            build_task_result = self._rstudio_client.get_shinyapps_build_task(deploy_task['id'])
-            build_task = build_task_result['tasks'][0]
+            build_task_result = self._rstudio_client.get_shinyapps_build_task(deploy_task["id"])
+            build_task = build_task_result["tasks"][0]
             logs = self._rstudio_client.get_task_logs(build_task["id"])
             logger.error("Build logs:\n{}".format(logs.response_body))
             raise e

--- a/rsconnect/exception.py
+++ b/rsconnect/exception.py
@@ -3,3 +3,6 @@ class RSConnectException(Exception):
         super(RSConnectException, self).__init__(message)
         self.message = message
         self.cause = cause
+
+class DeploymentFailedException(RSConnectException):
+    pass

--- a/rsconnect/exception.py
+++ b/rsconnect/exception.py
@@ -4,5 +4,6 @@ class RSConnectException(Exception):
         self.message = message
         self.cause = cause
 
+
 class DeploymentFailedException(RSConnectException):
     pass

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -271,7 +271,7 @@ class HTTPServer(object):
     ):
         full_uri = path
         if query_params is not None:
-            full_uri = "%s?%s" % (path, urlencode(query_params))
+            full_uri = "%s?%s" % (path, urlencode(query_params, doseq=True))
         headers = self._headers.copy()
         if self._proxy_headers:
             headers.update(self._proxy_headers)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -429,17 +429,6 @@ class CloudServiceTestCase(TestCase):
         assert prepare_deploy_result.presigned_url == "https://presigned.url"
         assert prepare_deploy_result.presigned_checksum == "the_checksum"
 
-    # def do_deploy(self, bundle_id, app_id):
-    #     self._rstudio_client.set_bundle_status(bundle_id, "ready")
-    #     deploy_task = self._rstudio_client.deploy_application(bundle_id, app_id)
-    #     try:
-    #         self._rstudio_client.wait_until_task_is_successful(deploy_task["id"])
-    #     except DeploymentFailedException as e:
-    #         logs_response = self._rstudio_client.get_task_logs(deploy_task["id"])
-    #         if len(logs_response.response_body) > 0:
-    #             logger.error("Build logs:\n{}".format(logs_response.response_body))
-    #         raise e
-
     def test_do_deploy(self):
         bundle_id = 1
         app_id = 2


### PR DESCRIPTION
## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Resolves https://github.com/rstudio/rsconnect-python/issues/427.
Resolves https://github.com/rstudio/rsconnect-python/issues/432.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

When a shinyapps.io task fails, we call the API to:
1. Get the child of the failed task whose action is `image-build`
2. Get and print the logs of that child task

Posit Cloud application builds don't have accessible logs yet (but will in the future). When a Posit Cloud task fails, we call the API to get the logs of the failed task, and if logs are returned, print them.

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->
Added tests for `ShinyappsService.do_deploy` and `CloudService.do_deploy`.

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->
Add a dependency to `my-shiny-app/requirements.txt` that doesn't exist on PyPI, then run `rsconnect deploy shiny my-shiny-app` to deploy to shinyapps.io.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
