### PR TITLE
fix: clarify Connect uses npm in Node.js lockfile error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- The "no package-lock.json" error when deploying Node.js content now states
+  that Connect installs Node.js dependencies with npm, helping publishers who
+  build with yarn or pnpm understand why a `package-lock.json` is required.
 - `pyproject.toml` can now be supplied via `--requirements-file` for deploy and
   write-manifest.
 - Perform case insensitive matching of the configured Snowflake connection authenticator.

--- a/rsconnect/environment_node.py
+++ b/rsconnect/environment_node.py
@@ -75,6 +75,7 @@ class NodeEnvironment:
         if not has_lock_file:
             raise RSConnectException(
                 f"No package-lock.json found in '{directory}'. "
+                "Connect installs Node.js dependencies with npm. "
                 "Both package.json and package-lock.json are required to deploy Node.js content."
             )
 

--- a/tests/test_environment_node.py
+++ b/tests/test_environment_node.py
@@ -42,7 +42,10 @@ class TestNodeEnvironmentCreate:
     def test_create_no_lock_file(self, mock_run, tmp_path):
         (tmp_path / "package.json").write_text(json.dumps({"dependencies": {"express": "^4.21.0"}}))
         (tmp_path / "app.js").write_text("// app")
-        with pytest.raises(RSConnectException, match="No package-lock.json found"):
+        with pytest.raises(
+            RSConnectException,
+            match="No package-lock.json found.*Connect installs Node.js dependencies with npm",
+        ):
             NodeEnvironment.create(str(tmp_path))
 
     @patch("rsconnect.environment_node.subprocess.run", side_effect=_mock_run)


### PR DESCRIPTION
## Intent

A publisher who builds a Node.js project with yarn or pnpm has no `package-lock.json`, so `rsconnect deploy nodejs` fails with an error that asks for `package-lock.json` without explaining that Connect specifically requires `npm`. This adds that clarification.

## Type of Change

- [x] Bug Fix

## Approach

`rsconnect/environment_node.py`: the `NodeEnvironment.create` lockfile check now adds the sentence "Connect installs Node.js dependencies with npm." to the raised `RSConnectException`. The message is unconditional - no `yarn.lock`/`pnpm-lock.yaml` detection - so it reads correctly in every case.

## Automated Tests

`tests/test_environment_node.py::test_create_no_lock_file` now asserts the exception text includes the npm clarification.

## Directions for Reviewers

In a Node.js project directory with a `package.json` but no `package-lock.json`, run `rsconnect deploy nodejs`. The error names npm as the package manager Connect uses.

## Checklist

- [x] I have updated [CHANGELOG.md](../docs/CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
- [ ] I have run the `rsconnect-python-tests-at-night` workflow in Connect against this feature branch.