### PR TITLE
ci: add preview to integration test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,6 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - "preview"   # nightly pre-release build of Connect
           - "release"   # special value that always points to the latest Connect release
           - "2025.09.0" # jammy
           - "2025.03.0" # jammy


### PR DESCRIPTION
## Intent

https://github.com/posit-dev/with-connect/pull/37 added support for the nightly prereleases of Connect. I wanted to get this added and passing in CI before landing #736, which should have different behavior on the prerelease.

## Automated Tests

yes

