### PR TITLE
Include API key with initial server check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The `https_proxy` environment variable is recognized as a synonym for
   `HTTPS_PROXY`.
+- When adding a new server, the initial request now includes an
+  Authorization header containing the API key. This is needed
+  for Connect installations behind a proxy that only passes
+  authenticated requests.
 
 ### Added
 - Added support for the `no_proxy` or `NO_PROXY` environment variables to specify

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -351,7 +351,7 @@ def _test_server_and_api(server, api_key, insecure, ca_cert):
     me = None
 
     with cli_feedback("Checking %s" % server):
-        real_server, _ = test_server(api.RSConnectServer(server, None, insecure, ca_data))
+        real_server, _ = test_server(api.RSConnectServer(server, api_key, insecure, ca_data))
 
     real_server.api_key = api_key
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
Fixes #487 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [X] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
The initial server check accesses /server_settings to verify that the target is a Connect server. That endpoint doesn't require authentication, so the API key was omitted. However, Connect servers using proxy authentication sometimes have the proxy configured to only pass requests that include an authentication header. This change allows rsconnect-python to work in those configurations.

## Automated Tests
This change is in an area of code that does not include tests.

## Directions for Reviewers
Add a new Connect server and verify that the initial request to /server_settings includes an Authorization header containing the provided API key. A couple ways to do this:
* Go through a proxy that logs requests including headers
* Add a log/print statement [here](https://github.com/rstudio/rsconnect-python/blob/api-key-in-server-check/rsconnect/http_support.py#L301)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
