### PR TITLE
Follow symlinks when building bundle

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -578,6 +578,7 @@ def list_files(
     base_dir: str,
     include_sub_dirs: bool,
     walk: Callable[[str], Iterator[tuple[str, list[str], list[str]]]] = os.walk,
+    followlinks: bool = True,
 ) -> list[str]:
     """List the files in the directory at path.
 
@@ -1259,7 +1260,7 @@ def create_file_list(
         file_set.add(path_to_add)
         return sorted(file_set)
 
-    for cur_dir, _, files in os.walk(path):
+    for cur_dir, _, files in os.walk(path, followlinks=True):
         if Path(cur_dir) in exclude_paths:
             continue
         if any(parent in exclude_paths for parent in Path(cur_dir).parents):

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -574,37 +574,6 @@ def write_manifest(
     return created, skipped
 
 
-def list_files(
-    base_dir: str,
-    include_sub_dirs: bool,
-    walk: Callable[[str], Iterator[tuple[str, list[str], list[str]]]] = os.walk,
-    followlinks: bool = True,
-) -> list[str]:
-    """List the files in the directory at path.
-
-    If include_sub_dirs is True, recursively list
-    files in subdirectories.
-
-    Returns an iterable of file paths relative to base_dir.
-    """
-    skip_dirs = [".ipynb_checkpoints", ".git"]
-
-    def iter_files():
-        for root, sub_dirs, files in walk(base_dir):
-            if include_sub_dirs:
-                for skip in skip_dirs:
-                    if skip in sub_dirs:
-                        sub_dirs.remove(skip)
-            else:
-                # tell walk not to traverse any subdirectories
-                sub_dirs[:] = []
-
-            for filename in files:
-                yield relpath(join(root, filename), base_dir)
-
-    return list(iter_files())
-
-
 def make_notebook_source_bundle(
     file: str,
     environment: Environment,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -20,7 +20,6 @@ from rsconnect.bundle import (
     get_default_node_entrypoint,
     guess_deploy_dir,
     keep_manifest_specified_file,
-    list_files,
     make_api_bundle,
     make_api_manifest,
     make_html_bundle,
@@ -685,41 +684,6 @@ class TestBundle(TestCase):
                     },
                 },
             )
-
-    def test_list_files(self):
-        # noinspection SpellCheckingInspection
-        paths = [
-            "notebook.ipynb",
-            "somedata.csv",
-            os.path.join("subdir", "subfile"),
-            os.path.join("subdir2", "subfile2"),
-            os.path.join(".ipynb_checkpoints", "notebook.ipynb"),
-            os.path.join(".git", "config"),
-        ]
-
-        def walk(base_dir):
-            dir_names = []
-            file_names = []
-
-            for path in paths:
-                if os.sep in path:
-                    dir_name, file_name = path.split(os.sep, 1)
-                    dir_names.append(dir_name)
-                else:
-                    file_names.append(path)
-
-            yield base_dir, dir_names, file_names
-
-            for subdir in dir_names:
-                for path in paths:
-                    if path.startswith(subdir + os.sep):
-                        yield base_dir + os.sep + subdir, [], [path.split(os.sep, 1)[1]]
-
-        files = list_files(".", True, walk=walk)
-        self.assertEqual(files, paths[:4])
-
-        files = list_files(os.sep, False, walk=walk)
-        self.assertEqual(files, paths[:2])
 
     def test_html_bundle1(self):
         self.do_test_html_bundle(get_dir("pip1"))


### PR DESCRIPTION
I have NOT tested this on Windows, only Mac. Please nobody merge until I've tested.

## Intent
Fixes #414. When building a bundle, follow symlinks. This allows apps to include directories that might live somewhere else for deduplication/centralization reasons.

## Type of Change
- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
`os.walk` takes a `followlinks` argument that defaults to `False`. I simply set this to `True`. Note that from googling, `os.walk` doesn't check for circular references--I'm happy to add that if we think it's important.

## Automated Tests
TODO

## Directions for Reviewers
Create two sibling directories, one called `data` and one called `shinytest`.

shinytest/app.py:
```
from pathlib import Path
from shiny.express import input, ui

msg_path = Path(__file__).parent / "data/message.txt"

with open(msg_path) as f:
    f.read()
```

data/message.txt:
```
Hello, world!
```

Then, from within the shinytest directory, run `ln -s ../data data`.

Deploy from within the shinytest directory as usual, and see if it crashes on startup or the message correctly appears instead.

## Checklist
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
