### PR TITLE
Compatibility with previous saved rsconnect.environment modules 

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1590,6 +1590,7 @@ def inspect_environment(
     if len(flags) > 0:
         args.append("-" + "".join(flags))
     args.append(directory)
+
     try:
         environment_json = check_output(args, universal_newlines=True)
     except subprocess.CalledProcessError as e:

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -49,6 +49,7 @@ def MakeEnvironment(
     pip: Optional[str] = None,
     python: Optional[str] = None,
     source: Optional[str] = None,
+    conda: Optional[str] = None,  # Deprecated, but included for compatibility with past environments
 ):
     return Environment(contents, error, filename, locale, package_manager, pip, python, source)
 

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -49,7 +49,7 @@ def MakeEnvironment(
     pip: Optional[str] = None,
     python: Optional[str] = None,
     source: Optional[str] = None,
-    conda: Optional[str] = None,  # Deprecated, but included for compatibility with past environments
+    **kwargs,  # provides compatibility where we no longer support some older properties
 ):
     return Environment(contents, error, filename, locale, package_manager, pip, python, source)
 


### PR DESCRIPTION
## Intent

reconnect-python saves an `rsconnect.environment` module within each python installation it executes from. With the removal of `condo` support, we need to be compatible with entries saved within those older installations.

Resolves #510 

## Type of Change
- [X] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
the `environment.py::MakeEnvironment` method is passed named arguments from attributes saved within
the `rsconnect.environment` module. Rather than add a `conda` parameter, I've chosen to catch all
unmatched arguments with a wild-card catch-all.

## Automated Tests
None impacted

## Directions for Reviewers
This should be tested against an older python installation which had an older version of reconnect-python used with it. It should also be tested against a new installation in which the user has never used rsconnect-python.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
