### PR TITLE
Aliases 'api' commands to 'flask'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## Unreleased
 
 ### Fixed
@@ -20,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `*_app.py` are now considered. However, if the directory contains more than
   one file matching these new patterns, you must provide rsconnect-python with an
   explicit `--entrypoint` argument.
+- Added the `deploy flask` command.
+- Added the `write-manifest flask` command.
+
+### Removed
+- Deprecated the `deploy api` command in favor of the `deploy flask` command.
+- Deprecated the `write-manifest api` command in favor of the `write-manifest flask` command.
 
 ## [1.20.0] - 2023-09-11
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ you will need to include the `--cacert` option that points to your certificate
 authority (CA) trusted certificates file. Both of these options can be saved along
 with the URL and API Key for a server.
 
-> **Note** 
+> **Note**
 > When certificate information is saved for the server, the specified file
 > is read and its _contents_ are saved under the server's nickname. If the CA file's
 > contents are ever changed, you will need to add the server information again.
@@ -135,7 +135,7 @@ rsconnect add \
     --name myserver
 ```
 
-> **Note** 
+> **Note**
 > The `rsconnect` CLI will verify that the serve URL and API key
 > are valid. If either is found not to be, no information will be saved.
 
@@ -286,7 +286,7 @@ API or application is run by the Posit Connect server. Just specify them on the
 command line after the API or application directory:
 
 ```bash
-rsconnect deploy api flask-api/ data.csv
+rsconnect deploy flask flask-api/ data.csv
 ```
 
 Since deploying an API or application starts at a directory level, there will be times
@@ -351,7 +351,7 @@ the package dependencies will be determined from the current Python environment,
 from an alternative Python executable specified via the `--python` option:
 
 ```bash
-rsconnect deploy api --python /path/to/python my-api/
+rsconnect deploy flask --python /path/to/python my-api/
 ```
 
 You can see the packages list that will be included by running `pip list --format=freeze` yourself,
@@ -374,7 +374,7 @@ Python executable specified in the `--python` option.
 Here is an example of the `write-manifest` command:
 
 ```bash
-rsconnect write-manifest api my-api/
+rsconnect write-manifest flask my-api/
 ```
 
 ### Deploying R or Other Content
@@ -421,7 +421,7 @@ this, use the `--title` option:
 rsconnect deploy notebook --title "My Notebook" my-notebook.ipynb
 ```
 
-When using `rsconnect deploy api`, `rsconnect deploy fastapi`, `rsconnect deploy dash`,
+When using `rsconnect deploy flask`, `rsconnect deploy fastapi`, `rsconnect deploy dash`,
 `rsconnect deploy streamlit`, or `rsconnect deploy bokeh`, the title is derived from the directory
 containing the API or application.
 
@@ -430,7 +430,7 @@ filename referenced in the manifest.
 
 ### Environment variables
 You can set environment variables during deployment. Their names and values will be
-passed to Posit Connect during deployment so you can use them in your code. Note that 
+passed to Posit Connect during deployment so you can use them in your code. Note that
 if you are using `rsconnect` to deploy to shinyapps.io, environment variable management
 is not supported on that platform.
 
@@ -985,9 +985,9 @@ xargs printf -- '-g %s\n' < guids.txt | xargs rsconnect content build add
 ```
 ## Programmatic Provisioning
 
-Posit Connect supports the programmatic bootstrapping of an administrator API key 
+Posit Connect supports the programmatic bootstrapping of an administrator API key
 for scripted provisioning tasks. This process is supported by the `rsconnect bootstrap` command,
-which uses a JSON Web Token to request an initial API key from a fresh Connect instance. 
+which uses a JSON Web Token to request an initial API key from a fresh Connect instance.
 
 > **Warning**
 > This feature **requires Python version 3.6 or higher**.
@@ -998,7 +998,7 @@ rsconnect bootstrap \
     --jwt-keypath /path/to/secret.key
 ```
 
