### PR TITLE
ci: Update vetiver tests to use with-connect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,8 +188,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r vetiver-testing/vetiver-requirements.txt
-          python -m pip install '.[test]'
+          python -m pip install '.[test,vetiver-testing]'
       - name: Run Posit Connect
         run: |
           docker compose up --build -d

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,6 +195,7 @@ jobs:
           version: "release"
           license: ${{ secrets.CONNECT_LICENSE_FILE }}
           command: |
+            pip freeze > requirements.txt
             pytest -m 'vetiver'
 
   test-dev-connect:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - run: pip install '.[test]'
+    - run: pip install '.[test,mcp]'
     - run: pip freeze
     - run: make lint
     - run: rsconnect version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,6 +177,26 @@ jobs:
           command: |
             make test-${{ env.python-version }}
 
+  test-vetiver:
+    name: "Vetiver integration test"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.12.4
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install '.[test,vetiver-testing]'
+      - name: Run tests
+        uses: posit-dev/with-connect@main
+        with:
+          version: "release"
+          license: ${{ secrets.CONNECT_LICENSE_FILE }}
+          command: |
+            pytest -m 'vetiver'
+
   test-dev-connect:
     name: "Integration tests against dev Connect"
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Run tests
         uses: posit-dev/with-connect@main
         with:
-          version: "release"
+          version: "jammy"
           license: ${{ secrets.CONNECT_LICENSE_FILE }}
           command: |
             pip freeze > requirements.txt
@@ -225,6 +225,8 @@ jobs:
 
       # NOTE: edited to run checks for python package
       - name: Run tests
+        env:
+          CONNECT_SERVER: http://localhost:3939
         run: |
           pytest tests/test_main_system_caches.py
           pytest -m 'vetiver'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,14 @@ test = [
 ]
 snowflake = ["snowflake-cli"]
 mcp = ["fastmcp==2.12.4; python_version >= '3.10'"]
+vetiver-testing = [
+    "pandas",
+    "numpy",
+    "pydantic",
+    "pytest",
+    "pins",
+    "vetiver",
+]
 docs = [
     "mkdocs-material",
     "mkdocs-click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ test = [
     "setuptools_scm[toml]>=3.4",
     "twine",
     "types-Flask",
-    "fastmcp==2.12.4; python_version >= '3.10'",
+    "fastmcp<3; python_version >= '3.10'",
 ]
 snowflake = ["snowflake-cli"]
