### PR TITLE
Integration Flakey Test Fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,6 +175,8 @@ jobs:
   test-rsconnect:
     name: "Integration tests against latest Connect"
     runs-on: ubuntu-latest
+    env:
+      RSC_LICENSE: ${{ secrets.RSC_LICENSE }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -190,9 +192,6 @@ jobs:
           docker compose up --build -d
           pip freeze > requirements.txt
           make dev
-        env:
-          RSC_LICENSE: ${{ secrets.RSC_LICENSE }}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Get logs in case of failure
         run: |
           docker compose logs rsconnect

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION := $(shell python -m setuptools_scm)
 HOSTNAME := $(shell hostname)
 S3_PREFIX := s3://rstudio-connect-downloads/connect/rsconnect-python
+export RSC_LICENSE := ${RSC_LICENSE}
 
 BDIST_WHEEL := dist/rsconnect_python-$(VERSION)-py2.py3-none-any.whl
 
@@ -150,7 +151,6 @@ promote-docs-in-s3:
 RSC_API_KEYS=vetiver-testing/rsconnect_api_keys.json
 
 dev:
-	RSC_LICENSE=$RSC_LICENSE \
 	docker compose up -d
 	docker compose exec -T rsconnect bash < vetiver-testing/setup-rsconnect/add-users.sh
 	python vetiver-testing/setup-rsconnect/dump_api_keys.py $(RSC_API_KEYS)

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ promote-docs-in-s3:
 RSC_API_KEYS=vetiver-testing/rsconnect_api_keys.json
 
 dev:
+	RSC_LICENSE=$RSC_LICENSE \
 	docker compose up -d
 	docker compose exec -T rsconnect bash < vetiver-testing/setup-rsconnect/add-users.sh
 	python vetiver-testing/setup-rsconnect/dump_api_keys.py $(RSC_API_KEYS)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 VERSION := $(shell python -m setuptools_scm)
 HOSTNAME := $(shell hostname)
 S3_PREFIX := s3://rstudio-connect-downloads/connect/rsconnect-python
-export RSC_LICENSE := ${RSC_LICENSE}
 
 BDIST_WHEEL := dist/rsconnect_python-$(VERSION)-py2.py3-none-any.whl
 

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ RSC_API_KEYS=vetiver-testing/rsconnect_api_keys.json
 
 dev:
 	docker compose up -d
+	vetiver-testing/wait_for_connect.sh
 	docker compose exec -T rsconnect bash < vetiver-testing/setup-rsconnect/add-users.sh
 	python vetiver-testing/setup-rsconnect/dump_api_keys.py $(RSC_API_KEYS)
 

--- a/vetiver-testing/setup-rsconnect/dump_api_keys.py
+++ b/vetiver-testing/setup-rsconnect/dump_api_keys.py
@@ -13,9 +13,9 @@ def get_api_key(user, password, email):
 
 
 api_keys = {
-    "admin": get_api_key("admin", "admin0", "admin@example.com"),
-    "susan": get_api_key("susan", "susan", "susan@example.com"),
-    "derek": get_api_key("derek", "derek", "derek@example.com"),
+    "admin": get_api_key("admin", "password", "admin@example.com"),
+    "susan": get_api_key("susan", "password", "susan@example.com"),
+    "derek": get_api_key("derek", "password", "derek@example.com"),
 }
 
 json.dump(api_keys, open(OUT_FILE, "w"))

--- a/vetiver-testing/setup-rsconnect/dump_api_keys.py
+++ b/vetiver-testing/setup-rsconnect/dump_api_keys.py
@@ -13,9 +13,9 @@ def get_api_key(user, password, email):
 
 
 api_keys = {
-    "admin": get_api_key("admin", "password", "admin@example.com"),
-    "susan": get_api_key("susan", "password", "susan@example.com"),
-    "derek": get_api_key("derek", "password", "derek@example.com"),
+    "admin": get_api_key("admin", "Km(7N0L*J", "admin@example.com"),
+    "susan": get_api_key("susan", "Km(7N0L*J", "susan@example.com"),
+    "derek": get_api_key("derek", "Km(7N0L*J", "derek@example.com"),
 }
 
 json.dump(api_keys, open(OUT_FILE, "w"))

--- a/vetiver-testing/setup-rsconnect/users.txt
+++ b/vetiver-testing/setup-rsconnect/users.txt
@@ -1,4 +1,4 @@
-admin password
-test  password
-susan password
-derek password
+admin Km(7N0L*J
+test  Km(7N0L*J
+susan Km(7N0L*J
+derek Km(7N0L*J

--- a/vetiver-testing/setup-rsconnect/users.txt
+++ b/vetiver-testing/setup-rsconnect/users.txt
@@ -1,4 +1,4 @@
-admin admin0
-test  test
-susan susan
-derek derek
+admin password
+test  password
+susan password
+derek password

--- a/vetiver-testing/wait_for_connect.sh
+++ b/vetiver-testing/wait_for_connect.sh
@@ -1,7 +1,7 @@
 timeout 5 bash -c \
-    'status=$(curl -s -o /dev/null -w ''%{http_code}'' http://localhdost:3939/__ping__); \
+    'status=$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:3939/__ping__); \
     while [[ "$status" != "200" ]]; \
         do sleep 1; \
         echo "retry"; \
-        status=$(curl -s -o /dev/null -w ''%{http_code}'' http://locadlhost:3939/__ping__); \
+        status=$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:3939/__ping__); \
         done'

--- a/vetiver-testing/wait_for_connect.sh
+++ b/vetiver-testing/wait_for_connect.sh
@@ -1,0 +1,7 @@
+timeout 5 bash -c \
+    'status=$(curl -s -o /dev/null -w ''%{http_code}'' http://localhdost:3939/__ping__); \
+    while [[ "$status" != "200" ]]; \
+        do sleep 1; \
+        echo "retry"; \
+        status=$(curl -s -o /dev/null -w ''%{http_code}'' http://locadlhost:3939/__ping__); \
+        done'

--- a/vetiver-testing/wait_for_connect.sh
+++ b/vetiver-testing/wait_for_connect.sh
@@ -1,4 +1,4 @@
-timeout 5 bash -c \
+timeout 30 bash -c \
     'status=$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:3939/__ping__); \
     while [[ "$status" != "200" ]]; \
         do sleep 1; \


### PR DESCRIPTION
The Intergration Tests have been flakey lately. The first issue was, the docker container wasn't getting the RSC_LICENSE variable for Connect so Connect never started.
Like here:
https://github.com/rstudio/rsconnect-python/actions/runs/8567414234/job/23488396171#step:6:12

I moved the `RSC_LICENSE` variable up in the Github Actions workflow and that seems to have solved the license issue.  However, I still saw some race conditions where the test would start before Connect was ready, so I added a script to wait for Connect to start.  There were also some warnings about password security when the users were being created, so I updated those as well.