### PR TITLE
Improve the error output for conflicting params and provide better option help describing environment variables used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Pending Next Release
+
+### Added
+- Added the name of the environment variables to the help output for those options that
+  use environment variables as a default value.
+
+### Changed
+- Improved the error and warning outputs when options conflict by providing the source 
+  from which the values have been determined. This allows for faster resolution of issues
+  when combinations of stored credentials, environment variables and command line options
+  are used.
+- Updated verbose mode to output the source of all options being used when processing the
+  CLI command.
+
 ## [1.21.0] - 2023-10-26
 
 ### Fixed
@@ -39,10 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   For cases where this is not desired, use the `--no-verify` flag on the command line.
 - Added the `deploy flask` command.
 - Added the `write-manifest flask` command.
-- Added the name of the environment variables to the help output for those options that
-  use environment variables as a default value.
-- Added the source of where the option was set within the error messages displayed for
-  when options conflict with each other.
 
 ### Changed
 - Removing experimental support for Conda. Connect does not support restoring Conda environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   For cases where this is not desired, use the `--no-verify` flag on the command line.
 - Added the `deploy flask` command.
 - Added the `write-manifest flask` command.
+- Added the name of the environment variables to the help output for those options that
+  use environment variables as a default value.
+- Added the source of where the option was set within the error messages displayed for
+  when options conflict with each other.
 
 ### Changed
 - Removing experimental support for Conda. Connect does not support restoring Conda environments.

--- a/integration-testing/docker/cypress.Dockerfile
+++ b/integration-testing/docker/cypress.Dockerfile
@@ -1,7 +1,8 @@
 FROM cypress/included:12.7.0
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    jq
+    jq \
+    curl
 
 RUN mkdir -p /libs-cypress && \
     curl -fsSL https://github.com/casey/just/releases/download/1.1.2/just-1.1.2-x86_64-unknown-linux-musl.tar.gz \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pip>=10.0.0",
     "semver>=2.0.0,<3.0.0",
     "pyjwt>=2.4.0",
+    "click>=8.0.0",
 ]
 
 dynamic = ["version"]