-mcp = ["fastmcp==2.12.4; python_version >= '3.10'"]
+mcp = ["fastmcp<3; python_version >= '3.10'"]
 vetiver-testing = [
     "pandas",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ test = [
     "setuptools_scm[toml]>=3.4",
     "twine",
     "types-Flask",
-    "fastmcp<3; python_version >= '3.10'",
 ]
 snowflake = ["snowflake-cli"]
 mcp = ["fastmcp<3; python_version >= '3.10'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ mcp = ["fastmcp==2.12.4; python_version >= '3.10'"]
 vetiver-testing = [
     "pandas",
     "numpy",
-    "pydantic",
+    "pydantic<2",
     "pytest",
     "pins",
     "vetiver",

--- a/tests/test_main_system_caches.py
+++ b/tests/test_main_system_caches.py
@@ -5,9 +5,9 @@ from os import system
 from click.testing import CliRunner
 
 from rsconnect.main import cli
+from .utils import require_connect
 
 
-CONNECT_SERVER = "http://localhost:3939"
 CONNECT_KEYS_JSON = "vetiver-testing/rsconnect_api_keys.json"
 CONNECT_CACHE_DIR = "/data/python-environments/_packages_cache"
 
@@ -64,11 +64,12 @@ class TestSystemCachesList(unittest.TestCase):
 
     # Admins can list caches
     def test_system_caches_list_admin(self):
+        connect_server = require_connect()
         api_key = get_key("admin")
         runner = CliRunner()
 
         args = ["system", "caches", "list"]
-        apply_common_args(args, server=CONNECT_SERVER, key=api_key)
+        apply_common_args(args, server=connect_server, key=api_key)
 
         result = runner.invoke(cli, args)
         self.assertEqual(result.exit_code, 0)
@@ -79,11 +80,12 @@ class TestSystemCachesList(unittest.TestCase):
 
     # Publishers cannot list caches
     def test_system_caches_list_publisher(self):
+        connect_server = require_connect()
         api_key = get_key("susan")
         runner = CliRunner()
 
         args = ["system", "caches", "list"]
-        apply_common_args(args, server=CONNECT_SERVER, key=api_key)
+        apply_common_args(args, server=connect_server, key=api_key)
 
         result = runner.invoke(cli, args)
         self.assertEqual(result.exit_code, 1)
@@ -106,11 +108,12 @@ class TestSystemCachesDelete(unittest.TestCase):
 
     # Publishers cannot delete caches
     def test_system_caches_delete_publisher(self):
+        connect_server = require_connect()
         api_key = get_key("susan")
         runner = CliRunner()
 
         args = ["system", "caches", "delete", "--language", "Python", "--version", "1.2.3", "--image-name", "Local"]
-        apply_common_args(args, server=CONNECT_SERVER, key=api_key)
+        apply_common_args(args, server=connect_server, key=api_key)
 
         result = runner.invoke(cli, args)
         self.assertEqual(result.exit_code, 1)
@@ -119,11 +122,12 @@ class TestSystemCachesDelete(unittest.TestCase):
 
     # Admins can delete caches that exist
     def test_system_caches_delete_admin(self):
+        connect_server = require_connect()
         api_key = get_key("admin")
         runner = CliRunner()
 
         args = ["system", "caches", "delete", "--language", "Python", "--version", "1.2.3", "--image-name", "Local"]
-        apply_common_args(args, server=CONNECT_SERVER, key=api_key)
+        apply_common_args(args, server=connect_server, key=api_key)
 
         self.assertTrue(cache_dir_exists())
         result = runner.invoke(cli, args)
@@ -134,26 +138,27 @@ class TestSystemCachesDelete(unittest.TestCase):
 
     # --version and --language flags are required
     def test_system_caches_delete_required_flags(self):
+        connect_server = require_connect()
         api_key = get_key("admin")
         runner = CliRunner()
 
         # neither flag provided should fail
         args = ["system", "caches", "delete"]
-        apply_common_args(args, server=CONNECT_SERVER, key=api_key)
+        apply_common_args(args, server=connect_server, key=api_key)
         result = runner.invoke(cli, args)
         self.assertEqual(result.exit_code, 2)
         self.assertRegex(result.output, "Error: Missing option '--language' / '-l'")
 
         # only --language flag provided should fail
         args = ["system", "caches", "delete", "--language", "Python"]
-        apply_common_args(args, server=CONNECT_SERVER, key=api_key)
+        apply_common_args(args, server=connect_server, key=api_key)
         result = runner.invoke(cli, args)
         self.assertEqual(result.exit_code, 2)
         self.assertRegex(result.output, "Error: Missing option '--version' / '-V'")
 
         # only --version flag provided should fail
         args = ["system", "caches", "delete", "--version", "1.2.3"]
-        apply_common_args(args, server=CONNECT_SERVER, key=api_key)
+        apply_common_args(args, server=connect_server, key=api_key)
         result = runner.invoke(cli, args)
         self.assertEqual(result.exit_code, 2)
         self.assertRegex(result.output, "Error: Missing option '--language' / '-l'")

--- a/tests/test_vetiver_pins.py
+++ b/tests/test_vetiver_pins.py
@@ -7,9 +7,6 @@ import pins  # noqa
 import pandas as pd  # noqa
 import numpy as np  # noqa
 
-from pins.boards import BoardRsConnect  # noqa
-from pins.rsconnect.api import RsConnectApi  # noqa
-from pins.rsconnect.fs import RsConnectFs  # noqa
 from rsconnect.api import RSConnectServer, RSConnectClient  # noqa
 
 from .utils import require_api_key, require_connect  # noqa
@@ -17,29 +14,6 @@ from .utils import require_api_key, require_connect  # noqa
 pytestmark = pytest.mark.vetiver  # noqa
 
 os.environ["CONNECT_CONTENT_BUILD_DIR"] = "vetiver-test-build"  # noqa
-
-
-def rsc_delete_user_content(rsc):
-    guid = rsc.get_user()["guid"]
-    content = rsc.get_content(owner_guid=guid)
-    for entry in content:
-        rsc.delete_content_item(entry["guid"])
-
-
-@pytest.fixture(scope="function")
-def rsc_short():
-    # tears down content after each test
-    server_url = require_connect()
-    api_key = require_api_key()
-    rsc = RsConnectApi(server_url, api_key)
-    fs_susan = RsConnectFs(rsc)
-
-    # delete any content that might already exist
-    rsc_delete_user_content(fs_susan.api)
-
-    yield BoardRsConnect("", fs_susan, allow_pickle_read=True)  # fs_susan.ls to list content
-
-    rsc_delete_user_content(fs_susan.api)
 
 
 def test_deploy():

--- a/tests/test_vetiver_pins.py
+++ b/tests/test_vetiver_pins.py
@@ -33,7 +33,7 @@ def test_deploy():
     vetiver.vetiver_pin_write(board=board, model=v)
     connect_server = RSConnectServer(url=server_url, api_key=require_api_key())
 
-    vetiver.deploy_connect(
+    vetiver.deploy_rsconnect(
         connect_server=connect_server,
         board=board,
         pin_name=modelname,

--- a/tests/test_vetiver_pins.py
+++ b/tests/test_vetiver_pins.py
@@ -51,6 +51,8 @@ def test_deploy():
 
     endpoint = vetiver.vetiver_endpoint(content_url + "/predict")
     response = vetiver.predict(endpoint, X_df, headers=h)
+    print(X_df)
+    print(response)
 
     assert isinstance(response, pd.DataFrame), response
     assert response.iloc[0, 0] == 44.47

--- a/vetiver-testing/vetiver-requirements.txt
+++ b/vetiver-testing/vetiver-requirements.txt
@@ -1,6 +1,0 @@
-pandas
-numpy
-pydantic<2
-pytest
-pins
-vetiver


### PR DESCRIPTION
WIP, trying to sort out whether there are global rsconnect-python things getting picked up that are causing local failure. (#646?)

## Intent

See https://github.com/posit-dev/rsconnect-python/issues/649#issuecomment-3504025244. Looking at the vetiver integration test, it should be able to run fine using `with-connect` and without the custom setup copied in from pins/vetiver.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
- [ ] I have run the `rsconnect-python-tests-at-night` workflow in Connect against this feature branch.
