### PR TITLE
fix(nodejs): add python env exclusion for nodejs manifest generation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uv venv` and `uv sync` to populate the scaffolded project's virtualenv.
   `uv` installs as a self-contained wheel from PyPI alongside `rsconnect`.
 
+### Fixed
+
+- Python virtual environments (e.g. `.venv`) in a Node.js project directory are
+  now excluded from the generated `manifest.json`, matching the behavior of the
+  Python and Quarto content types.
+
 ## [1.29.0] - 2026-04-29
 
 - Added `rsconnect deploy nodejs` command for deploying Node.js applications

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1438,6 +1438,7 @@ def make_nodejs_manifest(
     excludes = list(excludes) if excludes else []
     excludes.append("manifest.json")
     excludes.append("node_modules")
+    excludes.extend(list_environment_dirs(directory))
 
     relevant_files = create_file_list(directory, extra_files, excludes)
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -3167,6 +3167,21 @@ class TestNodeJSManifest:
 
         assert "package-lock.json" in manifest["files"]
 
+    def test_manifest_excludes_python_virtual_environment(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"dependencies":{}}')
+        (tmp_path / "app.js").write_text("// app")
+        # Make a directory that looks like a Python virtualenv (has bin/python).
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").write_text("")
+        (tmp_path / ".venv" / "pyvenv.cfg").write_text("")
+
+        env = _make_node_env()
+        manifest, files = make_nodejs_manifest(str(tmp_path), "app.js", env, [], [])
+
+        for f in manifest["files"]:
+            assert ".venv" not in f
+
 
 class TestNodeJSBundle:
     def test_bundle_contents(self):


### PR DESCRIPTION
Exculde python env files in nodejs manifest generation.

## Intent
resolves #783 

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

`make_nodejs_manifest` only excluded `manifest.json` and `node_modules`.  It needs to also exclude python env files. Every other content generator strips these via `list_environment_dirs(...)` so we just have to do that here as well

## Automated Tests

`test_manifest_excludes_python_virtual_environment` creates a venv-shaped .venv and asserts none of its files appear in the manifest. Confirmed it fails without the fix and passes with it.

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
- [ ] I have run the `rsconnect-python-tests-at-night` workflow in Connect against this feature branch.