@@ -33,9 +34,9 @@ test = [
     "pytest-cov",
     "pytest-mypy",
     "pytest",
-    "setuptools_scm[toml]",
+    "setuptools>=61",
+    "setuptools_scm[toml]>=3.4",
     "twine",
-    "types-click",
     "types-Flask",
     "types-six",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ wheel
 
 # project.dependencies
 six>=1.14.0
-click>=7.0.0
+click>=8.0.0
 pip>=10.0.0
 semver>=2.0.0,<3.0.0
 pyjwt>=2.4.0
@@ -29,6 +29,5 @@ pytest-mypy
 pytest
 setuptools_scm[toml]
 twine
-types-click
 types-Flask
 types-six

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -515,6 +515,13 @@ class RSConnectExecutor:
                     header_output = self.output_overlap_details("secret", header_output)
                 if header_output:
                     self.logger.warning("\n")
+            
+            api_key = server_data.api_key or api_key
+            insecure = server_data.insecure or insecure
+            ca_data = server_data.ca_data or ca_data
+            account_name = server_data.account_name or account_name
+            token = server_data.token or token
+            secret = server_data.secret or secret
 
         self.is_server_from_store = server_data.from_store
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 import re
 from warnings import warn
 import gc
+import click
 
 from . import validation
 from .certificates import read_certificate_file
@@ -389,6 +390,7 @@ RSConnect = RSConnectClient
 class RSConnectExecutor:
     def __init__(
         self,
+        cli_ctx: click.Context = None,
         name: str = None,
         url: str = None,
         api_key: str = None,
@@ -406,7 +408,9 @@ class RSConnectExecutor:
         self.reset()
         self._d = kwargs
         self.logger = logger
+        self.cli_ctx = cli_ctx
         self.setup_remote_server(
+            ctx=cli_ctx,
             name=name,
             url=url or kwargs.get("server"),
             api_key=api_key,
@@ -442,8 +446,32 @@ class RSConnectExecutor:
         gc.collect()
         return self
 
+    def output_overlap_header(self, previous):
+        if self.logger and not previous:
+            self.logger.warning(
+                "Connect detected CLI commands and/or environment variables that overlap with stored credential.\n"
+            )
+            self.logger.warning(
+                "Check your environment variables (e.g. CONNECT_API_KEY) to make sure you want them to be used.\n"
+            )
+            self.logger.warning(
+                "Credential parameters are taken with the following precedence: stored > CLI > environment.\n"
+            )
+            self.logger.warning(
+                "To ignore an environment variable, override it in the CLI with an empty string (e.g. -k '').\n"
+            )
+            return True
+
+    def output_overlap_details(self, cli_param, previous):
+        new_previous = self.output_overlap_header(previous)
+        if self.cli_ctx:
+            source = self.cli_ctx.get_parameter_source(cli_param)
+            self.logger.warning(f"stored {cli_param} value overrides the {cli_param} value from {source.name}")
+        return new_previous
+
     def setup_remote_server(
         self,
+        ctx: click.Context,
         name: str = None,
         url: str = None,
         api_key: str = None,
@@ -455,6 +483,7 @@ class RSConnectExecutor:
         secret: str = None,
     ):
         validation.validate_connection_options(
+            ctx=ctx,
             url=url,
             api_key=api_key,
             insecure=insecure,
@@ -464,6 +493,7 @@ class RSConnectExecutor:
             secret=secret,
             name=name,
         )
+        header_output = False
 
         if cacert and not ca_data:
             ca_data = read_certificate_file(cacert)
@@ -471,38 +501,20 @@ class RSConnectExecutor:
         server_data = ServerStore().resolve(name, url)
         if server_data.from_store:
             url = server_data.url
-            if (
-                server_data.api_key
-                and api_key
-                or server_data.insecure
-                and insecure
-                or server_data.ca_data
-                and ca_data
-                or server_data.account_name
-                and account_name
-                or server_data.token
-                and token
-                or server_data.secret
-                and secret
-            ) and self.logger:
-                self.logger.warning(
-                    "Connect detected CLI commands and/or environment variables that overlap with stored credential.\n"
-                )
-                self.logger.warning(
-                    "Check your environment variables (e.g. CONNECT_API_KEY) to make sure you want them to be used.\n"
-                )
-                self.logger.warning(
-                    "Credential paremeters are taken with the following precedence: stored > CLI > environment.\n"
-                )
-                self.logger.warning(
-                    "To ignore an environment variable, override it in the CLI with an empty string (e.g. -k '').\n"
-                )
-            api_key = server_data.api_key or api_key
-            insecure = server_data.insecure or insecure
-            ca_data = server_data.ca_data or ca_data
-            account_name = server_data.account_name or account_name
-            token = server_data.token or token
-            secret = server_data.secret or secret
+            if self.logger:
+                if server_data.api_key and api_key:
+                    header_output = self.output_overlap_details("api-key", header_output)
+                if server_data.insecure and insecure:
+                    header_output = self.output_overlap_details("insecure", header_output)
+                if server_data.ca_data and ca_data:
+                    header_output = self.output_overlap_details("cacert", header_output)
+                if server_data.account_name and account_name:
+                    header_output = self.output_overlap_details("account", header_output)
+                if server_data.token and token:
+                    header_output = self.output_overlap_details("token", header_output)
+                if server_data.secret and secret:
+                    header_output = self.output_overlap_details("secret", header_output)
+
         self.is_server_from_store = server_data.from_store
 
         if api_key:
@@ -571,7 +583,7 @@ class RSConnectExecutor:
         :param url: the URL, if any, specified by the user.
         :param api_key: the API key, if any, specified by the user.
         :param insecure: a flag noting whether TLS host/validation should be skipped.
-        :param cacert: the file object of a CA certs file containing certificates to use.
+        :param cacert: the file path of a CA certs file containing certificates to use.
         :param api_key_is_required: a flag that notes whether the API key is required or may
         be omitted.
         :param token: The shinyapps.io authentication token.

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -390,7 +390,7 @@ RSConnect = RSConnectClient
 class RSConnectExecutor:
     def __init__(
         self,
-        cli_ctx: click.Context = None,
+        ctx: click.Context = None,
         name: str = None,
         url: str = None,
         api_key: str = None,
@@ -408,9 +408,9 @@ class RSConnectExecutor:
         self.reset()
         self._d = kwargs
         self.logger = logger
-        self.cli_ctx = cli_ctx
+        self.ctx = ctx
         self.setup_remote_server(
-            ctx=cli_ctx,
+            ctx=ctx,
             name=name,
             url=url or kwargs.get("server"),
             api_key=api_key,
@@ -464,8 +464,8 @@ class RSConnectExecutor:
 
     def output_overlap_details(self, cli_param, previous):
         new_previous = self.output_overlap_header(previous)
-        if self.cli_ctx:
-            source = self.cli_ctx.get_parameter_source(cli_param)
+        if self.ctx:
+            source = self.ctx.get_parameter_source(cli_param)
             self.logger.warning(f"stored {cli_param} value overrides the {cli_param} value from {source.name}")
         return new_previous
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -465,7 +465,7 @@ class RSConnectExecutor:
     def output_overlap_details(self, cli_param, previous):
         new_previous = self.output_overlap_header(previous)
         sourceName = validation.get_parameter_source_name_from_ctx(cli_param, self.ctx)
-        self.logger.warning(f"- stored {cli_param} value overrides the {cli_param} value from {sourceName}\n")
+        self.logger.warning(f">> stored {cli_param} value overrides the {cli_param} value from {sourceName}\n")
         return new_previous
 
     def setup_remote_server(
@@ -515,7 +515,7 @@ class RSConnectExecutor:
                     header_output = self.output_overlap_details("secret", header_output)
                 if header_output:
                     self.logger.warning("\n")
-            
+
             api_key = server_data.api_key or api_key
             insecure = server_data.insecure or insecure
             ca_data = server_data.ca_data or ca_data

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -449,7 +449,7 @@ class RSConnectExecutor:
     def output_overlap_header(self, previous):
         if self.logger and not previous:
             self.logger.warning(
-                "Connect detected CLI commands and/or environment variables that overlap with stored credential.\n"
+                "\nConnect detected CLI commands and/or environment variables that overlap with stored credential.\n"
             )
             self.logger.warning(
                 "Check your environment variables (e.g. CONNECT_API_KEY) to make sure you want them to be used.\n"
@@ -458,15 +458,14 @@ class RSConnectExecutor:
                 "Credential parameters are taken with the following precedence: stored > CLI > environment.\n"
             )
             self.logger.warning(
-                "To ignore an environment variable, override it in the CLI with an empty string (e.g. -k '').\n"
+                "To ignore an environment variable, override it in the CLI with an empty string (e.g. -k '').\n\n"
             )
             return True
 
     def output_overlap_details(self, cli_param, previous):
         new_previous = self.output_overlap_header(previous)
-        if self.ctx:
-            source = self.ctx.get_parameter_source(cli_param)
-            self.logger.warning(f"stored {cli_param} value overrides the {cli_param} value from {source.name}")
+        sourceName = validation.get_parameter_source_name_from_ctx(cli_param, self.ctx)
+        self.logger.warning(f"- stored {cli_param} value overrides the {cli_param} value from {sourceName}\n")
         return new_previous
 
     def setup_remote_server(
@@ -514,6 +513,8 @@ class RSConnectExecutor:
                     header_output = self.output_overlap_details("token", header_output)
                 if server_data.secret and secret:
                     header_output = self.output_overlap_details("secret", header_output)
+                if header_output:
+                    self.logger.warning("\n")
 
         self.is_server_from_store = server_data.from_store
 

--- a/rsconnect/certificates.py
+++ b/rsconnect/certificates.py
@@ -21,12 +21,12 @@ def read_certificate_file(location: str):
     suffix = path.suffix
 
     if suffix in BINARY_ENCODED_FILETYPES:
-        with open(path, "rb") as file:
-            return file.read()
+        with open(path, "rb") as bFile:
+            return bFile.read()
 
     if suffix in TEXT_ENCODED_FILETYPES:
-        with open(path, "r") as file:
-            return file.read()
+        with open(path, "r") as tFile:
+            return tFile.read()
 
     types = BINARY_ENCODED_FILETYPES + TEXT_ENCODED_FILETYPES
     types = sorted(types)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -63,7 +63,7 @@ from .bundle import (
     fake_module_file_from_directory,
     get_python_env_info,
 )
-from .log import logger, LogOutputFormat
+from .log import logger, LogOutputFormat, VERBOSE
 from .metadata import ServerStore, AppStore
 from .models import (
     AppMode,
@@ -114,16 +114,16 @@ def output_params(
     vars,
 ):
     if click.__version__ >= "8.0.0" and sys.version_info >= (3, 7):
-        click.echo("Detected the following inputs:")
+        logger.log(VERBOSE, "Detected the following inputs:")
         for k, v in vars:
-            if k in {"ctx", "verbose"}:
+            if k in {"ctx", "verbose", "kwargs"}:
                 continue
             if v is not None:
                 val = v
                 if k in {"api_key", "api-key"}:
                     val = "**********"
                 sourceName = validation.get_parameter_source_name_from_ctx(k, ctx)
-                click.echo("    {}:\t{} (from {})".format(k, val, sourceName))
+                logger.log(VERBOSE, "    %-18s%s (from %s)", (k+":"), val, sourceName)
 
 
 def server_args(func):

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -123,7 +123,7 @@ def output_params(
                 varName = k.replace("-", "_")
                 if varName in {"api_key"}:
                     val = "**********"
-                source = ctx.get_parameter_source(varName)
+                source = ctx.get_parameter_source(varName)  # type: ignore
                 if source:
                     click.echo("    {}:\t{} (from {})".format(k, val, source.name))  # type: ignore
                 else:

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -120,14 +120,10 @@ def output_params(
                 continue
             if v is not None:
                 val = v
-                varName = k.replace("-", "_")
-                if varName in {"api_key"}:
+                if k in {"api_key", "api-key"}:
                     val = "**********"
-                source = ctx.get_parameter_source(varName)  # type: ignore
-                if source:
-                    click.echo("    {}:\t{} (from {})".format(k, val, source.name))  # type: ignore
-                else:
-                    click.echo("    {}:\t{}".format(k, val))
+                sourceName = validation.get_parameter_source_name_from_ctx(k, ctx)
+                click.echo("    {}:\t{} (from {})".format(k, val, sourceName))
 
 
 def server_args(func):

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -115,27 +115,30 @@ def server_args(func):
         "--server",
         "-s",
         envvar="CONNECT_SERVER",
-        help="The URL for the Posit Connect server to deploy to.",
+        help="The URL for the Posit Connect server to deploy to. \
+(Also settable via CONNECT_SERVER environment variable.)",
     )
     @click.option(
         "--api-key",
         "-k",
         envvar="CONNECT_API_KEY",
-        help="The API key to use to authenticate with Posit Connect.",
+        help="The API key to use to authenticate with Posit Connect. \
+(Also settable via CONNECT_API_KEY environment variable.)",
     )
     @click.option(
         "--insecure",
         "-i",
         envvar="CONNECT_INSECURE",
         is_flag=True,
-        help="Disable TLS certification/host validation.",
+        help="Disable TLS certification/host validation. (Also settable via CONNECT_INSECURE environment variable.)",
     )
     @click.option(
         "--cacert",
         "-c",
         envvar="CONNECT_CA_CERTIFICATE",
         type=click.Path(exists=True, file_okay=True, dir_okay=False),
-        help="The path to trusted TLS CA certificates.",
+        help="The path to trusted TLS CA certificates. (Also settable via \
+CONNECT_CA_CERTIFICATE environment variable.)",
     )
     @click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
     @functools.wraps(func)
@@ -150,19 +153,22 @@ def cloud_shinyapps_args(func):
         "--account",
         "-A",
         envvar=["SHINYAPPS_ACCOUNT"],
-        help="The shinyapps.io/Posit Cloud account name.",
+        help="The shinyapps.io/Posit Cloud account name. (Also settable via \
+SHINYAPPS_ACCOUNT environment variable.)",
     )
     @click.option(
         "--token",
         "-T",
         envvar=["SHINYAPPS_TOKEN", "RSCLOUD_TOKEN"],
-        help="The shinyapps.io/Posit Cloud token.",
+        help="The shinyapps.io/Posit Cloud token. (Also settable via \
+SHINYAPPS_TOKEN or RSCLOUD_TOKEN environment variables.)",
     )
     @click.option(
         "--secret",
         "-S",
         envvar=["SHINYAPPS_SECRET", "RSCLOUD_SECRET"],
-        help="The shinyapps.io/Posit Cloud token secret.",
+        help="The shinyapps.io/Posit Cloud token secret. \
+(Also settable via SHINYAPPS_SECRET or RSCLOUD_SECRET environment variables.)",
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -385,21 +391,21 @@ def _test_rstudio_creds(server: api.PositServer):
     "-s",
     envvar="CONNECT_SERVER",
     required=True,
-    help="The URL for the RStudio Connect server.",
+    help="The URL for the RStudio Connect server. (Also settable via CONNECT_SERVER environment variable.)",
 )
 @click.option(
     "--insecure",
     "-i",
     envvar="CONNECT_INSECURE",
     is_flag=True,
-    help="Disable TLS certification/host validation.",
+    help="Disable TLS certification/host validation. (Also settable via CONNECT_INSECURE environment variable.)",
 )
 @click.option(
     "--cacert",
     "-c",
     envvar="CONNECT_CA_CERTIFICATE",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
-    help="The path to trusted TLS CA certificates.",
+    help="The path to trusted TLS CA certificates. (Also settable via CONNECT_CA_CERTIFICATE environment variable.)",
 )
 @click.option(
     "--jwt-keypath",
@@ -468,27 +474,30 @@ def bootstrap(
     "--server",
     "-s",
     envvar="CONNECT_SERVER",
-    help="The URL for the Posit Connect server to deploy to, OR rstudio.cloud OR shinyapps.io.",
+    help="The URL for the Posit Connect server to deploy to, OR \
+rstudio.cloud OR shinyapps.io. (Also settable via CONNECT_SERVER \
+environment variable.)",
 )
 @click.option(
     "--api-key",
     "-k",
     envvar="CONNECT_API_KEY",
-    help="The API key to use to authenticate with Posit Connect.",
+    help="The API key to use to authenticate with Posit Connect. \
+(Also settable via CONNECT_API_KEY environment variable.)",
 )
 @click.option(
     "--insecure",
     "-i",
     envvar="CONNECT_INSECURE",
     is_flag=True,
-    help="Disable TLS certification/host validation.",
+    help="Disable TLS certification/host validation. (Also settable via CONNECT_INSECURE environment variable.)",
 )
 @click.option(
     "--cacert",
     "-c",
     envvar="CONNECT_CA_CERTIFICATE",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
-    help="The path to trusted TLS CA certificates.",
+    help="The path to trusted TLS CA certificates. (Also settable via CONNECT_CA_CERTIFICATE environment variable.)",
 )
 @click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
 @cloud_shinyapps_args
@@ -504,6 +513,7 @@ def add(ctx, name, server, api_key, insecure, cacert, account, token, secret, ve
                 click.echo("    {}: {}".format(k, ctx.get_parameter_source(k).name))
 
     validation.validate_connection_options(
+        ctx=ctx,
         url=server,
         api_key=api_key,
         insecure=insecure,
@@ -594,10 +604,19 @@ def list_servers(verbose):
 )
 @server_args
 @cli_exception_handler
-def details(name, server, api_key, insecure, cacert, verbose):
+@click.pass_context
+def details(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    verbose: int,
+):
     set_verbosity(verbose)
 
-    ce = RSConnectExecutor(name, server, api_key, insecure, cacert).validate_server()
+    ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert).validate_server()
 
     click.echo("    Posit Connect URL: %s" % ce.remote_server.url)
 
@@ -834,12 +853,14 @@ def _warn_on_ignored_requirements(directory, requirements_file_name):
     type=click.Path(exists=True, dir_okay=False, file_okay=True),
 )
 @cli_exception_handler
+@click.pass_context
 def deploy_notebook(
+    cli_ctx: click.Context,
     name: str,
     server: str,
     api_key: str,
     insecure: bool,
-    cacert: typing.IO,
+    cacert: str,
     static: bool,
     new: bool,
     app_id: str,
@@ -956,7 +977,9 @@ def deploy_notebook(
     type=click.Path(exists=True, dir_okay=False, file_okay=True),
 )
 @cli_exception_handler
+@click.pass_context
 def deploy_voila(
+    cli_ctx: click.Context,
     path: str = None,
     entrypoint: str = None,
     python=None,
@@ -1024,12 +1047,14 @@ def deploy_voila(
 @click.argument("file", type=click.Path(exists=True, dir_okay=True, file_okay=True))
 @shinyapps_deploy_args
 @cli_exception_handler
+@click.pass_context
 def deploy_manifest(
+    cli_ctx: click.Context,
     name: str,
     server: str,
     api_key: str,
     insecure: bool,
-    cacert: typing.IO,
+    cacert: str,
     account: str,
     token: str,
     secret: str,
@@ -1124,7 +1149,7 @@ def deploy_quarto(
     server: str,
     api_key: str,
     insecure: bool,
-    cacert: typing.IO,
+    cacert: str,
     new: bool,
     app_id: str,
     title: str,
@@ -1227,7 +1252,9 @@ def deploy_quarto(
     type=click.Path(exists=True, dir_okay=False, file_okay=True),
 )
 @cli_exception_handler
+@click.pass_context
 def deploy_html(
+    cli_ctx: click.Context,
     connect_server: api.RSConnectServer = None,
     path: str = None,
     entrypoint: str = None,
@@ -1338,12 +1365,14 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
     )
     @shinyapps_deploy_args
     @cli_exception_handler
+    @click.pass_context
     def deploy_app(
+        cli_ctx: click.Context,
         name: str,
         server: str,
         api_key: str,
         insecure: bool,
-        cacert: typing.IO,
+        cacert: str,
         entrypoint,
         exclude,
         new: bool,
@@ -1958,7 +1987,9 @@ def content():
 )
 # todo: --format option (json, text)
 @cli_exception_handler
+@click.pass_context
 def content_search(
+    cli_ctx: click.Context,
     name,
     server,
     api_key,
@@ -1975,7 +2006,7 @@ def content_search(
 ):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         result = search_content(
             ce.remote_server, published, unpublished, content_type, r_version, py_version, title_contains, order_by
         )
@@ -1998,10 +2029,20 @@ def content_search(
     help="The GUID of a content item to describe. This flag can be passed multiple times.",
 )
 # todo: --format option (json, text)
-def content_describe(name, server, api_key, insecure, cacert, guid, verbose):
+@click.pass_context
+def content_describe(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    guid: str,
+    verbose: int,
+):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         result = get_content(ce.remote_server, guid)
         json.dump(result, sys.stdout, indent=2)
 
@@ -2032,10 +2073,22 @@ def content_describe(name, server, api_key, insecure, cacert, guid, verbose):
     is_flag=True,
     help="Overwrite the output file if it already exists.",
 )
-def content_bundle_download(name, server, api_key, insecure, cacert, guid, output, overwrite, verbose):
+@click.pass_context
+def content_bundle_download(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    guid: str,
+    output: str,
+    overwrite: bool,
+    verbose: int,
+):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         if exists(output) and not overwrite:
             raise RSConnectException("The output file already exists: %s" % output)
 
@@ -2063,10 +2116,20 @@ def build():
     metavar="GUID[,BUNDLE_ID]",
     help="Add a content item by its guid. This flag can be passed multiple times.",
 )
-def add_content_build(name, server, api_key, insecure, cacert, guid, verbose):
+@click.pass_context
+def add_content_build(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    guid: str,
+    verbose: int,
+):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         build_add_content(ce.remote_server, guid)
         if len(guid) == 1:
             logger.info('Added "%s".' % guid[0])
@@ -2100,10 +2163,22 @@ def add_content_build(name, server, api_key, insecure, cacert, guid, verbose):
     is_flag=True,
     help="Remove build history and log files from the local filesystem.",
 )
-def remove_content_build(name, server, api_key, insecure, cacert, guid, all, purge, verbose):
+@click.pass_context
+def remove_content_build(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    guid: str,
+    all: bool,
+    purge: bool,
+    verbose: int,
+):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         _validate_build_rm_args(guid, all, purge)
         guids = build_remove_content(ce.remote_server, guid, all, purge)
         if len(guids) == 1:
@@ -2117,7 +2192,11 @@ def remove_content_build(name, server, api_key, insecure, cacert, guid, all, pur
     name="ls", short_help="List the content items that are being tracked for build on a given Connect server."
 )
 @server_args
-@click.option("--status", type=click.Choice(BuildStatus._all), help="Filter results by status of the build operation.")
+@click.option(
+    "--status",
+    type=click.Choice(BuildStatus._all),
+    help="Filter results by status of the build operation.",
+)
 @click.option(
     "--guid",
     "-g",
@@ -2128,10 +2207,21 @@ def remove_content_build(name, server, api_key, insecure, cacert, guid, all, pur
 )
 @click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
 # todo: --format option (json, text)
-def list_content_build(name, server, api_key, insecure, cacert, status, guid, verbose):
+@click.pass_context
+def list_content_build(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    status: str,
+    guid: str,
+    verbose: int,
+):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         result = build_list_content(ce.remote_server, guid, status)
         json.dump(result, sys.stdout, indent=2)
 
@@ -2148,10 +2238,20 @@ def list_content_build(name, server, api_key, insecure, cacert, status, guid, ve
     help="The guid of the content item.",
 )
 # todo: --format option (json, text)
-def get_build_history(name, server, api_key, insecure, cacert, guid, verbose):
+@click.pass_context
+def get_build_history(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    guid: str,
+    verbose: int,
+):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert)
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert)
         ce.validate_server()
         result = build_history(ce.remote_server, guid)
         json.dump(result, sys.stdout, indent=2)
@@ -2185,10 +2285,22 @@ def get_build_history(name, server, api_key, insecure, cacert, guid, verbose):
     default=LogOutputFormat.DEFAULT,
     help="The output format of the logs. Defaults to text.",
 )
-def get_build_logs(name, server, api_key, insecure, cacert, guid, task_id, format, verbose):
+@click.pass_context
+def get_build_logs(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    guid: str,
+    task_id: str,
+    format: str,
+    verbose: int,
+):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         for line in emit_build_log(ce.remote_server, guid, format, task_id):
             sys.stdout.write(line)
 
@@ -2221,14 +2333,32 @@ def get_build_logs(name, server, api_key, insecure, cacert, guid, task_id, forma
     default=LogOutputFormat.DEFAULT,
     help="The output format of the logs. Defaults to text.",
 )
-@click.option("--debug", is_flag=True, help="Log stacktraces from exceptions during background operations.")
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Log stacktraces from exceptions during background operations.",
+)
+@click.pass_context
 def start_content_build(
-    name, server, api_key, insecure, cacert, parallelism, aborted, error, all, poll_wait, format, debug, verbose
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    parallelism: int,
+    aborted: bool,
+    error: bool,
+    all: bool,
+    poll_wait: float,
+    format: str,
+    debug: bool,
+    verbose: int,
 ):
     set_verbosity(verbose)
     logger.set_log_output_format(format)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         build_start(ce.remote_server, parallelism, aborted, error, all, poll_wait, debug)
 
 
@@ -2251,7 +2381,7 @@ def caches():
 def system_caches_list(name, server, api_key, insecure, cacert, verbose):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(None, name, server, api_key, insecure, cacert, logger=None).validate_server()
         result = ce.runtime_caches
         json.dump(result, sys.stdout, indent=2)
 
@@ -2284,10 +2414,23 @@ def system_caches_list(name, server, api_key, insecure, cacert, verbose):
     is_flag=True,
     help="If true, verify that deletion would occur, but do not delete.",
 )
-def system_caches_delete(name, server, api_key, insecure, cacert, verbose, language, version, image_name, dry_run):
+@click.pass_context
+def system_caches_delete(
+    cli_ctx: click.Context,
+    name: str,
+    server: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    verbose: int,
+    language: str,
+    version: str,
+    image_name: str,
+    dry_run: bool,
+):
     set_verbosity(verbose)
     with cli_feedback("", stderr=True):
-        ce = RSConnectExecutor(name, server, api_key, insecure, cacert, logger=None).validate_server()
+        ce = RSConnectExecutor(cli_ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         ce.delete_runtime_cache(language, version, image_name, dry_run)
 
 

--- a/rsconnect/validation.py
+++ b/rsconnect/validation.py
@@ -115,7 +115,7 @@ See command help for further details."
         if len(present_cloud_options) != len(cloud_options):
             raise RSConnectException(
                 "-T/--token and -S/--secret must be provided for Posit Cloud. \
- See command help for further details."
+See command help for further details."
             )
     elif present_shinyapps_options:
         if len(present_shinyapps_options) != len(shinyapps_options):

--- a/rsconnect/validation.py
+++ b/rsconnect/validation.py
@@ -7,7 +7,7 @@ from rsconnect.exception import RSConnectException
 
 def _get_present_options(
     options: typing.Dict[str, typing.Optional[typing.Any]],
-    ctx: click.Context = None,
+    ctx: click.Context,
 ) -> typing.List[str]:
     result: typing.List[str] = []
     for k, v in options.items():
@@ -15,8 +15,8 @@ def _get_present_options(
             parts = k.split("--")
             if ctx and len(parts) == 2:
                 varName = parts[1].replace("-", "_")
-                source = ctx.get_parameter_source(varName)
-                sourceName = source.name  # type: ignore
+                source = ctx.get_parameter_source(varName)  # type: ignore
+                sourceName = source.name
                 result.append(f"{k} (from {sourceName})")
             else:
                 result.append(f"{k}")

--- a/rsconnect/validation.py
+++ b/rsconnect/validation.py
@@ -14,8 +14,10 @@ def _get_present_options(
         if v:
             parts = k.split("--")
             if ctx and len(parts) == 2:
-                source = ctx.get_parameter_source(parts[1]).name  # type: ignore
-                result.append(f"{k} (from {source})")
+                varName = parts[1].replace("-", "_")
+                source = ctx.get_parameter_source(varName)
+                sourceName = source.name  # type: ignore
+                result.append(f"{k} (from {sourceName})")
             else:
                 result.append(f"{k}")
     return result

--- a/rsconnect/validation.py
+++ b/rsconnect/validation.py
@@ -1,46 +1,119 @@
 import typing
 
+import click
+
 from rsconnect.exception import RSConnectException
 
 
-def _get_present_options(options: typing.Dict[str, typing.Optional[str]]) -> typing.List[str]:
-    return [k for k, v in options.items() if v]
+def _get_present_options(
+    options: typing.Dict[str, typing.Optional[typing.Any]],
+    ctx: click.Context = None,
+) -> typing.List[str]:
+    result: typing.List[str] = []
+    for k, v in options.items():
+        if v:
+            parts = k.split("--")
+            if ctx and len(parts) == 2:
+                source = ctx.get_parameter_source(parts[1]).name  # type: ignore
+                result.append(f"{k} (from {source})")
+            else:
+                result.append(f"{k}")
+    return result
 
 
-def validate_connection_options(url, api_key, insecure, cacert, account_name, token, secret, name=None):
+def validate_connection_options(
+    ctx: click.Context,
+    url: str,
+    api_key: str,
+    insecure: bool,
+    cacert: str,
+    account_name: str,
+    token: str,
+    secret: str,
+    name: str = None,
+):
     """
     Validates provided Connect or shinyapps.io connection options and returns which target to use given the provided
     options.
+
+    rsconnect deploy api --name localhost ./python-bottle-py3
+    should fail w/
+    -s/--server or CONNECT_SERVER
+    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
+    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
+    -A/--account or SHINYAPPS_ACCOUNT
+
+    FAILURE if not any of:
+    -n/--name
+    -s/--server or CONNECT_SERVER
+    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
+    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
+    -A/--account or SHINYAPPS_ACCOUNT
+
+    FAILURE if any of:
+    -k/--api-key or CONNECT_API_KEY
+    -i/--insecure or CONNECT_INSECURE
+    -c/--cacert or CONNECT_CA_CERTIFICATE
+    AND any of:
+    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
+    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
+    -A/--account or SHINYAPPS_ACCOUNT
+
+    FAILURE if specify -s/--server or CONNECT_SERVER and it includes "posit.cloud" or "rstudio.cloud"
+    and not specified all of following:
+    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
+    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
+
+    FAILURE if any of following are specified, without the rest:
+    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
+    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
+    -A/--account or SHINYAPPS_ACCOUNT
     """
     connect_options = {"-k/--api-key": api_key, "-i/--insecure": insecure, "-c/--cacert": cacert}
     shinyapps_options = {"-T/--token": token, "-S/--secret": secret, "-A/--account": account_name}
     cloud_options = {"-T/--token": token, "-S/--secret": secret}
     options_mutually_exclusive_with_name = {"-s/--server": url, **shinyapps_options}
-    present_options_mutually_exclusive_with_name = _get_present_options(options_mutually_exclusive_with_name)
+    present_options_mutually_exclusive_with_name = _get_present_options(options_mutually_exclusive_with_name, ctx)
 
     if name and present_options_mutually_exclusive_with_name:
-        raise RSConnectException(
-            "-n/--name cannot be specified in conjunction with options {}".format(
-                ", ".join(present_options_mutually_exclusive_with_name)
+        if ctx:
+            name_source = ctx.get_parameter_source("name").name  # type: ignore
+            raise RSConnectException(
+                f"-n/--name (from {name_source}) cannot be specified in conjunction with options \
+{', '.join(present_options_mutually_exclusive_with_name)}. See command help for further details."
             )
-        )
-    if not name and not url and not shinyapps_options:
-        raise RSConnectException("You must specify one of -n/--name OR -s/--server OR  T/--token, -S/--secret.")
+        else:
+            raise RSConnectException(
+                f"-n/--name cannot be specified in conjunction with options \
+{', '.join(present_options_mutually_exclusive_with_name)}. See command help for further details."
+            )
 
-    present_connect_options = _get_present_options(connect_options)
-    present_shinyapps_options = _get_present_options(shinyapps_options)
-    present_cloud_options = _get_present_options(cloud_options)
+    if not name and not url and not shinyapps_options:
+        raise RSConnectException(
+            "You must specify one of -n/--name OR -s/--server OR  T/--token, -S/--secret, \
+either via command options or environment variables. See command help for further details."
+        )
+
+    present_connect_options = _get_present_options(connect_options, ctx)
+    present_shinyapps_options = _get_present_options(shinyapps_options, ctx)
+    present_cloud_options = _get_present_options(cloud_options, ctx)
 
     if present_connect_options and present_shinyapps_options:
         raise RSConnectException(
-            "Connect options ({}) may not be passed alongside shinyapps.io or Posit Cloud options ({}).".format(
-                ", ".join(present_connect_options), ", ".join(present_shinyapps_options)
-            )
+            f"Connect options ({', '.join(present_connect_options)}) may not be passed \
+alongside shinyapps.io or Posit Cloud options ({', '.join(present_shinyapps_options)}). \
+See command help for further details."
         )
 
     if url and ("posit.cloud" in url or "rstudio.cloud" in url):
         if len(present_cloud_options) != len(cloud_options):
-            raise RSConnectException("-T/--token and -S/--secret must be provided for Posit Cloud.")
+            raise RSConnectException(
+                "-T/--token and -S/--secret must be provided for Posit Cloud. \
+ See command help for further details."
+            )
     elif present_shinyapps_options:
         if len(present_shinyapps_options) != len(shinyapps_options):
-            raise RSConnectException("-A/--account, -T/--token, and -S/--secret must all be provided for shinyapps.io.")
+            raise RSConnectException(
+                "-A/--account, -T/--token, and -S/--secret must all be provided \
+for shinyapps.io. See command help for further details."
+            )

--- a/rsconnect/validation.py
+++ b/rsconnect/validation.py
@@ -4,6 +4,7 @@ import click
 
 from rsconnect.exception import RSConnectException
 
+
 def get_parameter_source_name_from_ctx(
     var_or_param_name: str,
     ctx: click.Context,
@@ -14,6 +15,7 @@ def get_parameter_source_name_from_ctx(
         if source and source.name:
             return source.name
     return "<source unknown>"
+
 
 def _get_present_options(
     options: typing.Dict[str, typing.Optional[typing.Any]],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,7 @@ class TestAPI(TestCase):
     def test_executor_init(self):
         connect_server = require_connect()
         api_key = require_api_key()
-        ce = RSConnectExecutor(None, connect_server, api_key, True, None)
+        ce = RSConnectExecutor(None, None, connect_server, api_key, True, None)
         self.assertEqual(ce.remote_server.url, connect_server)
 
     def test_output_task_log(self):
@@ -70,7 +70,7 @@ class TestAPI(TestCase):
     def test_make_deployment_name(self):
         connect_server = require_connect()
         api_key = require_api_key()
-        ce = RSConnectExecutor(None, connect_server, api_key, True, None)
+        ce = RSConnectExecutor(None, None, connect_server, api_key, True, None)
         self.assertEqual(ce.make_deployment_name("title", False), "title")
         self.assertEqual(ce.make_deployment_name("Title", False), "title")
         self.assertEqual(ce.make_deployment_name("My Title", False), "my_title")
@@ -100,7 +100,7 @@ class TestSystemRuntimeCachesAPI(TestCase):
     # RSConnectExecutor.runtime_caches returns the resulting JSON from the server.
     @httpretty.activate(verbose=True, allow_net_connect=False)
     def test_client_system_caches_runtime_list(self):
-        ce = RSConnectExecutor(None, "http://test-server/", "api_key")
+        ce = RSConnectExecutor(None, None, "http://test-server/", "api_key")
         mocked_response = {
             "caches": [
                 {"language": "R", "version": "3.6.3", "image_name": "Local"},
@@ -121,7 +121,7 @@ class TestSystemRuntimeCachesAPI(TestCase):
     # RSConnectExecutor.delete_runtime_cache() dry run prints expected messages
     @httpretty.activate(verbose=True, allow_net_connect=False)
     def test_executor_delete_runtime_cache_dry_run(self):
-        ce = RSConnectExecutor(None, "http://test-server/", "api_key")
+        ce = RSConnectExecutor(None, None, "http://test-server/", "api_key")
         mocked_output = {"language": "Python", "version": "1.2.3", "image_name": "teapot", "task_id": None}
 
         httpretty.register_uri(
@@ -148,7 +148,7 @@ class TestSystemRuntimeCachesAPI(TestCase):
     # RSConnectExecutor.delete_runtime_cache() wet run prints expected messages
     @httpretty.activate(verbose=True, allow_net_connect=False)
     def test_executor_delete_runtime_cache_wet_run(self):
-        ce = RSConnectExecutor(None, "http://test-server/", "api_key")
+        ce = RSConnectExecutor(None, None, "http://test-server/", "api_key")
         mocked_delete_output = {
             "language": "Python",
             "version": "1.2.3",
@@ -197,7 +197,7 @@ class TestSystemRuntimeCachesAPI(TestCase):
     # RSConnectExecutor.delete_runtime_cache() raises the correct error
     @httpretty.activate(verbose=True, allow_net_connect=False)
     def test_executor_delete_runtime_cache_error(self):
-        ce = RSConnectExecutor(None, "http://test-server/", "api_key")
+        ce = RSConnectExecutor(None, None, "http://test-server/", "api_key")
         mocked_delete_output = {"code": 4, "error": "Cache does not exist", "payload": None}
         httpretty.register_uri(
             httpretty.DELETE,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1152,10 +1152,8 @@ class TestBootstrap(TestCase):
         result = runner.invoke(cli, ["bootstrap", "--server", "123.some.ip.address", "--jwt-keypath", self.jwt_keypath])
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertGreater(
-            result.output.find("Error: Server URL expected to begin with transfer protocol (ex. http/https).\n"), 
-            -1
+            result.output.find("Error: Server URL expected to begin with transfer protocol (ex. http/https).\n"), -1
         )
-
 
     def test_boostrap_missing_jwt_option(self):
         """
@@ -1165,8 +1163,7 @@ class TestBootstrap(TestCase):
         result = runner.invoke(cli, ["bootstrap", "--server", "http://a_server"])
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertGreater(
-            result.output.find("Error: Must specify secret key using either a keyfile or environment variable.\n"), 
-            -1
+            result.output.find("Error: Must specify secret key using either a keyfile or environment variable.\n"), -1
         )
 
     def test_bootstrap_conflicting_jwt_option(self):
@@ -1179,8 +1176,7 @@ class TestBootstrap(TestCase):
         result = runner.invoke(cli, self.default_cli_args)
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertGreater(
-            result.output.find("Error: Cannot specify secret key using both a keyfile and environment variable."), 
-            -1
+            result.output.find("Error: Cannot specify secret key using both a keyfile and environment variable."), -1
         )
 
         del os.environ[SECRET_KEY_ENV]
@@ -1195,8 +1191,10 @@ class TestBootstrap(TestCase):
         result = runner.invoke(cli, ["bootstrap", "--server", "http://a_server"])
         self.assertEqual(result.exit_code, 1, result.output)
         self.assertGreater(
-            result.output.find("Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRETKEY\n"), 
-            -1
+            result.output.find(
+                "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRETKEY\n"
+            ),
+            -1,
         )
 
         del os.environ[SECRET_KEY_ENV]
@@ -1238,7 +1236,4 @@ class TestBootstrap(TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
 
-        self.assertEqual(
-            result.output.find("Error:"), 
-            -1
-        )
+        self.assertEqual(result.output.find("Error:"), -1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1141,7 +1141,7 @@ class TestBootstrap(TestCase):
         runner = CliRunner()
         result = runner.invoke(cli, ["bootstrap", "--server", "http://host:port", "--jwt-keypath", "this/is/invalid"])
         self.assertEqual(result.exit_code, 1, result.output)
-        self.assertEqual(result.output, "Error: Keypath does not exist.\n")
+        self.assertGreater(result.output.find("Error: Keypath does not exist."), -1)
 
     def test_bootstrap_invalid_server(self):
         """
@@ -1151,9 +1151,11 @@ class TestBootstrap(TestCase):
         runner = CliRunner()
         result = runner.invoke(cli, ["bootstrap", "--server", "123.some.ip.address", "--jwt-keypath", self.jwt_keypath])
         self.assertEqual(result.exit_code, 1, result.output)
-        self.assertEqual(
-            result.output, "Error: Server URL expected to begin with transfer protocol (ex. http/https).\n"
+        self.assertGreater(
+            result.output.find("Error: Server URL expected to begin with transfer protocol (ex. http/https).\n"), 
+            -1
         )
+
 
     def test_boostrap_missing_jwt_option(self):
         """
@@ -1162,8 +1164,9 @@ class TestBootstrap(TestCase):
         runner = CliRunner()
         result = runner.invoke(cli, ["bootstrap", "--server", "http://a_server"])
         self.assertEqual(result.exit_code, 1, result.output)
-        self.assertEqual(
-            result.output, "Error: Must specify secret key using either a keyfile or environment variable.\n"
+        self.assertGreater(
+            result.output.find("Error: Must specify secret key using either a keyfile or environment variable.\n"), 
+            -1
         )
 
     def test_bootstrap_conflicting_jwt_option(self):
@@ -1175,8 +1178,9 @@ class TestBootstrap(TestCase):
         runner = CliRunner()
         result = runner.invoke(cli, self.default_cli_args)
         self.assertEqual(result.exit_code, 1, result.output)
-        self.assertEqual(
-            result.output, "Error: Cannot specify secret key using both a keyfile and environment variable.\n"
+        self.assertGreater(
+            result.output.find("Error: Cannot specify secret key using both a keyfile and environment variable."), 
+            -1
         )
 
         del os.environ[SECRET_KEY_ENV]
@@ -1190,9 +1194,9 @@ class TestBootstrap(TestCase):
         runner = CliRunner()
         result = runner.invoke(cli, ["bootstrap", "--server", "http://a_server"])
         self.assertEqual(result.exit_code, 1, result.output)
-        self.assertEqual(
-            result.output,
-            "Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRETKEY\n",
+        self.assertGreater(
+            result.output.find("Error: Unable to decode base64 data from environment variable: CONNECT_BOOTSTRAP_SECRETKEY\n"), 
+            -1
         )
 
         del os.environ[SECRET_KEY_ENV]
@@ -1234,4 +1238,7 @@ class TestBootstrap(TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
 
-        self.assertEqual(result.output, "\n")
+        self.assertEqual(
+            result.output.find("Error:"), 
+            -1
+        )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -918,7 +918,8 @@ class TestMain:
             assert result.exit_code == 1, result.output
             assert (
                 str(result.exception)
-                == "-A/--account, -T/--token, and -S/--secret must all be provided for shinyapps.io."
+                == "-A/--account, -T/--token, and -S/--secret must all be provided for shinyapps.io. \
+See command help for further details."
             )
         finally:
             if original_api_key_value:


### PR DESCRIPTION
## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

Provide visibility into what environment variables are used as defaults for options. Also provide the source of where options were set (via environment variable, defaults, command line) when producing error messages to show conflicting values across options.

Resolves #423 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [X] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

The click library provides an interface that will describe the source of an option. This source was added to the string being thrown when an exception was being produced for the multi-option validation errors.

To better enable the user to resolve the issue when they receive one of these errors, I also enhanced the help output for those options which also may be set via an environment variable.

Detailed description of what I've changed: 
- use click library to identify source of conflicting parameters
- update help output to display possible source of options - env or cmd
- internal documentation of failure case where complex logic used
- Types added for functions where click context passed down
- Type errors fixed after new type hints
- Errors updated to mention environment variables
- Unit tests updated
- Most complex commands now output what parameters they are using (values and their source), when verbose option provided

**Examples of new help output:**

![2023-10-24 at 10 24 AM](https://github.com/rstudio/rsconnect-python/assets/17675905/6add3d70-25e0-47a6-959f-94539135a174)

**Examples of enhanced error output**

![2023-11-09 at 2 12 PM](https://github.com/rstudio/rsconnect-python/assets/17675905/4ccd2bad-c797-4702-8489-29ba85740d82)


## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->
Some failure conditions are already included within the unit tests.

I've outlined the combinations of conflicting or missing options below (and within the code) that will produce validation errors. After discussing with @kgartland-rstudio , he will be adding validation for the messages below to rsconnect-python tests present within the Connect repo.

For example: rsconnect deploy api --name localhost ./python-bottle-py3

    should fail w/
    -s/--server or CONNECT_SERVER
    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
    -A/--account or SHINYAPPS_ACCOUNT

    FAILURE if not any of:
    -n/--name
    -s/--server or CONNECT_SERVER
    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
    -A/--account or SHINYAPPS_ACCOUNT

    FAILURE if any of:
    -k/--api-key or CONNECT_API_KEY
    -i/--insecure or CONNECT_INSECURE
    -c/--cacert or CONNECT_CA_CERTIFICATE
    AND any of:
    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
    -A/--account or SHINYAPPS_ACCOUNT

    FAILURE if specify -s/--server or CONNECT_SERVER and it includes "posit.cloud" or "rstudio.cloud"
    and not specified all of following:
    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET

    FAILURE if any of following are specified, without the rest:
    -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
    -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
    -A/--account or SHINYAPPS_ACCOUNT

**Impacted commands needing validation:**

- rsconnect system caches delete
- rsconnect system caches list
- rsconnect content build run
- rsconnect content build logs
- rsconnect content build history
- rsconnect content build ls
- rsconnect content build rm
- rsconnect content build add
- rsconnect content download-bundle
- rsconnect content describe
- rsconnect content search
- rsconnect write-manifest api
- rsconnect write-manifest bokeh
- rsconnect write-manifest dash
- rsconnect write-manifest fastapi
- rsconnect write-manifest flask
- rsconnect write-manifest notebook
- rsconnect write-manifest quarto
- rsconnect write-manifest shiny
- rsconnect write-manifest streamlit
- rsconnect write-manifest voila
- rsconnect deploy api 
- rsconnect deploy bokeh
- rsconnect deploy dash
- rsconnect deploy fastapi
- rsconnect deploy flask
- rsconnect deploy html
- rsconnect deploy manifest
- rsconnect deploy notebook
- rsconnect deploy other-content
- rsconnect deploy quarto
- rsconnect deploy shiny
- rsconnect deploy streamlit
- rsconnect deploy voila
- rsconnect remove
- rsconnect details
- rsconnect add

**help output to include env variables - static string**

Any check of help against a single command which accepts server parameters will validate for all usage. 

For example: `rsconnect deploy bokeh --help`:

```
Usage: rsconnect deploy bokeh [OPTIONS] DIRECTORY [EXTRA_FILES]...

  Deploy a Bokeh Application module to Posit Connect, Posit Cloud, or
  shinyapps.io (if supported by the platform). The "directory" argument must
  refer to an existing directory that contains the application code.

Options:
  -n, --name TEXT                 The nickname of the Posit Connect server to
                                  deploy to.
  -s, --server TEXT               The URL for the Posit Connect server to
                                  deploy to. (Also settable via CONNECT_SERVER
                                  environment variable.)
  -k, --api-key TEXT              The API key to use to authenticate with
                                  Posit Connect. (Also settable via
                                  CONNECT_API_KEY environment variable.)
  -i, --insecure                  Disable TLS certification/host validation.
                                  (Also settable via CONNECT_INSECURE
                                  environment variable.)
  -c, --cacert FILE               The path to trusted TLS CA certificates.
                                  (Also settable via CONNECT_CA_CERTIFICATE
                                  environment variable.)
  -v, --verbose                   Enable verbose output. Use -vv for very
                                  verbose (debug) output.
  -N, --new                       Force a new deployment, even if there is
                                  saved metadata from a previous deployment.
                                  Cannot be used with --app-id.
  -a, --app-id TEXT               Existing app ID or GUID to replace. Cannot
                                  be used with --new.
  -t, --title TEXT                Title of the content (default is the same as
                                  the filename).
  -E, --environment TEXT          Set an environment variable. Specify a value
                                  with NAME=VALUE, or just NAME to use the
                                  value from the local environment. May be
                                  specified multiple times. [v1.8.6+]
  --no-verify                     Don't access the deployed content to verify
                                  that it started correctly.
  -A, --account TEXT              The shinyapps.io/Posit Cloud account name.
                                  (Also settable via SHINYAPPS_ACCOUNT
                                  environment variable.)
  -T, --token TEXT                The shinyapps.io/Posit Cloud token. (Also
                                  settable via SHINYAPPS_TOKEN or
                                  RSCLOUD_TOKEN environment variables.)
  -S, --secret TEXT               The shinyapps.io/Posit Cloud token secret.
                                  (Also settable via SHINYAPPS_SECRET or
                                  RSCLOUD_SECRET environment variables.)
  -I, --image TEXT                Target image to be used during content build
                                  and execution. This option is only
                                  applicable if the Connect server is
                                  configured to use off-host execution.
  --disable-env-management        Shorthand to disable environment management
                                  for both Python and R.
  --disable-env-management-py     Disable Python environment management for
                                  this bundle. Connect will not create an
                                  environment or install packages. An
                                  administrator must install the required
                                  packages in the correct Python environment
                                  on the Connect server.
  --disable-env-management-r      Disable R environment management for this
                                  bundle. Connect will not create an
                                  environment or install packages. An
                                  administrator must install the required
                                  packages in the correct R environment on the
                                  Connect server.
  -e, --entrypoint TEXT           The module and executable object which
                                  serves as the entry point for the Bokeh
                                  Application (defaults to app)
  -x, --exclude TEXT              Specify a glob pattern for ignoring files
                                  when building the bundle. Note that your
                                  shell may try to expand this which will not
                                  do what you expect. Generally, it's safest
                                  to quote the pattern. This option may be
                                  repeated.
  -p, --python PATH               Path to Python interpreter whose environment
                                  should be used. The Python environment must
                                  have the rsconnect package installed.
  -g, --force-generate            Force generating "requirements.txt", even if
                                  it already exists.
  -V, --visibility [public|private]
                                  The visibility of the resource being
                                  deployed. (shinyapps.io only; must be public
                                  (default) or private)
  --help                          Show this message and exit.
```

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

You can validate some of the combinations above manually, as well as execute the help commands.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
