### PR TITLE
quarto: adjust manifest construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `starlette>=0.35.0`. When deploying to these servers, the starlette version
   is now automatically set to `starlette<0.35.0`.
 
+### Fixed
+
+- Quarto content is marked as a "site" only when there are multiple input
+  files. (#552)
+
+- Quarto content automatically ignores `name.html` and `name_files` when
+  `name.md`, `name.ipynb`, `name.Rmd`, or `name.qmd` is an input. (#553)
+
 ### Removed
 
 - Python 3.7 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quarto content automatically ignores `name.html` and `name_files` when
   `name.md`, `name.ipynb`, `name.Rmd`, or `name.qmd` is an input. (#553)
 
+- Patterns provided to `--exclude` allow NT-style paths on Windows. (#320)
+
 ### Removed
 
 - Python 3.7 support.

--- a/README.md
+++ b/README.md
@@ -319,6 +319,15 @@ The following shows an example of an extra file taking precedence:
 rsconnect deploy dash --exclude “*.csv” dash-app/ important_data.csv
 ```
 
+The "`**`" glob pattern will recursively match all files and directories,
+while "`*`" only matches files. The "`**`" pattern is useful with complicated
+project hierarchies where enumerating the _included_ files is simpler than
+listing the _exclusions_.
+
+```bash
+rsconnect deploy quarto . _quarto.yml index.qmd requirements.txt --exclude "**" 
+```
+
 Some directories are excluded by default, to prevent bundling and uploading files that are not needed or might interfere with the deployment process:
 
 ```

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -2,7 +2,7 @@
 Data models
 """
 
-import os
+import pathlib
 import re
 
 import fnmatch
@@ -163,6 +163,7 @@ class GlobMatcher(object):
     """
 
     def __init__(self, pattern):
+        pattern = pathlib.PurePath(pattern).as_posix()
         if pattern.endswith("/**/*"):
             # Note: the index used here makes sure the pattern has a trailing
             # slash.  We want that.
@@ -185,7 +186,8 @@ class GlobMatcher(object):
         :return: a list of pattern pieces and the index of the special '**' pattern.
         The index will be None if `**` is never found.
         """
-        parts = pattern.split(os.path.sep)
+        # Incoming pattern is ALWAYS a Posix-style path.
+        parts = pattern.split("/")
         depth_wildcard_index = None
         for index, name in enumerate(parts):
             if name == "**":
@@ -197,10 +199,12 @@ class GlobMatcher(object):
         return parts, depth_wildcard_index
 
     def _match_with_starts_with(self, path):
+        path = pathlib.PurePath(path).as_posix()
         return path.startswith(self._pattern)
 
     def _match_with_list_parts(self, path):
-        parts = path.split(os.path.sep)
+        path = pathlib.PurePath(path).as_posix()
+        parts = path.split("/")
 
         def items_match(i1, i2):
             if i2 >= len(parts):


### PR DESCRIPTION
## Intent

* multi-file project according to files.input
* automatic ignores according to files.input
* glob handling allows posix OS path separators (`/` and optionally `\\`)
* documentation for '**'

fixes #552
fixes #553
fixes #551
fixes #320

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Actively iterating and deploying different types of Quarto content; filed each of the linked issues based on observations.

## Automated Tests

* Expanded Quarto single-file, simple project and multi-file project tests. Confirm that intermediate and rendered output is ignored, that simple projects are not classified as sites.
* Expanded glob tests to test using "/" and host-specific ("/" and "\\") path separators.

## Directions for Reviewers

> If your content is within a Git repository, Quarto may create a `.gitignore` file.
> If it exists, `.gitignore` will show up in the `manifest.json` for projects.

Simple Quarto document

```bash
mkdir simple
cd simple
touch index.qmd
rsconnect write-manifest quarto index.qmd
# confirm that this is quarto-static content and only index.qmd is a target file
```

Simple Quarto document, rendered

```bash
mkdir simple-rendered
cd simple-rendered
touch index.qmd
quarto render index.qmd
rsconnect write-manifest quarto index.qmd
# confirm that this is quarto-static content and only index.qmd is a target file
```

Simple Quarto project

```bash
mkdir simple-project
cd simple-project
echo "project:\n  type: default" > _quarto.yml
touch index.qmd
rsconnect write-manifest quarto .
# confirm that this is quarto-static content with _quarto.yml and index.qmd target files
```

Simple Quarto project, rendered

```bash
mkdir simple-project-rendered
cd simple-project-rendered
echo "project:\n  type: default" > _quarto.yml
touch index.qmd
quarto render
rsconnect write-manifest quarto .
# confirm that this is quarto-static content with _quarto.yml and index.qmd target files
```

Simple Quarto website

```bash
mkdir simple-website
cd simple-website
echo "project:\n  type: website" > _quarto.yml
touch index.qmd
touch about.qmd
rsconnect write-manifest quarto .
# confirm that this is quarto-static content with _quarto.yml, index.qmd, about.qmd target files
# confirm that this is marked as a "site"
```

Simple Quarto project, rendered

```bash
mkdir simple-website-rendered
cd simple-website-rendered
echo "project:\n  type: website" > _quarto.yml
touch index.qmd
touch about.qmd
quarto render
rsconnect write-manifest quarto .
# confirm that this is quarto-static content with _quarto.yml, index.qmd, about.qmd target files
# confirm that this is marked as a "site"
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
