### PR TITLE
remove python 3.7 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
         - os: macos-latest
           python-version: '3.9'

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         include:
         - os: macos-latest
           python-version: '3.9'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
`black` was updated to 24.3.0 here:
https://github.com/rstudio/rsconnect-python/commit/818d393c3b802136014839c927698ef5a7352779

but it's not available for Python 3.7:
https://github.com/rstudio/rsconnect-python/actions/runs/8372241141/job/22922828215

This PR removes Python 3.7 from the testing matrix.  The nightly tests now pass again:
https://github.com/rstudio/rsconnect-python/actions/runs/8375941880
