### PR TITLE
fix: snowflake authenticator matching is case insensitive

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pyproject.toml` can now be supplied via `--requirements-file` for deploy and
   write-manifest.
+- Perform case insensitive matching of the configured Snowflake connection authenticator.
 
 ## [1.29.0] - 2026-04-29
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -274,7 +274,11 @@ class SPCSConnectServer(AbstractRemoteServer):
             raise RSConnectException("No Snowflake connection found.")
 
         authenticator = params.get("authenticator")
-        if authenticator == "SNOWFLAKE_JWT":
+        if not authenticator:
+            raise NotImplementedError("Snowflake connection does not declare an authenticator.")
+
+        authenticator = authenticator.lower()
+        if authenticator == "snowflake_jwt":
             spcs_url = urlparse(self.url)
             scope = f"session:role:{params['role']} {spcs_url.netloc}" if params.get("role") else spcs_url.netloc
             jwt = generate_jwt(self.snowflake_connection_name)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -293,7 +293,7 @@ class SPCSConnectServerTestCase(TestCase):
             server.token_endpoint()
 
     @patch("rsconnect.api.get_parameters")
-    def test_fmt_payload(self, mock_get_parameters):
+    def test_fmt_payload_jwt_uppercase(self, mock_get_parameters):
         server = SPCSConnectServer("https://spcs.example.com", "test-api-key", "example_connection")
         mock_get_parameters.return_value = {
             "account": "test_account",
@@ -314,6 +314,50 @@ class SPCSConnectServerTestCase(TestCase):
 
             mock_get_parameters.assert_called_once_with("example_connection")
             mock_generate_jwt.assert_called_once_with("example_connection")
+
+    @patch("rsconnect.api.get_parameters")
+    def test_fmt_payload_jwt_lowercase(self, mock_get_parameters):
+        server = SPCSConnectServer("https://spcs.example.com", "test-api-key", "example_connection")
+        mock_get_parameters.return_value = {
+            "account": "test_account",
+            "role": "test_role",
+            "authenticator": "snowflake_jwt",
+        }
+
+        with patch("rsconnect.api.generate_jwt") as mock_generate_jwt:
+            mock_generate_jwt.return_value = "mocked_jwt"
+            payload = server.fmt_payload()
+
+            assert (
+                payload["body"]
+                == "scope=session%3Arole%3Atest_role+spcs.example.com&assertion=mocked_jwt&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer"  # noqa
+            )
+            assert payload["headers"] == {"Content-Type": "application/x-www-form-urlencoded"}
+            assert payload["path"] == "/oauth/token"
+
+            mock_get_parameters.assert_called_once_with("example_connection")
+            mock_generate_jwt.assert_called_once_with("example_connection")
+
+    @patch("rsconnect.api.get_parameters")
+    def test_fmt_payload_with_unsupported_authenticator(self, mock_get_parameters):
+        server = SPCSConnectServer("https://spcs.example.com", "test-api-key", "example_connection")
+        mock_get_parameters.return_value = {
+            "account": "test_account",
+            "role": "test_role",
+            "authenticator": "unrecognized",
+        }
+        with pytest.raises(NotImplementedError, match="Unsupported authenticator for SPCS Connect: unrecognized"):
+            server.fmt_payload()
+
+    @patch("rsconnect.api.get_parameters")
+    def test_fmt_payload_with_no_authenticator(self, mock_get_parameters):
+        server = SPCSConnectServer("https://spcs.example.com", "test-api-key", "example_connection")
+        mock_get_parameters.return_value = {
+            "account": "test_account",
+            "role": "test_role",
+        }
+        with pytest.raises(NotImplementedError, match="Snowflake connection does not declare an authenticator."):
+            server.fmt_payload()
 
     @patch("rsconnect.api.get_parameters")
     def test_fmt_payload_with_none_params(self, mock_get_parameters):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

The `connections.toml` may have a lower-cased authenticator name.

```toml
authenticator = "snowflake_jwt"
```

Permit arbitrary case for authenticator names.

fixes #771

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Fetched the authenticator from the parsed connection parameters, ensure that it exists, and lower it before comparing to known authenticator names.

## Automated Tests

Added unit tests which confirm support for `SNOWFLAKE_JWT` and `snowflake_jwt`. Added unit tests confirming the errors produced when no authenticator is defined and when the named authenticator is not supported.

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
- [ ] I have run the `rsconnect-python-tests-at-night` workflow in Connect against this feature branch.
