### PR TITLE
Release 1.29.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.29.0] - 2026-04-29
+
 - Added `rsconnect deploy nodejs` command for deploying Node.js applications
   (Express, Fastify, etc.) to Posit Connect. Supports JavaScript and TypeScript
   entry points with auto-detection from package.json. Requires Posit Connect with


### PR DESCRIPTION
Prep the CHANGELOG for the `1.29.0` release.