### PR TITLE
Fix git metadata detection for deploy with bare manifest filename

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fixed a bug where `rsconnect deploy manifest manifest.json` (and other deploy
+  commands given a bare filename) failed to detect git metadata. The directory
+  passed to git detection was empty in that case, which caused detection to be
+  silently skipped; it now falls back to the current directory.
 - The `CONNECT_SERVER_VERSION` environment variable can now be set to tell
   rsconnect-python which Connect version to assume for feature-availability
   checks. Some servers can be configured to suppress their version, which makes

--- a/rsconnect/git_metadata.py
+++ b/rsconnect/git_metadata.py
@@ -22,7 +22,9 @@ def _run_git_command(args: list[str], cwd: str) -> Optional[str]:
     try:
         result = subprocess.run(
             ["git"] + args,
-            cwd=cwd,
+            # dirname() of a bare filename (e.g. "manifest.json") yields "",
+            # which subprocess rejects; treat it as the current directory.
+            cwd=cwd or ".",
             capture_output=True,
             text=True,
             timeout=5,

--- a/tests/test_git_metadata.py
+++ b/tests/test_git_metadata.py
@@ -123,6 +123,19 @@ class TestGitDetection:
             metadata = detect_git_metadata(tmpdir)
             assert metadata == {}
 
+    def test_is_git_repo_empty_dir_uses_cwd(self, git_repo, monkeypatch):
+        # dirname("manifest.json") yields "", which subprocess rejects as cwd.
+        # An empty directory should be treated as the current directory so that
+        # `rsconnect deploy manifest manifest.json` still detects git metadata.
+        monkeypatch.chdir(git_repo)
+        assert is_git_repo("") is True
+
+    def test_detect_git_metadata_empty_dir_uses_cwd(self, git_repo, monkeypatch):
+        monkeypatch.chdir(git_repo)
+        metadata = detect_git_metadata("")
+        assert metadata["source"] == "git"
+        assert metadata["source_repo"] == "https://github.com/user/repo.git"
+
 
 class TestServerVersionSupport:
     def test_server_supports_git_metadata(self):


### PR DESCRIPTION
## Intent

Resolves #770.

`rsconnect deploy manifest manifest.json` (and other deploy commands given a bare relative filename) failed to attach git metadata to the bundle upload, even inside a git checkout.

## Approach

The deploy commands derive the directory to scan for git metadata with `dirname(file)`. For a bare filename like `manifest.json`, `os.path.dirname("manifest.json")` returns `""`. That empty string was passed straight to `subprocess.run(..., cwd="")`, which raises `FileNotFoundError`; `_run_git_command` catches it and returns `None`, so `is_git_repo("")` returned `False` and metadata detection was silently skipped — the "short-circuit" described in the issue.

The fix normalizes an empty `cwd` to `"."` at the single choke point (`_run_git_command`), so it covers every deploy command that derives `base_dir` via `dirname(...)`, not just `deploy manifest`.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

## Automated Tests

Added two tests in `tests/test_git_metadata.py` covering the empty-directory-uses-cwd behavior (`is_git_repo("")` and `detect_git_metadata("")` from within a git repo). All tests in the file pass; ruff format/check clean.

## Checklist

- [x] I have updated CHANGELOG.md to cover notable changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)