-A full description on how to use `rsconnect bootstrap` in a provisioning workflow is provided in the Connect administrator guide's 
+A full description on how to use `rsconnect bootstrap` in a provisioning workflow is provided in the Connect administrator guide's
 [programmatic provisioning](https://docs.posit.co/connect/admin/programmatic-provisioning) documentation.
 
 ## Server Administration Tasks

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -861,7 +861,7 @@ def deploy_python_api(
     :return: the ultimate URL where the deployed app may be accessed and the sequence
     of log lines.  The log lines value will be None if a log callback was provided.
     """
-    return deploy_app(app_mode=AppModes.PYTHON_API, **locals())
+    return deploy_app(app_mode=AppModes.PYTHON_FLASK, **locals())
 
 
 def deploy_python_fastapi(
@@ -1280,7 +1280,7 @@ def create_api_deployment_bundle(
         extra_files = validate_extra_files(directory, extra_files)
 
     if app_mode is None:
-        app_mode = AppModes.PYTHON_API
+        app_mode = AppModes.PYTHON_FLASK
 
     return make_api_bundle(directory, entry_point, app_mode, environment, extra_files, excludes,
                            image, env_management_py, env_management_r)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -65,6 +65,7 @@ from .bundle import (
 from .log import logger, LogOutputFormat
 from .metadata import ServerStore, AppStore
 from .models import (
+    AppMode,
     AppModes,
     BuildStatus,
     ContentGuidWithBundleParamType,
@@ -1281,7 +1282,7 @@ def deploy_html(
     )
 
 
-def generate_deploy_python(app_mode, alias, min_version):
+def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, deprecated: bool = False):
     # noinspection SpellCheckingInspection
     @deploy.command(
         name=alias,
@@ -1294,6 +1295,7 @@ def generate_deploy_python(app_mode, alias, min_version):
             'The "directory" argument must refer to an existing directory that contains the application code.'
         ).format(desc=app_mode.desc()),
         no_args_is_help=True,
+        deprecated=deprecated
     )
     @server_args
     @content_args
@@ -1407,7 +1409,8 @@ def generate_deploy_python(app_mode, alias, min_version):
     return deploy_app
 
 
-deploy_api = generate_deploy_python(app_mode=AppModes.PYTHON_API, alias="api", min_version="1.8.2")
+deploy_api = generate_deploy_python(app_mode=AppModes.PYTHON_FLASK, alias="api", min_version="1.8.2", deprecated=True)
+deploy_flask = generate_deploy_python(app_mode=AppModes.PYTHON_FLASK, alias="flask", min_version="1.8.2")
 # TODO: set fastapi min_version correctly
 # deploy_fastapi = generate_deploy_python(app_mode=AppModes.PYTHON_FASTAPI, alias="fastapi", min_version="2021.08.0")
 deploy_fastapi = generate_deploy_python(app_mode=AppModes.PYTHON_FASTAPI, alias="fastapi", min_version="2021.08.0")
@@ -1759,7 +1762,7 @@ def write_manifest_quarto(
         )
 
 
-def generate_write_manifest_python(app_mode, alias):
+def generate_write_manifest_python(app_mode, alias, deprecated=False):
     # noinspection SpellCheckingInspection
     @write_manifest.command(
         name=alias,
@@ -1769,6 +1772,7 @@ def generate_write_manifest_python(app_mode, alias):
             'environment file ("requirements.txt") if one does not exist. All files '
             "are created in the same directory as the API code."
         ).format(desc=app_mode.desc()),
+        deprecated=deprecated,
     )
     @click.option("--overwrite", "-o", is_flag=True, help="Overwrite manifest.json, if it exists.")
     @click.option(
@@ -1850,7 +1854,8 @@ def generate_write_manifest_python(app_mode, alias):
     return manifest_writer
 
 
-write_manifest_api = generate_write_manifest_python(AppModes.PYTHON_API, alias="api")
+write_manifest_api = generate_write_manifest_python(AppModes.PYTHON_FLASK, alias="api", deprecated=True)
+write_manifest_flask = generate_write_manifest_python(AppModes.PYTHON_FLASK, alias="flask")
 write_manifest_fastapi = generate_write_manifest_python(AppModes.PYTHON_FASTAPI, alias="fastapi")
 write_manifest_dash = generate_write_manifest_python(AppModes.DASH_APP, alias="dash")
 write_manifest_streamlit = generate_write_manifest_python(AppModes.STREAMLIT_APP, alias="streamlit")

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -70,7 +70,7 @@ class AppModes(object):
     PLUMBER = AppMode(5, "api", "API")
     TENSORFLOW = AppMode(6, "tensorflow-saved-model", "TensorFlow Model")
     JUPYTER_NOTEBOOK = AppMode(7, "jupyter-static", "Jupyter Notebook", ".ipynb")
-    PYTHON_API = AppMode(8, "python-api", "Python API")
+    PYTHON_FLASK = AppMode(8, "python-api", "Flask Application")
     DASH_APP = AppMode(9, "python-dash", "Dash Application")
     STREAMLIT_APP = AppMode(10, "python-streamlit", "Streamlit Application")
     BOKEH_APP = AppMode(11, "python-bokeh", "Bokeh Application")
@@ -89,7 +89,7 @@ class AppModes(object):
         PLUMBER,
         TENSORFLOW,
         JUPYTER_NOTEBOOK,
-        PYTHON_API,
+        PYTHON_FLASK,
         DASH_APP,
         STREAMLIT_APP,
         BOKEH_APP,
@@ -105,7 +105,7 @@ class AppModes(object):
         "rmarkdown_static": RMD,
         "rmarkdown": SHINY_RMD,
         "plumber": PLUMBER,
-        "flask": PYTHON_API,
+        "flask": PYTHON_FLASK,
         "dash": DASH_APP,
         "streamlit": STREAMLIT_APP,
         "fastapi": PYTHON_FASTAPI,

--- a/rsconnect/timeouts.py
+++ b/rsconnect/timeouts.py
@@ -84,6 +84,6 @@ def get_task_timeout_help_message(timeout=get_task_timeout()) -> str:
 
         Example:
 
-            CONNECT_TASK_TIMEOUT={_CONNECT_TASK_TIMEOUT_DEFAULT_VALUE} rsconnect deploy api --server <your-server> --api-key <your-api-key> ./
+            CONNECT_TASK_TIMEOUT={_CONNECT_TASK_TIMEOUT_DEFAULT_VALUE} rsconnect deploy flask --server <your-server> --api-key <your-api-key> ./
         """  # noqa: E501
     )

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -563,14 +563,14 @@ class TestBundle(TestCase):
         # quarto_inspection=None,  # type: typing.Optional[typing.Dict[str, typing.Any]]
 
         # No optional parameters
-        manifest = make_source_manifest(AppModes.PYTHON_API, None, None, None)
+        manifest = make_source_manifest(AppModes.PYTHON_FLASK, None, None, None)
         self.assertEqual(
             manifest,
             {"version": 1, "metadata": {"appmode": "python-api"}, "files": {}},
         )
 
         # include image parameter
-        manifest = make_source_manifest(AppModes.PYTHON_API, None, None, None,
+        manifest = make_source_manifest(AppModes.PYTHON_FLASK, None, None, None,
                                         image="rstudio/connect:bionic")
         self.assertEqual(
             manifest,
@@ -585,7 +585,7 @@ class TestBundle(TestCase):
         )
 
         # include env_management_py parameter
-        manifest = make_source_manifest(AppModes.PYTHON_API, None, None, None,
+        manifest = make_source_manifest(AppModes.PYTHON_FLASK, None, None, None,
                                         env_management_py=False)
         self.assertEqual(
             manifest,
@@ -602,7 +602,7 @@ class TestBundle(TestCase):
         )
 
         # include env_management_r parameter
-        manifest = make_source_manifest(AppModes.PYTHON_API, None, None, None,
+        manifest = make_source_manifest(AppModes.PYTHON_FLASK, None, None, None,
                                         env_management_r=False)
         self.assertEqual(
             manifest,
@@ -619,7 +619,7 @@ class TestBundle(TestCase):
         )
 
         # include all runtime environment parameters
-        manifest = make_source_manifest(AppModes.PYTHON_API, None, None, None,
+        manifest = make_source_manifest(AppModes.PYTHON_FLASK, None, None, None,
                                         image="rstudio/connect:bionic", env_management_py=False, env_management_r=False)
         self.assertEqual(
             manifest,
@@ -639,7 +639,7 @@ class TestBundle(TestCase):
 
         # include environment parameter
         manifest = make_source_manifest(
-            AppModes.PYTHON_API,
+            AppModes.PYTHON_FLASK,
             Environment(
                 conda=None,
                 contents="",
@@ -671,7 +671,7 @@ class TestBundle(TestCase):
 
         # include entrypoint parameter
         manifest = make_source_manifest(
-            AppModes.PYTHON_API,
+            AppModes.PYTHON_FLASK,
             None,
             "main.py",
             None,
@@ -685,7 +685,7 @@ class TestBundle(TestCase):
 
         # include quarto_inspection parameter
         manifest = make_source_manifest(
-            AppModes.PYTHON_API,
+            AppModes.PYTHON_FLASK,
             None,
             None,
             {
@@ -2538,7 +2538,7 @@ def test_make_api_manifest_flask():
     manifest, _ = make_api_manifest(
         flask_dir,
         None,
-        AppModes.PYTHON_API,
+        AppModes.PYTHON_FLASK,
         environment,
         None,
         None,
@@ -2570,7 +2570,7 @@ def test_make_api_bundle_flask():
     with make_api_bundle(
         flask_dir,
         None,
-        AppModes.PYTHON_API,
+        AppModes.PYTHON_FLASK,
         environment,
         None,
         None,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Renames commands using the `api` nomenclature to use `flask` instead.

Closes #491 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

This change adds the `flask` target to the `deploy` and `write-manifest` commands and deprecates the `api` target. Since `api` is designed for `flask` functionality, a new AppMode is not required. Instead, the `AppModes.PTYHON_API` is reused.

The existing `api` commands are marked as deprecated to ensure backward compatibility.

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

Existing tests for the `api` command are refactored to use `flask`.

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

- Try deploying an application using `deploy flask`.
- Try writing a manifest using `write-manifest flask`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
