### PR TITLE
switch from snyk/actions/python to snyk/actions/setup

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,20 +16,34 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: snyk/actions/setup@master
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Run Snyk (setup.py)
+      #   uses: snyk/actions/python@master
+      #   with:
+      #     command: monitor
+      #     args: --file=setup.py --package-manager=pip --project-name=setup.py --org=${{ env.SNYK_ORG }}
+
+      # - name: Run Snyk (requirements.txt)
+      #   uses: snyk/actions/python@master
+      #   with:
+      #     command: monitor
+      #     args: --file=requirements.txt --package-manager=pip --project-name=requirements.txt --org=${{ env.SNYK_ORG }}
+
+      # On Oct 2 2023, the steps using snyk/actions/python@master started failing with "undefined".
+      # Nothing obvious changed in our code or in the Snyk action or Docker image.
+      # Setting up and running snyk generically seems to work, so we'll go with that.
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          limit-access-to-actor: true
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - uses: snyk/actions/setup@master
 
       - name: Run Snyk (setup.py)
-        uses: snyk/actions/python@master
-        with:
-          command: monitor
-          args: --file=setup.py --package-manager=pip --project-name=setup.py --org=${{ env.SNYK_ORG }}
+        run: snyk monitor --file="setup.py" --package-manager=pip --project-name="setup.py" --org=${{ env.SNYK_ORG }}
 
       - name: Run Snyk (requirements.txt)
-        uses: snyk/actions/python@master
-        with:
-          command: monitor
-          args: --file=requirements.txt --package-manager=pip --project-name=requirements.txt --org=${{ env.SNYK_ORG }}
+        run: snyk monitor --file="requirements.txt" --package-manager=pip --project-name="requirements.txt" --org=${{ env.SNYK_ORG }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,6 +16,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: snyk/actions/setup@master
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+
       - name: Run Snyk (setup.py)
         uses: snyk/actions/python@master
         with:


### PR DESCRIPTION
For some reason the python-specific action started failing. I ssh'd in to the running action to try to debug but couldn't reproduce the error. Using the generic snyk setup action and running the command directly works so we'll just go with that.