### PR TITLE
bug: allow requirements.txt to not exist

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -1021,7 +1021,7 @@ def _warn_on_ignored_requirements(directory: str, requirements_file_name: str):
 @click.option(
     "--requirements-file",
     "-r",
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(dir_okay=False),
     default="requirements.txt",
     help=(
         "Path to requirements file to record in the manifest instead of detecting the environment. "
@@ -1191,7 +1191,7 @@ def deploy_notebook(
 @click.option(
     "--requirements-file",
     "-r",
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(dir_okay=False),
     default="requirements.txt",
     help=(
         "Path to requirements file to record in the manifest instead of detecting the environment. "
@@ -1425,7 +1425,7 @@ def deploy_manifest(
 @click.option(
     "--requirements-file",
     "-r",
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(dir_okay=False),
     default="requirements.txt",
     help=(
         "Path to requirements file to record in the manifest instead of detecting the environment. "
@@ -1824,7 +1824,7 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
     @click.option(
         "--requirements-file",
         "-r",
-        type=click.Path(exists=True, dir_okay=False),
+        type=click.Path(dir_okay=False),
         help=(
             "Path to requirements file to record in the manifest instead of detecting the environment. "
             "Must be inside the deployment directory. Use 'none' to capture via pip freeze."
@@ -2032,7 +2032,7 @@ def write_manifest():
 @click.option(
     "--requirements-file",
     "-r",
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(dir_okay=False),
     help=(
         "Path to requirements file to record in the manifest instead of detecting the environment. "
         "Must be inside the notebook directory. Use 'none' to capture via pip freeze."
@@ -2302,7 +2302,7 @@ def write_manifest_voila(
 @click.option(
     "--requirements-file",
     "-r",
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(dir_okay=False),
     help=(
         "Path to requirements file to record in the manifest instead of detecting the environment. "
         "Must be inside the project directory."
@@ -2517,7 +2517,7 @@ def generate_write_manifest_python(app_mode: AppMode, alias: str, desc: Optional
     @click.option(
         "--requirements-file",
         "-r",
-        type=click.Path(exists=True, dir_okay=False),
+        type=click.Path(dir_okay=False),
         help=(
             "Path to requirements file to record in the manifest instead of detecting the environment. "
             "Must be inside the application directory. Use 'none' to capture via pip freeze."


### PR DESCRIPTION
## Intent

Previously `rsconnect` didn't check that the `requirements.txt` didn't exist, it did just emit a warning

```
    Warning: Capturing the environment using 'pip freeze'.
             Consider creating a requirements.txt file instead.
```

Now instead it errors if the requirements file doesn't exist

```
Invalid value for '--requirements-file' / '-r': File 'requirements.txt' does not exist.
```

The change in behavior accidentally slipped in as part of #748 as `click.Path` unexpectedly validates the default value too even if the option wasn't provided.

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Just disable `exists=True` from command line validation, this will restore the previous behavior of issuing the warning.

## Automated Tests

Tests in Connect triggered this issue