### PR TITLE
build proper docker containers in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -197,7 +197,9 @@ jobs:
       CONNECT_LICENSE: ${{ secrets.RSC_LICENSE }}
       ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: extractions/setup-just@v1
@@ -205,14 +207,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Containers
         run: |
-            just integration-testing/build
+            cd integration-testing
+            docker compose build client
+            docker compose build cypress
       - name: Start Connect + rsconnect-jupyter
         run: |
             just integration-testing/up
-
+            
       - name: Run Cypress Tests
         run: |
-            export ADMIN_API_KEY="${{ secrets.ADMIN_API_KEY }}"
             just integration-testing/up-cypress
 
       # Videos are captured whether the suite fails or passes


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent
<!-- Describe what problem you are addressing in this pull request. -->
<!-- If this change is associated with an open issue, please link to it here. -->
<!-- Example: "Resolves #24" -->
<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

This fixes the nightly tests. In the [previous PR](https://github.com/rstudio/rsconnect-python/pull/564/files#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L221), I had to update the `main` workflow to build only the docker containers we needed during that run.  I failed to update the nightly workflow too.

The nightly tests are now passing here:
https://github.com/rstudio/rsconnect-python/actions/runs/8467207701

