### PR TITLE
chore: add support for Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         include:
         - os: macos-latest
           python-version: '3.13'
+        - os: macos-latest
+          python-version: '3.14'
         - os: windows-latest
           python-version: '3.13'
+        - os: windows-latest
+          python-version: '3.14'
     runs-on: ${{ matrix.os }}
     name: test (py${{ matrix.python-version }} ${{ matrix.os }})
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ The app mode determines how Connect runs the content. Manifests must specify the
 
 ### CI/CD
 - GitHub Actions workflow in `.github/workflows/main.yml`
-- Tests run on Python 3.8-3.13 across ubuntu/macos/windows
+- Tests run on Python 3.8-3.14 across ubuntu/macos/windows
 - Linting enforced on all PRs
 - Coverage reported on Python 3.8 PRs
 

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 # rsconnect-python task runner. Run `just --list` to see recipes.
 
-python_versions := "3.8 3.9 3.10 3.11 3.12 3.13"
+python_versions := "3.8 3.9 3.10 3.11 3.12 3.13 3.14"
 
 # Run the test suite against a single Python version (default 3.13)
 # Invoke via `bash` so the recipe works on Windows, where uv cannot spawn the

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,10 @@
 import os
+import ssl
 import sys
 
 from os.path import abspath, dirname
+
+import httpretty.core
 
 
 HERE = dirname(abspath(__file__))
@@ -12,3 +15,23 @@ sys.path.insert(0, HERE)
 # default argument value at import time, so this must be set before any test
 # module imports rsconnect. (Previously injected by the Makefile's TEST_ENV.)
 os.environ.setdefault("CONNECT_CONTENT_BUILD_DIR", "rsconnect-build-test")
+
+
+# httpretty (1.1.4, released 2021) mocks TLS with
+# `ssl.SSLContext.wrap_socket = functools.partial(fake_wrap_socket, ...)`.
+# Python 3.14 made partial objects descriptors, so that class attribute now binds
+# the SSLContext as the first positional argument and httpretty mistakes it for
+# the socket. Drop the extra argument. The isinstance check makes this a no-op on
+# Python 3.13 and earlier, and also once httpretty ships the fix in
+# gabrielfalcao/HTTPretty#488. Tracked by #833, which proposes replacing
+# httpretty with mocket so this shim can go away.
+_httpretty_fake_wrap_socket = httpretty.core.fake_wrap_socket
+
+
+def _fake_wrap_socket(orig_wrap_socket_fn, *args, **kw):
+    if args and isinstance(args[0], ssl.SSLContext):
+        args = args[1:]
+    return _httpretty_fake_wrap_socket(orig_wrap_socket_fn, *args, **kw)
+
+
+httpretty.core.fake_wrap_socket = _fake_wrap_socket

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added support for Python 3.14. The test suite now runs on Python 3.14 in CI.
 - `rsconnect deploy` subcommands now accept `--quiet`, which suppresses the
   step-by-step progress lines and the streamed server build log, printing only
   the deployed content URL to stdout so it can be captured with


### PR DESCRIPTION
## What

Adds Python 3.14 to the supported versions: CI matrix, `just all-tests`, and the changelog. No source changes are needed — `requires-python` is `>=3.8` with no upper bound.

## CI matrix

The ubuntu matrix gains 3.14. macOS and Windows now run **both** 3.13 and 3.14, so 3.14 gets cross-platform coverage without dropping the previous version.

An earlier revision of this PR moved macOS/Windows from 3.13 to 3.14 instead of adding to it. That renamed two job names that `main` branch protection requires, so the PR could never satisfy them. Running both versions restores those names.

## The conftest.py shim

Python 3.14 makes `functools.partial` objects descriptors. httpretty 1.1.4 (the latest release, from 2022) mocks TLS by assigning a partial to the `ssl.SSLContext.wrap_socket` **class attribute**. On 3.14 that partial now binds the context as the first positional argument, and httpretty mistakes it for the socket. This broke every HTTPS test.

`conftest.py` wraps `httpretty.core.fake_wrap_socket` and drops the leading `SSLContext` argument. An `isinstance` check makes it a no-op on 3.13 and earlier.

Tracked for removal in #833, which proposes replacing httpretty with a maintained library (mocket).

## Verification

Full suite run locally on 3.8, 3.13, and 3.14 (macOS):

- **Same tests, same skips.** 768 passed / 12 skipped on both 3.13 and 3.14. The skip *reasons* diff clean, so no new version-gated skips hide behind the totals.
- **Coverage matches.** 83.02% on 3.13 vs 83.01% on 3.14. The single delta is in `rsconnect/pyproject.py`, where five bare field annotations are statements on 3.13 but not on 3.14.

Windows on 3.14 is untested locally, and the shim touches `ssl` and socket mocking — worth watching that job.

Relates to #833.