### PR TITLE
fix: input validation gap in `rsconnect add`

### DIFF
--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -741,6 +741,12 @@ def add(
     set_verbosity(verbose)
     output_params(ctx, locals().items())
 
+    if not server and not any([token, secret, account]):
+        raise RSConnectException(
+            "`rsconnect add` requires -s/--server (for Posit Connect) or -A/--account, -T/--token, "
+            "and -S/--secret (for shinyapps.io)."
+        )
+
     validation.validate_connection_options(
         ctx=ctx,
         url=server,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -715,6 +715,28 @@ class TestMain:
             if original_server_value:
                 os.environ["CONNECT_SERVER"] = original_server_value
 
+    def test_add_name_only_missing_server_and_credentials(self):
+        """Regression test: `rsconnect add -n x` should produce a validation error, not a TypeError."""
+        original_api_key_value = os.environ.pop("CONNECT_API_KEY", None)
+        original_server_value = os.environ.pop("CONNECT_SERVER", None)
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "add",
+                    "--name",
+                    "some-name",
+                ],
+            )
+            assert result.exit_code == 1, result.output
+            assert "`rsconnect add` requires" in str(result.exception)
+        finally:
+            if original_api_key_value:
+                os.environ["CONNECT_API_KEY"] = original_api_key_value
+            if original_server_value:
+                os.environ["CONNECT_SERVER"] = original_server_value
+
     def test_add_shinyapps_missing_options(self):
         original_api_key_value = os.environ.pop("CONNECT_API_KEY", None)
         original_server_value = os.environ.pop("CONNECT_SERVER", None)

--- a/vetiver-testing/vetiver-requirements.txt
+++ b/vetiver-testing/vetiver-requirements.txt
@@ -1,6 +1,6 @@
 pandas
 numpy
-pydantic
+pydantic<2
 pytest
 pins
 vetiver


### PR DESCRIPTION
## Intent
Running `rsconnect add` with insufficient inputs (in this case only specifying the name) should result in a clear `RSConnectException`


fixes: #757

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 

## Approach

The add command supports three credential pathways, each requiring a different set of options:

1. Posit Connect — requires --server (and typically --api-key)
2. shinyapps.io / Cloud — requires --account, --token, and --secret
3. Snowflake (SPCS) — requires --server with a snowflakecomputing.app host (and optionally --snowflake-connection-name)

Adds an early check at the top of the add command. It raises an `RSConnectException` with a clear message if neither --server nor any of the shinyapps.io options are provided, before any downstream code can encounter None values

Note: click resolves env vars before calling the function, so this won't screw us up in cases where things are being specified as env vars instead of inputs

## Automated Tests
Added a unit test ` test_add_name_only_missing_server_and_credentials`

New behavior

```
uv run rsconnect add -n x
...
rsconnect.exception.RSConnectException: `rsconnect add` requires -s/--server (for Posit Connect) or -A/--account, -T/--token, and -S/--secret (for shinyapps.io).
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
- [ ] I have run the `rsconnect-python-tests-at-night` workflow in Connect against this feature branch.
