### PR TITLE
Handle bad response on multipart bundle upload

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -736,7 +736,7 @@ class RSConnectClient(HTTPServer):
             response = cast(
                 Union[BundleMetadata, HTTPResponse], self.post(f"v1/content/{content_guid}/bundles", body=tarball)
             )
-            response = self._server.handle_bad_response(response)
+        response = self._server.handle_bad_response(response)
         return response
 
     def content_update(self, content_guid: str, updates: Mapping[str, str | None]) -> ContentItemV1:

--- a/tests/test_git_metadata.py
+++ b/tests/test_git_metadata.py
@@ -266,3 +266,22 @@ class TestIntegration:
         # Check that upload_bundle has metadata parameter
         sig = signature(RSConnectClient.upload_bundle)
         assert "metadata" in sig.parameters
+
+    def test_upload_bundle_with_metadata_handles_bad_response(self):
+        """A bad response on the multipart (metadata) upload path is surfaced as an
+        RSConnectException rather than a raw HTTPResponse (issue #814)."""
+        import io
+        from unittest.mock import patch
+
+        from rsconnect.api import RSConnectClient, RSConnectException, RSConnectServer
+        from rsconnect.http_support import HTTPResponse
+
+        client = RSConnectClient(RSConnectServer("http://test-server", "api_key"))
+        bad_response = HTTPResponse(
+            "http://test-server/__api__/v1/content/guid/bundles",
+            exception=OSError("connection refused"),
+        )
+        with patch.object(RSConnectClient, "post", return_value=bad_response):
+            with pytest.raises(RSConnectException) as cm:
+                client.upload_bundle("guid", io.BytesIO(b"tarball"), metadata={"source": "git"})
+        assert "connection refused" in str(cm.value)


### PR DESCRIPTION
Fixes #814.

## Problem

In `RSConnectClient.upload_bundle` (`rsconnect/api.py`), the multipart form branch (used when `metadata` is provided) never called `handle_bad_response`. Only the plain-tarball branch did. As a result, a bad HTTP response on a metadata upload propagated as a raw `HTTPResponse` object rather than raising an `RSConnectException`, leading to cryptic failures downstream.

## Fix

Moved the single `handle_bad_response` call out of the `else` branch so it runs for both upload paths before returning.

## Test

Added `test_upload_bundle_with_metadata_handles_bad_response`, which patches `post` to return a failed `HTTPResponse` on the metadata path and asserts a clean `RSConnectException` is raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)