### PR TITLE
Add support for git deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `*_app.py` are now considered. However, if the directory contains more than
   one file matching these new patterns, you must provide rsconnect-python with an
   explicit `--entrypoint` argument.
+- Added support for deploying directly from remote git repositories. Only
+  Connect server targets are supported, and the Connect server must have git
+  configured with access to your git repositories. See the
+  [Connect administrator guide](https://docs.posit.co/connect/admin/content-management/git-backed/)
+  and
+  [Connect user guide](https://docs.posit.co/connect/user/git-backed/) for details.
 
 ## [1.20.0] - 2023-09-11
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ you will need to include the `--cacert` option that points to your certificate
 authority (CA) trusted certificates file. Both of these options can be saved along
 with the URL and API Key for a server.
 
-> **Note** 
+> **Note**
 > When certificate information is saved for the server, the specified file
 > is read and its _contents_ are saved under the server's nickname. If the CA file's
 > contents are ever changed, you will need to add the server information again.
@@ -135,7 +135,7 @@ rsconnect add \
     --name myserver
 ```
 
-> **Note** 
+> **Note**
 > The `rsconnect` CLI will verify that the serve URL and API key
 > are valid. If either is found not to be, no information will be saved.
 
@@ -407,6 +407,35 @@ library(rsconnect)
 ?rsconnect::writeManifest
 ```
 
+### Deploying from Git Repositories
+You can deploy content directly from from hosted Git repositories to Posit Connect.
+The content must have an existing `manifest.json` file to identify the content
+type. For Python content, a `requirements.txt` file must also be present.
+
+See the [Connect user guide](https://docs.posit.co/connect/user/git-backed/)
+for details on how to prepare your content for Git publishing.
+
+Once your git repository contains the prepared content, use the `deploy git` command:
+```
+rsconnect deploy git -r https://my.repository.server/repository
+```
+
+To deploy from a branch other than `main`, use the `--branch/-b` option.
+
+To deploy content from a subdirectory, provide the subdirectory
+using the `--subdirectory/-d` option. The specified directory
+must contain the `manifest.json` file.
+
+```
+rsconnect deploy git -r https://my.repository.server/repository -b my-branch -d path/within/repo
+```
+
+These commands create a new git-backed deployment within Posit Connect,
+which will periodically check for new commits to your repository/branch
+and deploy updates automatically. Do not run the
+`deploy git` command again for the same source
+unless you want to create a second, separate deployment for it.
+
 ### Options for All Types of Deployments
 
 These options apply to any type of content deployment.
@@ -430,7 +459,7 @@ filename referenced in the manifest.
 
 ### Environment variables
 You can set environment variables during deployment. Their names and values will be
-passed to Posit Connect during deployment so you can use them in your code. Note that 
+passed to Posit Connect during deployment so you can use them in your code. Note that
 if you are using `rsconnect` to deploy to shinyapps.io, environment variable management
 is not supported on that platform.
 
@@ -985,9 +1014,9 @@ xargs printf -- '-g %s\n' < guids.txt | xargs rsconnect content build add
 ```
 ## Programmatic Provisioning
 
-Posit Connect supports the programmatic bootstrapping of an administrator API key 
+Posit Connect supports the programmatic bootstrapping of an administrator API key
 for scripted provisioning tasks. This process is supported by the `rsconnect bootstrap` command,
-which uses a JSON Web Token to request an initial API key from a fresh Connect instance. 
+which uses a JSON Web Token to request an initial API key from a fresh Connect instance.
 
 > **Warning**
 > This feature **requires Python version 3.6 or higher**.
@@ -998,7 +1027,7 @@ rsconnect bootstrap \
     --jwt-keypath /path/to/secret.key
 ```
 
-A full description on how to use `rsconnect bootstrap` in a provisioning workflow is provided in the Connect administrator guide's 
+A full description on how to use `rsconnect bootstrap` in a provisioning workflow is provided in the Connect administrator guide's
 [programmatic provisioning](https://docs.posit.co/connect/admin/programmatic-provisioning) documentation.
 
 ## Server Administration Tasks

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -233,19 +233,17 @@ class RSConnectClient(HTTPServer):
         self._server.handle_bad_response(response)
         return response
 
-
     def deploy_git(self, app_name, repository, branch, subdirectory):
         app = self.app_create(app_name)
         self._server.handle_bad_response(app)
 
-        self.post(
+        resp = self.post(
             "applications/%s/repo" % app["guid"],
-            body={
-                "repository": repository, "branch": branch , "subdirectory": subdirectory
-            }
+            body={"repository": repository, "branch": branch, "subdirectory": subdirectory},
         )
+        self._server.handle_bad_response(resp)
 
-        task = self.post("applications/%s/deploy" % app["guid"], body=dict())
+        task = self.app_deploy(app["guid"])
         self._server.handle_bad_response(task)
 
         return {
@@ -323,7 +321,6 @@ class RSConnectClient(HTTPServer):
         poll_wait=0.5,
         raise_on_error=True,
     ):
-
         if log_callback is None:
             log_lines = []
             log_callback = log_lines.append
@@ -764,6 +761,18 @@ class RSConnectExecutor:
             }
             return self
 
+    @cls_logged("Deploying git repository ...")
+    def deploy_git(self, app_name: str = None, repository: str = None, branch: str = None, subdirectory: str = None):
+        app_name = app_name or self.get("app_name")
+        repository = repository or self.get("repository")
+        branch = branch or self.get("branch")
+        subdirectory = subdirectory or self.get("subdirectory")
+
+        result = self.client.deploy_git(app_name, repository, branch, subdirectory)
+        self.remote_server.handle_bad_response(result)
+        self.state["deployed_info"] = result
+        return self
+
     def emit_task_log(
         self,
         app_id: int = None,
@@ -1144,14 +1153,9 @@ class PositClient(HTTPServer):
         return response
 
     def create_output(self, name: str, application_type: str, project_id=None, space_id=None, render_by=None):
-        data = {
-            "name": name,
-            "space": space_id,
-            "project": project_id,
-            "application_type": application_type
-        }
+        data = {"name": name, "space": space_id, "project": project_id, "application_type": application_type}
         if render_by:
-            data['render_by'] = render_by
+            data["render_by"] = render_by
         response = self.post("/v1/outputs/", body=data)
         self._server.handle_bad_response(response)
         return response
@@ -1364,10 +1368,7 @@ class CloudService:
         app_mode: AppMode,
         app_store_version: typing.Optional[int],
     ) -> PrepareDeployOutputResult:
-
-        application_type = "static" if app_mode in [
-            AppModes.STATIC,
-            AppModes.STATIC_QUARTO] else "connect"
+        application_type = "static" if app_mode in [AppModes.STATIC, AppModes.STATIC_QUARTO] else "connect"
         logger.debug(f"application_type: {application_type}")
 
         render_by = "server" if app_mode == AppModes.STATIC_QUARTO else None
@@ -1385,11 +1386,13 @@ class CloudService:
                 space_id = None
 
             # create the new output and associate it with the current Posit Cloud project and space
-            output = self._rstudio_client.create_output(name=app_name,
-                                                        application_type=application_type,
-                                                        project_id=project_id,
-                                                        space_id=space_id,
-                                                        render_by=render_by)
+            output = self._rstudio_client.create_output(
+                name=app_name,
+                application_type=application_type,
+                project_id=project_id,
+                space_id=space_id,
+                render_by=render_by,
+            )
             app_id_int = output["source_id"]
         else:
             # this is a redeployment of an existing output

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -233,6 +233,29 @@ class RSConnectClient(HTTPServer):
         self._server.handle_bad_response(response)
         return response
 
+
+    def deploy_git(self, app_name, repository, branch, subdirectory):
+        app = self.app_create(app_name)
+        self._server.handle_bad_response(app)
+
+        self.post(
+            "applications/%s/repo" % app["guid"],
+            body={
+                "repository": repository, "branch": branch , "subdirectory": subdirectory
+            }
+        )
+
+        task = self.post("applications/%s/deploy" % app["guid"], body=dict())
+        self._server.handle_bad_response(task)
+
+        return {
+            "task_id": task["id"],
+            "app_id": app["id"],
+            "app_guid": app["guid"],
+            "app_url": app["url"],
+            "title": app["title"],
+        }
+
     def deploy(self, app_id, app_name, app_title, title_is_default, tarball, env_vars=None):
         if app_id is None:
             # create an app if id is not provided

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1408,9 +1408,24 @@ def deploy_help():
 )
 @server_args
 @click.option("--app_name", "-a")
-@click.option("--repository", "-r", required=True)
-@click.option("--branch", "-b", default="main")
-@click.option("--subdirectory", "-d", default="/")
+@click.option(
+    "--repository",
+    "-r",
+    required=True,
+    help="Repository URL to deploy, e.g. https://github.com/username/repository. Only https URLs are supported.",
+)
+@click.option(
+    "--branch",
+    "-b",
+    default="main",
+    help="Name of the branch to deploy. Connect will automatically deploy updates when commits are pushed to the branch.",
+)
+@click.option(
+    "--subdirectory",
+    "-d",
+    default="/",
+    help="Directory within the repository to deploy. The directory must contain a manifest.json file.",
+)
 @click.option("--title", "-t", help="Title of the content (default is the same as the filename).")
 @click.option(
     "--environment",

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1446,6 +1446,17 @@ def deploy_help():
 @click.option("--repository", "-r", required=True)
 @click.option("--branch", "-b", default="main")
 @click.option("--subdirectory", "-d", default="/")
+@click.option("--title", "-t", help="Title of the content (default is the same as the filename).")
+@click.option(
+    "--environment",
+    "-E",
+    "env_vars",
+    multiple=True,
+    callback=validate_env_vars,
+    help="Set an environment variable. Specify a value with NAME=VALUE, "
+    "or just NAME to use the value from the local environment. "
+    "May be specified multiple times. [v1.8.6+]",
+)
 @cli_exception_handler
 def deploy_git(
     name: str,
@@ -1458,6 +1469,8 @@ def deploy_git(
     repository: str,
     branch: str,
     subdirectory: str,
+    title: str,
+    env_vars: typing.Dict[str, str],
 ):
     subdirectory = subdirectory.strip("/")
     kwargs = locals()

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1436,6 +1436,56 @@ def deploy_help():
     click.echo()
 
 
+@deploy.command(
+    name="git",
+    short_help="Deploy git repository with exisiting manifest file",
+    help="Deploy git repository with exisiting manifest file"
+)
+@click.option("--name", "-n", help="The nickname of the RStudio Connect server to deploy to.")
+@click.option(
+    "--server", "-s", envvar="CONNECT_SERVER", help="The URL for the RStudio Connect server to deploy to.",
+)
+@click.option(
+    "--api-key", "-k", envvar="CONNECT_API_KEY", help="The API key to use to authenticate with RStudio Connect.",
+)
+@click.option(
+    "--insecure", "-i", envvar="CONNECT_INSECURE", is_flag=True, help="Disable TLS certification/host validation.",
+)
+@click.option(
+    "--cacert",
+    "-c",
+    envvar="CONNECT_CA_CERTIFICATE",
+    type=click.File(),
+    help="The path to trusted TLS CA certificates.",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Print detailed messages.")
+@click.option('--app_name', '-a')
+@click.option('--repository', "-r")
+@click.option('--branch', "-b")
+@click.option('--subdirectory', "-d")
+def deploy_git(name, server, api_key, insecure, cacert, verbose, app_name, repository, branch, subdirectory):
+    set_verbosity(verbose)
+
+    with cli_feedback("Checking arguments"):
+        connect_server = _validate_deploy_to_args(name, server, api_key, insecure, cacert)
+
+    connect_client = api.RSConnect(connect_server)
+
+    with cli_feedback("Deploying git repository"):
+        app = connect_client.deploy_git(app_name, repository, branch, subdirectory)
+
+    with cli_feedback(""):
+        click.secho("\nDeployment log:", fg="bright_white")
+        app_url, _ = spool_deployment_log(connect_server, app, click.echo)
+        click.secho("Deployment completed successfully.", fg="bright_white")
+        click.secho("    Dashboard content URL: %s" % app_url, fg="bright_white")
+        click.secho("    Direct content URL: %s" % app["app_url"], fg="bright_white")
+
+
+    click.secho("Git deployment completed successfully.", fg="bright_white")
+    click.secho("App available as %s" % app_name, fg="bright_white")
+
+
 @cli.group(
     name="write-manifest",
     no_args_is_help=True,
@@ -1448,7 +1498,6 @@ def deploy_help():
 )
 def write_manifest():
     pass
-
 
 @write_manifest.command(
     name="notebook",

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1418,7 +1418,8 @@ def deploy_help():
     "--branch",
     "-b",
     default="main",
-    help="Name of the branch to deploy. Connect will automatically deploy updates when commits are pushed to the branch.",
+    help=("Name of the branch to deploy. Connect will automatically " +
+          "deploy updates when commits are pushed to the branch."),
 )
 @click.option(
     "--subdirectory",


### PR DESCRIPTION
This PR adds support for deploying a new git-backed content item using rsconnect-python.

## Intent

This is based on [@colearendt 's PR](https://github.com/rstudio/rsconnect-python/pull/284). I moved it to a local branch (for CI), updated it to work the the executor, added title/env var support, and added documentation.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Automated Tests
Needs tests.

## Directions for Reviewers
Run something like
```
rsconnect deploy git -r https://github.com/rstudio/rsc-hello-world-content -d square-plot
```

See a new git-backed content item in Connect. You can also use `--title`, and `-E` to specify environment variables as for other content types.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
