### PR TITLE
force version during make dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,9 @@ version:
 # exported as a point of reference instead.
 .PHONY: dist
 dist:
+	$(eval CLEAN_VERSION := $(shell python -m setuptools_scm))
 	./scripts/temporary-rename
-	pip wheel --no-deps -w dist .
+	SETUPTOOLS_SCM_PRETEND_VERSION=$(CLEAN_VERSION) pip wheel --no-deps -w dist .
 	twine check $(BDIST_WHEEL)
 	rm -vf dist/*.egg
 	@echo "::set-output name=whl::$(BDIST_WHEEL)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,6 @@ packages = ["rsconnect"]
 
 [tool.setuptools_scm]
 write_to = "rsconnect/version.py"
-# since we dirty the state by transforming the file
-# keep the version number consistent
-version_scheme = "no-guess-dev"
-local_scheme = "no-local-version"
 
 [tool.setuptools.package-data]
 rsconnect = ["py.typed"]


### PR DESCRIPTION
Compute the package version before transforming the `pyproject.toml` file and set it with an environment variable
