### PR TITLE
Use requirements.txt in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /rsconnect
 COPY scripts/build-image build-image
+COPY requirements.txt .
 RUN bash build-image && rm -vf build-image

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -8,4 +8,4 @@ set -o xtrace
   exit 1
 }
 python -m pip install --upgrade pip
-pip install '.[test]'
+pip install -r requirements.txt


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
This PR fixes the `make image-*` target, which currently fails because the `.[test]` is not installable within the docker build. Instead, we're using `pip install -r requirements.txt`.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Automated Tests
This is used in as part of running `make test` locally.

## Directions for Reviewers
```
make image-3.8
make test-3.8
```
