### PR TITLE
Include ctx in executor init

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1439,6 +1439,7 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
         )
 
         ce = RSConnectExecutor(
+            ctx=ctx,
             name=name,
             api_key=api_key,
             insecure=insecure,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
PR #521 cleaned up the executor parameters (on my recommendation). However, we lost the `ctx` parameter, and this causes parameter source checking to return `<unknown source>` instead of the parameter source.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->
