### PR TITLE
Add verbose log level for filenames being bundled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `*_app.py` are now considered. However, if the directory contains more than
   one file matching these new patterns, you must provide rsconnect-python with an
   explicit `--entrypoint` argument.
+- Added a new verbose logging level. Specifying `-v` on the command line uses this
+  new level. Currently this will cause filenames to be logged as they are added to
+  a bundle. To enable maximum verbosity (debug level), use `-vv`.
 
 ## [1.20.0] - 2023-09-11
 

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -40,7 +40,7 @@ from .bundle import (
     read_manifest_file,
 )
 from .environment import Environment, MakeEnvironment, EnvironmentException
-from .log import logger
+from .log import logger, VERBOSE
 from .models import AppModes, AppMode
 from .api import RSConnectExecutor, filter_out_server_info
 
@@ -98,15 +98,17 @@ def cli_feedback(label, stderr=False):
         logger.set_in_feedback(False)
 
 
-def set_verbosity(verbose):
+def set_verbosity(verbose: int):
     """Set the verbosity level based on a passed flag
 
     :param verbose: boolean specifying verbose or not
     """
-    if verbose:
-        logger.setLevel(logging.DEBUG)
-    else:
+    if verbose == 0:
         logger.setLevel(logging.INFO)
+    elif verbose == 1:
+        logger.setLevel(VERBOSE)
+    else:
+        logger.setLevel(logging.DEBUG)
 
 
 def which_python(python, env=os.environ):

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -28,7 +28,7 @@ except ImportError:
 
 from os.path import basename, dirname, exists, isdir, join, relpath, splitext, isfile, abspath
 
-from .log import logger
+from .log import logger, VERBOSE
 from .models import AppMode, AppModes, GlobSet
 from .environment import Environment, MakeEnvironment
 from .exception import RSConnectException
@@ -281,11 +281,13 @@ class Bundle:
                 if Path(fp).name in self.buffer:
                     continue
                 rel_path = Path(fp).relative_to(self.deploy_dir) if flatten_to_deploy_dir else None
+                logger.log(VERBOSE, "Adding file: %s", fp)
                 bundle.add(fp, arcname=rel_path)
             for k, v in self.buffer.items():
                 buf = io.BytesIO(to_bytes(v))
                 file_info = tarfile.TarInfo(k)
                 file_info.size = len(buf.getvalue())
+                logger.log(VERBOSE, "Adding file: %s", k)
                 bundle.addfile(file_info, buf)
         bundle_file.seek(0)
         return bundle_file
@@ -428,7 +430,7 @@ def bundle_add_file(bundle, rel_path, base_dir):
     The file path is relative to the notebook directory.
     """
     path = join(base_dir, rel_path) if os.path.isdir(base_dir) else rel_path
-    logger.debug("adding file: %s", path)
+    logger.log(VERBOSE, "Adding file: %s", path)
     bundle.add(path, arcname=rel_path)
 
 
@@ -437,7 +439,7 @@ def bundle_add_buffer(bundle, filename, contents):
 
     `contents` may be a string or bytes object
     """
-    logger.debug("adding file: %s", filename)
+    logger.log(VERBOSE, "Adding file: %s", filename)
     buf = io.BytesIO(to_bytes(contents))
     file_info = tarfile.TarInfo(filename)
     file_info.size = len(buf.getvalue())

--- a/rsconnect/log.py
+++ b/rsconnect/log.py
@@ -9,6 +9,8 @@ import six
 
 _DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 
+VERBOSE = int((logging.INFO + logging.DEBUG) / 2)
+
 
 class LogOutputFormat(object):
     TEXT = "text"

--- a/rsconnect/log.py
+++ b/rsconnect/log.py
@@ -10,6 +10,7 @@ import six
 _DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 
 VERBOSE = int((logging.INFO + logging.DEBUG) / 2)
+logging.addLevelName(VERBOSE, "VERBOSE")
 
 
 class LogOutputFormat(object):

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -135,7 +135,7 @@ def server_args(func):
         type=click.Path(exists=True, file_okay=True, dir_okay=False),
         help="The path to trusted TLS CA certificates.",
     )
-    @click.option("--verbose", "-v", is_flag=True, help="Print detailed messages.")
+    @click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -242,6 +242,7 @@ def content_args(func):
         return func(*args, **kwargs)
 
     return wrapper
+
 
 # This callback handles the "shorthand" --disable-env-management option.
 # If the shorthand flag is provided, then it takes precendence over the R and Python flags.
@@ -399,7 +400,7 @@ def _test_rstudio_creds(server: api.PositServer):
     help="The path to the file containing the private key used to sign the JWT.",
 )
 @click.option("--raw", "-r", is_flag=True, help="Return the API key as raw output rather than a JSON object")
