### PR TITLE
black version constraint is in two places. happy days.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ rsconnect = "rsconnect.main:cli"
 
 [project.optional-dependencies]
 test = [
-    "black==22.3.0",
+    "black==24.3.0",
     "coverage",
     "flake8-pyproject",
     "flake8",


### PR DESCRIPTION
This is why https://github.com/rstudio/rsconnect-python/pull/559 was needed and https://github.com/rstudio/rsconnect-python/pull/555 did not fail on master.