### PR TITLE
Add `rsconnect server set-default` and a `server` command group

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--no-set-default` is passed. `CONNECT_SERVER` still takes precedence. An
   already-saved server can be made the default without re-adding it using
   `rsconnect server set-default -n <name>`. The new `rsconnect server` command
-  group also aliases `add`, `list`, `remove`, and `details`.
+  group also aliases `add`, `list`, `remove`, `details`, and `bootstrap`.
 - New `environment` subcommand for managing execution environments on Connect.
 - New `integration` subcommand for managing OAuth integrations on Connect.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,7 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Servers can now be marked as the default with `rsconnect add --set-default`.
   When neither `-n/--name` nor `-s/--server` is provided, the default server is
   used automatically. `rsconnect login` sets the server as default unless
-  `--no-set-default` is passed. `CONNECT_SERVER` still takes precedence.
+  `--no-set-default` is passed. `CONNECT_SERVER` still takes precedence. An
+  already-saved server can be made the default without re-adding it using
+  `rsconnect server set-default -n <name>`. The new `rsconnect server` command
+  group also aliases `add`, `list`, `remove`, and `details`.
 - New `environment` subcommand for managing execution environments on Connect.
 - New `integration` subcommand for managing OAuth integrations on Connect.
 

--- a/docs/commands/set-default.md
+++ b/docs/commands/set-default.md
@@ -1,0 +1,4 @@
+::: mkdocs-click
+    :module: rsconnect.main
+    :command: set_default
+    :prog_name: rsconnect server set-default

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - logout: commands/logout.md
       - quickstart: commands/quickstart.md
       - remove: commands/remove.md
+      - set-default: commands/set-default.md
       - system: commands/system.md
       - version: commands/version.md
       - write-manifest: commands/write-manifest.md

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -995,9 +995,6 @@ def set_default(
 def server_group():
     """
     Manage saved Posit Connect and shinyapps.io server nicknames.
-
-    These subcommands are aliases for the top-level add, list, remove, and
-    details commands, grouped under a single namespace.
     """
 
 
@@ -1006,6 +1003,7 @@ server_group.add_command(list_servers)
 server_group.add_command(remove)
 server_group.add_command(details)
 server_group.add_command(set_default)
+server_group.add_command(bootstrap)
 
 
 def _resolve_identity_token(identity_token: Optional[str], identity_token_file: Optional[str]) -> Optional[str]:

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -994,7 +994,7 @@ def set_default(
 @cli.group("server", no_args_is_help=True)
 def server_group():
     """
-    Manage saved Posit Connect and shinyapps.io server nicknames.
+    Manage connections with Posit Connect and shinyapps.io servers.
     """
 
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -950,6 +950,22 @@ def remove(
             click.echo("Note: the removed server was the default. Use `rsconnect add --set-default` to set a new one.")
 
 
+@cli.group("server", no_args_is_help=True)
+def server_group():
+    """
+    Manage saved Posit Connect and shinyapps.io server nicknames.
+
+    These subcommands are aliases for the top-level add, list, remove, and
+    details commands, grouped under a single namespace.
+    """
+
+
+server_group.add_command(add)
+server_group.add_command(list_servers)
+server_group.add_command(remove)
+server_group.add_command(details)
+
+
 def _resolve_identity_token(identity_token: Optional[str], identity_token_file: Optional[str]) -> Optional[str]:
     """Resolve the identity token from the flag/env var or a file.
 

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -947,7 +947,48 @@ def remove(
     if message:
         click.echo(message)
         if removed_was_default:
-            click.echo("Note: the removed server was the default. Use `rsconnect add --set-default` to set a new one.")
+            click.echo("Note: the removed server was the default. Use `rsconnect server set-default` to set a new one.")
+
+
+@click.command(
+    "set-default",
+    short_help="Set an already-saved server as the default.",
+    help=(
+        "Mark an already-saved server as the default. The default is used when "
+        "neither -n/--name nor -s/--server is given to other commands. This only "
+        "updates local metadata; the server is not contacted. Prefer -n/--name; "
+        "-s/--server must match the stored URL exactly."
+    ),
+    no_args_is_help=True,
+)
+@click.option("--name", "-n", help="The nickname of the server to set as the default.")
+@click.option("--server", "-s", help="The URL of the server to set as the default.")
+@click.option("--verbose", "-v", count=True, help="Enable verbose output. Use -vv for very verbose (debug) output.")
+@click.pass_context
+def set_default(
+    ctx: click.Context,
+    name: Optional[str],
+    server: Optional[str],
+    verbose: int,
+):
+    set_verbosity(verbose)
+    output_params(ctx, locals().items())
+
+    with cli_feedback("Checking arguments"):
+        if name and server:
+            raise RSConnectException("You must specify only one of -n/--name or -s/--server.")
+        if not name and not server:
+            raise RSConnectException("You must specify one of -n/--name or -s/--server.")
+
+        if server:
+            entry = server_store.get_by_url(server)
+            if entry is None:
+                raise RSConnectException('URL "%s" was not found.' % server)
+            name = entry["name"]
+
+        server_store.set_default(name)
+
+    click.echo('Server "%s" is now the default.' % name)
 
 
 @cli.group("server", no_args_is_help=True)
@@ -964,6 +1005,7 @@ server_group.add_command(add)
 server_group.add_command(list_servers)
 server_group.add_command(remove)
 server_group.add_command(details)
+server_group.add_command(set_default)
 
 
 def _resolve_identity_token(identity_token: Optional[str], identity_token_file: Optional[str]) -> Optional[str]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1886,8 +1886,19 @@ class TestServerGroup:
         runner = CliRunner()
         result = runner.invoke(cli, ["server", "--help"])
         assert result.exit_code == 0, result.output
-        for sub in ("add", "list", "remove", "details", "set-default"):
+        for sub in ("add", "list", "remove", "details", "set-default", "bootstrap"):
             assert sub in result.output
+
+    def test_server_bootstrap_alias_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "bootstrap", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "bootstrap" in result.output
+
+    def test_top_level_bootstrap_still_works(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["bootstrap", "--help"])
+        assert result.exit_code == 0, result.output
 
     def test_server_group_no_args_shows_help(self):
         runner = CliRunner()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1774,6 +1774,43 @@ class TestDefaultServer:
                 os.environ["CONNECT_SERVER"] = original_server_value
 
 
+class TestServerGroup:
+    def test_server_group_help_lists_subcommands(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "--help"])
+        assert result.exit_code == 0, result.output
+        for sub in ("add", "list", "remove", "details"):
+            assert sub in result.output
+
+    def test_server_group_no_args_shows_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_server_list_alias(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["server", "list"])
+        assert result.exit_code == 0, result.output
+        assert "s1" in result.output
+
+    def test_top_level_list_still_works(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["list"])
+        assert result.exit_code == 0, result.output
+        assert "s1" in result.output
+
+
 class TestDeployGit(TestCase):
     """Tests for deploy git CLI command."""
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1773,6 +1773,112 @@ class TestDefaultServer:
             if original_server_value:
                 os.environ["CONNECT_SERVER"] = original_server_value
 
+    def test_server_set_default_by_name(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1", set_as_default=True)
+        store.set("s2", "http://s2.local", api_key="key2")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["server", "set-default", "-n", "s2"])
+        assert result.exit_code == 0, result.output
+        assert 'Server "s2" is now the default.' in result.output
+        assert store.get_default()["name"] == "s2"
+
+    def test_server_set_default_by_url_reports_nickname(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["server", "set-default", "-s", "http://s1.local"])
+        assert result.exit_code == 0, result.output
+        assert 'Server "s1" is now the default.' in result.output
+        assert store.get_default()["name"] == "s1"
+
+    def test_server_set_default_unknown_name(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["server", "set-default", "-n", "nope"])
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+
+    def test_server_set_default_unknown_url(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["server", "set-default", "-s", "http://absent.local"])
+        assert result.exit_code != 0
+        assert "was not found" in result.output
+
+    def test_server_set_default_both_options_error(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["server", "set-default", "-n", "s1", "-s", "http://s1.local"])
+        assert result.exit_code != 0
+        assert "only one of" in result.output
+
+    def test_server_set_default_no_args_shows_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "set-default"])
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_server_set_default_idempotent(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1", set_as_default=True)
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["server", "set-default", "-n", "s1"])
+        assert result.exit_code == 0, result.output
+        assert store.get_default()["name"] == "s1"
+
+    def test_server_set_default_shinyapps_entry(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("shiny", "https://api.shinyapps.io", account_name="acct", token="tok", secret="sec")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            result = runner.invoke(cli, ["server", "set-default", "-n", "shiny"])
+        assert result.exit_code == 0, result.output
+        assert store.get_default()["name"] == "shiny"
+
+    def test_no_top_level_set_default(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["set-default", "-n", "s1"])
+        assert result.exit_code != 0
+        assert "No such command" in result.output or "Usage:" in result.output
+
+    def test_set_default_moves_list_marker(self, tmp_path):
+        from rsconnect.metadata import ServerStore
+
+        store = ServerStore(base_dir=str(tmp_path))
+        store.set("s1", "http://s1.local", api_key="key1", set_as_default=True)
+        store.set("s2", "http://s2.local", api_key="key2")
+        runner = CliRunner()
+        with mock.patch("rsconnect.main.server_store", store):
+            runner.invoke(cli, ["server", "set-default", "-n", "s2"])
+            result = runner.invoke(cli, ["list"])
+        assert result.exit_code == 0, result.output
+        s2_line = next(line for line in result.output.splitlines() if '"s2"' in line)
+        assert "[default]" in s2_line
+
 
 class TestServerGroup:
     def test_server_group_help_lists_subcommands(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1846,6 +1846,7 @@ class TestDefaultServer:
         with mock.patch("rsconnect.main.server_store", store):
             result = runner.invoke(cli, ["server", "set-default", "-n", "s1"])
         assert result.exit_code == 0, result.output
+        assert 'Server "s1" is now the default.' in result.output
         assert store.get_default()["name"] == "s1"
 
     def test_server_set_default_shinyapps_entry(self, tmp_path):
@@ -1885,7 +1886,7 @@ class TestServerGroup:
         runner = CliRunner()
         result = runner.invoke(cli, ["server", "--help"])
         assert result.exit_code == 0, result.output
-        for sub in ("add", "list", "remove", "details"):
+        for sub in ("add", "list", "remove", "details", "set-default"):
             assert sub in result.output
 
     def test_server_group_no_args_shows_help(self):


### PR DESCRIPTION
## What

Adds `rsconnect server set-default -n <name> | -s <url>` to mark an already-saved server as the default without re-adding it, and introduces a `rsconnect server` command group as the home for server management.

## The `server` command group

A single Click `Command` object can belong to multiple groups, so the group **reuses the existing** `add`/`list`/`remove`/`details`/`bootstrap` command objects — no duplication; the top-level commands are unchanged and keep working. `set-default` is new and registered only under the group.

- `rsconnect server add|list|remove|details|bootstrap` — aliases of the existing top-level commands
- `rsconnect server set-default` — new; the only entry point for this command

`login`/`logout` are intentionally **not** in the group — they stay top-level (common publisher commands). `bootstrap` (rare server-provisioning) is grouped.

## Behavior notes

- **`set-default` is local only** — no server contact/re-validation; use `rsconnect details -n <name>` to re-check.
- `-s` matches the stored, normalized URL exactly (like `remove -s`); prefer `-n`. Reports the resolved nickname.
- Exactly one of `-n`/`-s` required.

## Tests & docs

Coverage in `tests/test_main.py` for set-default (name/URL, errors, both/neither, idempotency, shinyapps.io, no top-level `set-default`), group help, and the alias wiring. New `docs/commands/set-default.md` + CHANGELOG entry. Suite green, lint clean.