### PR TITLE
remove support for Python 3.7; test 3.11, 3.12

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
         - os: macos-latest
           python-version: '3.9'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Pending Next Release
 
 ### Changed
+
 - When deploying Shiny for Python applications on servers using a version of
   Connect prior to 2024.01.0, there is an incompatibility with
   `starlette>=0.35.0`. When deploying to these servers, the starlette version
   is now automatically set to `starlette<0.35.0`.
+
+### Removed
+
+- Python 3.7 support.
 
 ## [1.22.0] - 2024-01-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ tooling](https://packaging.python.org/guides/tool-recommendations/).
 
 To get started, you'll want to:
 - clone the repo into a project directory
-- setup a virtual 3.7+ python environment in the project directory
+- setup a virtual 3.8+ python environment in the project directory
 - activate that virtual environment
 - install the dependencies
 - validate your build environment with some sample commands

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ SOURCE_DATE_EPOCH := $(shell date +%s)
 export SOURCE_DATE_EPOCH
 
 .PHONY: all-tests
-all-tests: all-images test-3.7 test-3.8 test-3.9 test-3.10
+all-tests: all-images test-3.8 test-3.9 test-3.10 test-3.11 test-3.12
 
 .PHONY: all-images
-all-images: image-3.7 image-3.8 image-3.9 image-3.10
+all-images: image-3.8 image-3.9 image-3.10 image-3.11 image-3.12
 
 image-%:
 	docker build -t rsconnect-python:$* --build-arg BASE_IMAGE=python:$*-slim .

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ content to Posit Connect, there are some caveats to understand when replicating 
 environment on the Posit Connect server:
 
 Posit Connect insists on matching `<MAJOR.MINOR>` versions of Python. For example,
-a server with only Python 3.8 installed will fail to match content deployed with
-Python 3.7. Your administrator may also enable exact Python version matching which
+a server with only Python 3.9 installed will fail to match content deployed with
+Python 3.8. Your administrator may also enable exact Python version matching which
 will be stricter and require matching major, minor, and patch versions. For more
 information see the [Posit Connect Admin Guide chapter titled Python Version
 Matching](https://docs.posit.co/connect/admin/python/#python-version-matching).
@@ -1000,9 +1000,6 @@ xargs printf -- '-g %s\n' < guids.txt | xargs rsconnect content build add
 Posit Connect supports the programmatic bootstrapping of an administrator API key
 for scripted provisioning tasks. This process is supported by the `rsconnect bootstrap` command,
 which uses a JSON Web Token to request an initial API key from a fresh Connect instance.
-
-> **Warning**
-> This feature **requires Python version 3.6 or higher**.
 
 ```bash
 rsconnect bootstrap \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Python integration with Posit Connect"
 authors = [{ name = "Michael Marchetti", email = "mike@posit.co" }]
 license = { file = "LICENSE.md" }
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 dependencies = [
     "six>=1.14.0",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

Removes support for Python 3.7, which is end-of-life.

Slightly forced by https://github.com/rstudio/rsconnect-python/pull/555, https://github.com/rstudio/rsconnect-python/pull/559, and https://github.com/rstudio/rsconnect-python/pull/560

fixes #556

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [x] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

inspired by https://github.com/rstudio/rsconnect-python/pull/329 and https://github.com/rstudio/rsconnect-python/pull/337

## Automated Tests

Added testing for Python 3.11 and Python 3.12.

## Directions for Reviewers

Sit back and relax.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
