### PR TITLE
Release 1.30.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.30.0] - 2026-07-16
 
 - Fixed a bug where `rsconnect deploy notebook --static` failed with `Unable to
   include the file <version> in the bundle: No such file or directory`. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Posit, PBC", email = "rsconnect@posit.co" }]
 license = { file = "LICENSE.md" }
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.8"
-version = "1.29.1.dev0"
+version = "1.30.0"
 
 dependencies = [
     "typing-extensions>=4.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4757,7 +4757,7 @@ wheels = [
 
 [[package]]
 name = "rsconnect-python"
-version = "1.29.1.dev0"
+version = "1.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version [1.30.0 did go to PyPi](https://pypi.org/project/rsconnect-python/1.30.0/) thus PR brings the repository in sync