-@click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
+@click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
 @cli_exception_handler
 def bootstrap(
     server,
@@ -482,11 +483,10 @@ def bootstrap(
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
     help="The path to trusted TLS CA certificates.",
 )
-@click.option("--verbose", "-v", is_flag=True, help="Print detailed messages.")
+@click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
 @cloud_shinyapps_args
 @click.pass_context
 def add(ctx, name, server, api_key, insecure, cacert, account, token, secret, verbose):
-
     set_verbosity(verbose)
     if click.__version__ >= "8.0.0" and sys.version_info >= (3, 7):
         click.echo("Detected the following inputs:")
@@ -550,7 +550,7 @@ def add(ctx, name, server, api_key, insecure, cacert, account, token, secret, ve
     short_help="List the known Posit Connect servers.",
     help="Show the stored information about each known server nickname.",
 )
-@click.option("--verbose", "-v", is_flag=True, help="Print detailed messages.")
+@click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
 def list_servers(verbose):
     set_verbosity(verbose)
     with cli_feedback(""):
@@ -630,7 +630,7 @@ def details(name, server, api_key, insecure, cacert, verbose):
 )
 @click.option("--name", "-n", help="The nickname of the Posit Connect server to remove.")
 @click.option("--server", "-s", help="The URL of the Posit Connect server to remove.")
-@click.option("--verbose", "-v", is_flag=True, help="Print detailed messages.")
+@click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
 def remove(name, server, verbose):
     set_verbosity(verbose)
 
@@ -866,7 +866,7 @@ def deploy_notebook(
     python,
     conda,
     force_generate,
-    verbose: bool,
+    verbose: int,
     file: str,
     extra_files,
     hide_all_input: bool,
@@ -986,7 +986,7 @@ def deploy_voila(
     env_management_r: bool = None,
     title: str = None,
     env_vars: typing.Dict[str, str] = None,
-    verbose: bool = False,
+    verbose: int = 0,
     new: bool = False,
     app_id: str = None,
     name: str = None,
@@ -1050,7 +1050,7 @@ def deploy_manifest(
     new: bool,
     app_id: str,
     title: str,
-    verbose: bool,
+    verbose: int,
     file: str,
     env_vars: typing.Dict[str, str],
     visibility: typing.Optional[str],
@@ -1143,7 +1143,7 @@ def deploy_quarto(
     quarto,
     python,
     force_generate: bool,
-    verbose: bool,
+    verbose: int,
     file_or_directory,
     extra_files,
     env_vars: typing.Dict[str, str],
@@ -1245,7 +1245,7 @@ def deploy_html(
     exclude=None,
     title: str = None,
     env_vars: typing.Dict[str, str] = None,
-    verbose: bool = False,
+    verbose: int = 0,
     new: bool = False,
     app_id: str = None,
     name: str = None,
@@ -1258,6 +1258,8 @@ def deploy_html(
     secret: str = None,
 ):
     kwargs = locals()
+    set_verbosity(verbose)
+
     ce = None
     if connect_server:
         kwargs = filter_out_server_info(**kwargs)
@@ -1360,7 +1362,7 @@ def generate_deploy_python(app_mode, alias, min_version):
         python,
         conda,
         force_generate: bool,
-        verbose: bool,
+        verbose: int,
         directory,
         extra_files,
         visibility: typing.Optional[str],
@@ -1373,6 +1375,7 @@ def generate_deploy_python(app_mode, alias, min_version):
         token: str = None,
         secret: str = None,
     ):
+        set_verbosity(verbose)
         kwargs = locals()
         kwargs["entrypoint"] = entrypoint = validate_entry_point(entrypoint, directory)
         kwargs["extra_files"] = extra_files = validate_extra_files(directory, extra_files)
@@ -2155,7 +2158,7 @@ def remove_content_build(name, server, api_key, insecure, cacert, guid, all, pur
     metavar="TEXT",
     help="Check the local build state of a specific content item. This flag can be passed multiple times.",
 )
-@click.option("--verbose", "-v", is_flag=True, help="Print detailed messages.")
+@click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
 # todo: --format option (json, text)
 def list_content_build(name, server, api_key, insecure, cacert, status, guid, verbose):
     set_verbosity(verbose)


### PR DESCRIPTION
This PR adds a new log level, and emits messages at that level for each file that is added to a bundle. The new level is used when `-v` is present on the command line; use `-vv` for full debug logging.

## Intent
Fixes #363 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
Introduced a custom log level `VERBOSE` between `INFO` and `DEBUG`, and configure log level appropriately based on the verbosity. Change verbosity from a bool/flag to a counter/int.

## Automated Tests
Our tests don't validate logged messages.

## Directions for Reviewers
Deploy various content types (notebook, app/API, and manifest) with no verbosity, `-v`, and `-vv`. With `-v`, and `-vv`, you should see messages logged at level `VERBOSE` showing the files added to the bundle.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
