### PR TITLE
fix: skip starlette check when server version is hidden

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ??
 
+### Fixed
+
+- Python Shiny apps can be deployed when Connect server version is hidden. (#695)
+
 ## [1.27.0] - 2025-07-10
 
 ### Added

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1694,12 +1694,20 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
 
         if isinstance(ce.client, RSConnectClient):
             # Update the starlette version if needed. After all users are on Connect
-            # 2024.01.1 or later, this can be removed.
-            environment = fix_starlette_requirements(
-                environment=environment,
-                app_mode=app_mode,
-                connect_version_string=ce.client.server_settings()["version"],
-            )
+            # 2024.01.1 or later, this can be removed. Requires access to the
+            # Connect server version, which may be hidden.
+            connect_version_string = ce.client.server_settings().get("version", "")
+            if connect_version_string:
+                environment = fix_starlette_requirements(
+                    environment=environment,
+                    app_mode=app_mode,
+                    connect_version_string=connect_version_string,
+                )
+            else:
+                click.secho(
+                    "    Warning: Connect server version is hidden. Skipping starlette requirements check.",
+                    fg="yellow",
+                )
 
         ce.validate_server()
         ce.validate_app_mode(app_mode=app_mode)


### PR DESCRIPTION
## Intent

If Connect's server version is hidden, skip the starlette dependency check and log a warning.

Fixes #695

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Only call `fix_starlette_requirements` if we have a non-empty Connect version string. Otherwise, log a warning, which will hopefully provide a helpful breadcrumb if users on a pre-2024.01.0 Connect see starlette errors.

## Automated Tests

Opted not to add a new test for such a small change.

## Directions for Reviewers

I manually reproduced the bug by running Connect locally with `[Server] HideVersion = true`:

<details>

<summary>logs of failed deploy</summary>

```
rsconnect-python on  chris-empty-version [?] via 🐍 v3.13.3 (.venv) on ☁️  (us-east-1)
❯ rsconnect deploy shiny top-5-income-share-shiny
    Warning: the existing manifest.json file will not be used or considered.
    Warning: Python version constraint missing from pyproject.toml, setup.cfg or .python-version
             Connect will guess the version to use based on local environment.
             Consider specifying a Python version constraint.
Traceback (most recent call last):
  File "/Users/chris/dev/posit-dev/rsconnect-python/rsconnect/main.py", line 118, in wrapper
    result = func(*args, **kwargs)
  File "/Users/chris/dev/posit-dev/rsconnect-python/.venv/lib/python3.13/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/chris/dev/posit-dev/rsconnect-python/rsconnect/main.py", line 1698, in deploy_app
    environment = fix_starlette_requirements(
        environment=environment,
        app_mode=app_mode,
        connect_version_string=ce.client.server_settings()["version"],
    )
  File "/Users/chris/dev/posit-dev/rsconnect-python/rsconnect/utils_package.py", line 220, in fix_starlette_requirements
    if not (app_mode == AppModes.PYTHON_SHINY and compare_semvers(connect_version_string, "2024.01.0") == -1):
                                                  ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/dev/posit-dev/rsconnect-python/rsconnect/utils_package.py", line 58, in compare_semvers
    return semver.VersionInfo.parse(version1).compare(version2)  # type: ignore
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/chris/dev/posit-dev/rsconnect-python/.venv/lib/python3.13/site-packages/semver/version.py", line 644, in parse
    raise ValueError(f"{version} is not valid SemVer string")
ValueError:  is not valid SemVer string
Internal error:  is not valid SemVer string
```

</details>

With this fix, the deployment succeeds:

<details>

<summary>logs of successful deploy</summary>

```
rsconnect-python on  chris-empty-version [!?] via 🐍 v3.11.12 (.venv) on ☁️  (us-east-1) took 11s
❯ rsconnect deploy shiny top-5-income-share-shiny
    Warning: the existing manifest.json file will not be used or considered.
    Warning: Python version constraint missing from pyproject.toml, setup.cfg or .python-version
             Connect will guess the version to use based on local environment.
             Consider specifying a Python version constraint.
    Warning: Connect server version is hidden. Skipping starlette requirements check.
Validating server...    [OK]
Validating app mode...  [OK]
Making bundle ...       [OK]
Deploying bundle ...    [OK]
Saving deployed information...  [OK]
Building Python Shiny application...
Bundle created with Python version 3.11.12 is compatible with environment Local with Python version 3.11.3 from /opt/python/3.11.3/bin/python3.11
Bundle requested Python version 3.11.12; using /opt/python/3.11.3/bin/python3.11 from Local which has version 3.11.3
2025/07/30 19:13:50.780421842 [connect-session] Content GUID: 0de661cc-bbf7-44e1-86ff-7e975c339f6b
2025/07/30 19:13:50.781082509 [connect-session] Content ID: 2
2025/07/30 19:13:50.781133426 [connect-session] Bundle ID: 6
2025/07/30 19:13:50.781191717 [connect-session] Job Key: Rfjtobm8E2dkAm6u
2025/07/30 19:13:50.781255926 [connect-session] WARNING: Publishing with rsconnect-python or Publisher, upgrade for the generated manifest.json to follow version constraints best practices.
2025/07/30 19:13:50.781300926 [connect-session] For more details on version matching, see https://docs.posit.co/connect/admin/python/#python-version-matching
Determining session server location ...
Connecting to session server http://127.0.0.1:43671 ...
Connected to session server http://127.0.0.1:43671
2025/07/30 19:13:50.941386051 Running on host: connect
...
Deployment completed successfully.
         Dashboard content URL: http://localhost:3939/connect/#/apps/0de661cc-bbf7-44e1-86ff-7e975c339f6b/access
         Direct content URL: http://localhost:3939/content/0de661cc-bbf7-44e1-86ff-7e975c339f6b/
Verifying deployed content...   [OK]
```
</details>

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
